### PR TITLE
fix(auth): decouple stateless auth paths from HTTP session in KeycloakAuthenticationFilter (#35)

### DIFF
--- a/docs/10-stateless-인증-HttpSession-분리.md
+++ b/docs/10-stateless-인증-HttpSession-분리.md
@@ -1,0 +1,169 @@
+# 10. Stateless 인증 경로 분리 — HttpSession 전제 제거 (v1.4.1, #35)
+
+## 배경 및 문제
+
+`KeycloakAuthenticationFilter`는 본래 **OIDC 쿠키(access_token / id_token) 기반 인증** 전용 필터입니다.
+그러나 기존 구현에서는 Bearer · Basic · Credential-Login 등 **stateless 인증 경로에서도 동일하게 HTTP Session 존재를 전제**하고 있어, 매 로그인(`POST /api/keycloak/login`)마다 아래 부작용이 발생했습니다.
+
+| 부작용 | 내용 |
+|--------|------|
+| ERROR 로그 폭주 | `AuthenticationFailedException: HTTP Session이 없음` 스택트레이스 100+ 라인 |
+| 감사 로그 오탐 | `[AUTH] result=FAILURE method=OIDC_COOKIE reason=HTTP Session이 없음` |
+| Rate-Limiter 오동작 | FAILURE 카운터 증가로 정상 로그인 차단 위험 |
+| 보안 알림 피로 | 오탐으로 인한 실제 공격 탐지 저해 |
+
+기능 자체는 200 OK로 정상 동작하나, 보안·운영 텔레메트리의 신뢰성이 훼손되는 긴급 버그.
+
+GitHub 이슈: [#35](https://github.com/L-DXD/keycloak-spring-security/issues/35)
+
+---
+
+## 근본 원인
+
+`doFilterInternal`이 **모든 요청**에 대해 세션을 조회하는 단일 경로를 사용:
+
+```
+요청 수신
+  └─ getSession(false) 호출 → null
+      └─ throw AuthenticationFailedException("HTTP Session이 없음")  ← NG
+          └─ catch(Exception) → log.error + logFailure(OIDC_COOKIE)
+```
+
+Bearer 요청은 내부 조건문으로 early return 처리되어 있었지만, **Basic / Credential-Login 경로에는 동일 처리가 없었음**.
+
+---
+
+## 해결 구조
+
+### AuthenticationMethod enum
+
+| 값 | 판별 조건 |
+|----|-----------|
+| `BEARER` | `Authorization: Bearer ` 헤더 |
+| `BASIC` | `Authorization: Basic ` 헤더 |
+| `CREDENTIAL_LOGIN` | POST + `loginPaths` 목록에 포함된 URI |
+| `OIDC_COOKIE` | `access_token` 또는 `id_token` 쿠키 존재 |
+| `NONE` | 위 어느 조건에도 해당하지 않음 |
+
+### AuthenticationMethodDetector
+
+판별 책임을 필터에서 분리한 독립 클래스. 판별 우선순위:
+
+```
+1. Authorization: Bearer  → BEARER
+2. Authorization: Basic   → BASIC
+3. POST + loginPaths URI  → CREDENTIAL_LOGIN
+4. OIDC 쿠키 존재         → OIDC_COOKIE
+5. 그 외                  → NONE
+```
+
+body 파싱 없이 **헤더 + URI + HTTP 메서드**만 사용하므로 InputStream 소비 문제 없음.
+
+### KeycloakAuthenticationFilter — doFilterInternal 재설계
+
+```
+요청 수신
+  └─ AuthenticationMethodDetector.detect(request)
+      ├─ BEARER / BASIC / CREDENTIAL_LOGIN
+      │     └─ logSkipped + chain.doFilter + return   ← 세션 조회 없음
+      ├─ NONE
+      │     └─ chain.doFilter + return
+      └─ OIDC_COOKIE
+            └─ handleOidcCookieAuth(...)
+                  ├─ getSession(false) == null
+                  │     └─ logNoSession + 쿠키삭제 + chain.doFilter + return  ← 예외 없음
+                  └─ 기존 인증 로직 수행
+```
+
+변경 전후 비교:
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| 세션 검사 위치 | 모든 요청 공통 | OIDC_COOKIE 분기 내부만 |
+| 세션 없음 처리 | `throw AuthenticationFailedException` | `logNoSession` + pass-through |
+| catch(Exception) 로그 레벨 | `log.error` | `log.warn` |
+| stateless 경로 처리 | 없음 (OIDC_COOKIE 경로로 낙하) | `logSkipped` + 즉시 return |
+
+---
+
+## 변경된 공개 설정 (신규)
+
+### `keycloak.security.authentication.login-paths`
+
+Credential-Login으로 판별할 경로 목록. POST 메서드 + 이 목록에 포함된 URI이면 `CREDENTIAL_LOGIN`으로 분류하여 OIDC 필터를 우회합니다.
+
+```yaml
+keycloak:
+  security:
+    authentication:
+      login-paths:
+        - /api/keycloak/login      # 기본값 (생략 가능)
+        - /api/auth/login          # 추가 경로 예시
+```
+
+**기본값**: `["/api/keycloak/login"]`
+
+**설정 클래스**: `KeycloakAuthenticationProperties.loginPaths`
+**주입 경로**: `KeycloakHttpConfigurer` → `KeycloakAuthenticationFilter` 6-arg 생성자 → `AuthenticationMethodDetector`
+
+---
+
+## 감사 로그 변경
+
+### 신규 로그 이벤트
+
+```
+# stateless 경로 pass-through (INFO)
+[AUTH] result=SKIPPED method=BEARER ip=10.0.0.1 username=unknown reason=stateless 인증 경로
+[AUTH] result=SKIPPED method=CREDENTIAL_LOGIN ip=10.0.0.1 username=unknown reason=stateless 인증 경로
+
+# OIDC 쿠키 경로 세션 없음 (DEBUG)
+[AUTH] result=NO_SESSION method=OIDC_COOKIE ip=10.0.0.1 username=unknown reason=session_not_found
+```
+
+- `SKIPPED` / `NO_SESSION` 이벤트는 rate-limit 카운터 대상에서 제외
+- 실제 인증 실패(잘못된 자격증명, 토큰 만료)만 `result=FAILURE`로 기록
+
+---
+
+## 변경 파일 목록
+
+| 파일 | 변경 유형 | 내용 |
+|------|-----------|------|
+| `AuthenticationEventLogger.java` | 수정 | `logSkipped`, `logNoSession` 메서드 추가 |
+| `AuthenticationMethod.java` | 신규 | BEARER/BASIC/CREDENTIAL_LOGIN/OIDC_COOKIE/NONE enum |
+| `AuthenticationMethodDetector.java` | 신규 | 판별 로직 클래스 분리 |
+| `KeycloakAuthenticationFilter.java` | 수정 | doFilterInternal 재설계, throw 제거, catch log.warn 하향 |
+| `KeycloakAuthenticationProperties.java` | 수정 | `loginPaths` 필드 추가 |
+| `KeycloakHttpConfigurer.java` | 수정 | 6-arg 생성자 주입 |
+
+---
+
+## 테스트 결과
+
+- `keycloak-spring-security-web` 단위 테스트: 217건 통과
+- `integration-tests/servlet-app` 통합 테스트: 14건 통과
+- `AuthenticationMethodDetectorTest`: Bearer/Basic/CREDENTIAL_LOGIN/OIDC_COOKIE/NONE 각 분기 및 우선순위 검증
+- `KeycloakAuthenticationFilterTest`: session null + OIDC_COOKIE 경로 예외 미발생 검증
+
+---
+
+## 후속 태스크 후보 (code-review Major 지적사항)
+
+| 우선순위 | 내용 | 이슈 유형 |
+|----------|------|-----------|
+| High | catch 블록 `request.getSession()` → `getSession(false)` 방어 (신규 세션 생성 버그 위험) | 버그 |
+| High | `loginPaths` 하드코딩 중복 3곳 → 상수 통일 | 코드 품질 |
+| Medium | `auth.unexpected_error` 메트릭 분리 (FAILURE와 구분하여 Grafana 알림 정밀화) | 관측성 |
+| Medium | `AntPathMatcher` 도입 — loginPaths 패턴 매칭 확장 (`/api/**` 형태 지원) | 기능 확장 |
+| Medium | 통합 테스트 실제 HTTP 레벨(MockMvc / @SpringBootTest) 보강 | 테스트 |
+| Low | Phase 5 — SecurityFilterChain stateless/OIDC 분리 (`@Order`) | 아키텍처 |
+
+---
+
+## 관련 문서
+
+- 태스크: `02.Tasks/keycloak-spring-security/14-Bearer-로그인-엔드포인트-세션없음-오탐-수정.md`
+- 브랜치: `bugfix/35-stateless-auth-session-decoupling`
+- 베이스: `release/1.4.0`
+- 릴리즈 버전: `1.4.1`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version Management
-projectVersion=1.4.0
+projectVersion=1.4.1
 
 # Maven Publishing Info
 mavenGroupId=io.github.l-dxd

--- a/integration-tests/servlet-app/src/test/java/com/ids/keycloak/security/test/servlet/OidcLoginIntegrationTest.java
+++ b/integration-tests/servlet-app/src/test/java/com/ids/keycloak/security/test/servlet/OidcLoginIntegrationTest.java
@@ -1,0 +1,417 @@
+package com.ids.keycloak.security.test.servlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.ids.keycloak.security.authentication.AuthenticationMethodDetector;
+import com.ids.keycloak.security.authentication.KeycloakAuthenticationProvider;
+import com.ids.keycloak.security.filter.KeycloakAuthenticationFilter;
+import com.ids.keycloak.security.ratelimit.AuthenticationEventLogger;
+import com.ids.keycloak.security.session.KeycloakSessionManager;
+import com.ids.keycloak.security.util.CookieUtil;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Phase 4-4 통합 테스트 — KeycloakAuthenticationFilter 핵심 시나리오.
+ * Spring 컨텍스트 없이 필터 레벨에서 AC#1~AC#4를 통합 검증합니다.
+ *
+ * <p>검증 항목:
+ * <ol>
+ *   <li>AC#1: POST /api/keycloak/login → ERROR 로그 0건</li>
+ *   <li>AC#2: POST /api/keycloak/login → result=FAILURE 오탐 0건</li>
+ *   <li>AC#3: 4개 경로(Bearer/Basic/CREDENTIAL_LOGIN/OIDC_COOKIE) 회귀 없음</li>
+ *   <li>AC#4: 세션 없음 이벤트로 rate-limiter 카운터 미증가 (logNoSession은 FAILURE 미기록)</li>
+ * </ol>
+ * </p>
+ */
+class OidcLoginIntegrationTest {
+
+    private KeycloakAuthenticationFilter filter;
+    private AuthenticationManager authenticationManager;
+    private KeycloakSessionManager sessionManager;
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        authenticationManager = mock(AuthenticationManager.class);
+        KeycloakAuthenticationProvider authProvider = mock(KeycloakAuthenticationProvider.class);
+        sessionManager = mock(KeycloakSessionManager.class);
+        KeycloakClient keycloakClient = mock(KeycloakClient.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+
+        filter = new KeycloakAuthenticationFilter(
+            authenticationManager,
+            authProvider,
+            sessionManager,
+            keycloakClient,
+            List.of("/api/keycloak/token", "/api/keycloak/refresh", "/api/keycloak/logout"),
+            List.of("/api/keycloak/login")
+        );
+
+        filterChain = new MockFilterChain();
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // =========================================================
+    // AC#1 + AC#2: POST /api/keycloak/login 시나리오
+    // =========================================================
+
+    @Nested
+    @DisplayName("AC#1,2: POST /api/keycloak/login — ERROR/FAILURE 오탐 없음")
+    class CredentialLoginScenario {
+
+        @Test
+        @DisplayName("POST /api/keycloak/login 요청에서 ERROR 로그가 0건이어야 한다 (AC#1)")
+        void postLoginRequest_shouldProduceZeroErrorLogs() throws Exception {
+            // Given
+            Logger filterLogger = (Logger) LoggerFactory.getLogger(KeycloakAuthenticationFilter.class);
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> appender = attachAppender(filterLogger, eventLogger, Level.ALL);
+
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keycloak/login");
+            // Authorization 헤더 없음 — body 기반 로그인 시뮬레이션
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            try {
+                // When
+                filter.doFilter(request, response, chain);
+
+                // Then — AC#1: ERROR 레벨 로그 0건
+                long errorCount = appender.list.stream()
+                    .filter(e -> e.getLevel() == Level.ERROR)
+                    .count();
+                assertThat(errorCount)
+                    .as("POST /api/keycloak/login 시 ERROR 로그가 발생하면 안 된다 (AC#1)")
+                    .isZero();
+            } finally {
+                detachAppender(appender, filterLogger, eventLogger);
+            }
+        }
+
+        @Test
+        @DisplayName("POST /api/keycloak/login 요청에서 result=FAILURE 감사 로그가 0건이어야 한다 (AC#2)")
+        void postLoginRequest_shouldProduceZeroFailureAuditLogs() throws Exception {
+            // Given
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> appender = attachAppender(eventLogger, Level.ALL);
+
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keycloak/login");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            try {
+                // When
+                filter.doFilter(request, response, chain);
+
+                // Then — AC#2: result=FAILURE 오탐 0건
+                boolean hasFailureLog = appender.list.stream()
+                    .anyMatch(e -> e.getFormattedMessage().contains("result=FAILURE"));
+                assertThat(hasFailureLog)
+                    .as("[AUTH] result=FAILURE method=OIDC_COOKIE 오탐이 발생하면 안 된다 (AC#2)")
+                    .isFalse();
+            } finally {
+                detachAppender(appender, eventLogger);
+            }
+        }
+
+        @Test
+        @DisplayName("POST /api/keycloak/login 요청은 필터 체인이 정상 진행되어야 한다")
+        void postLoginRequest_shouldProceedThroughFilterChain() throws Exception {
+            // Given
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keycloak/login");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            // When
+            filter.doFilter(request, response, chain);
+
+            // Then — 필터 체인이 실행되었음 (chain.getRequest() != null 로 확인)
+            assertThat(chain.getRequest()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("POST /api/keycloak/login 요청에서 result=SKIPPED 감사 로그가 기록된다")
+        void postLoginRequest_shouldLogSkipped() throws Exception {
+            // Given
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> appender = attachAppender(eventLogger, Level.INFO);
+
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keycloak/login");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            try {
+                // When
+                filter.doFilter(request, response, chain);
+
+                // Then
+                boolean hasSkippedLog = appender.list.stream()
+                    .anyMatch(e -> e.getFormattedMessage().contains("result=SKIPPED"));
+                assertThat(hasSkippedLog)
+                    .as("CREDENTIAL_LOGIN 경로는 result=SKIPPED로 감사 기록되어야 한다")
+                    .isTrue();
+            } finally {
+                detachAppender(appender, eventLogger);
+            }
+        }
+    }
+
+    // =========================================================
+    // AC#3: 4개 경로 회귀 시나리오
+    // =========================================================
+
+    @Nested
+    @DisplayName("AC#3: 4개 경로 회귀 — Bearer/Basic/CREDENTIAL_LOGIN/OIDC_COOKIE")
+    class FourPathRegressionScenario {
+
+        @Test
+        @DisplayName("Bearer 리소스 호출: 필터 체인 정상 진행, ERROR 0건")
+        void bearerResourceRequest_shouldPassThroughWithoutError() throws Exception {
+            // Given
+            Logger filterLogger = (Logger) LoggerFactory.getLogger(KeycloakAuthenticationFilter.class);
+            ListAppender<ILoggingEvent> appender = attachAppender(filterLogger, Level.ALL);
+
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/organizations");
+            request.addHeader("Authorization", "Bearer eyJhbGciOiJSUzI1NiIs...");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            try {
+                // When
+                filter.doFilter(request, response, chain);
+
+                // Then
+                assertThat(chain.getRequest()).isNotNull();
+                long errorCount = appender.list.stream()
+                    .filter(e -> e.getLevel() == Level.ERROR)
+                    .count();
+                assertThat(errorCount).isZero();
+            } finally {
+                detachAppender(appender, filterLogger);
+            }
+        }
+
+        @Test
+        @DisplayName("Basic 인증 호출: 필터 체인 정상 진행, ERROR 0건")
+        void basicAuthRequest_shouldPassThroughWithoutError() throws Exception {
+            // Given
+            Logger filterLogger = (Logger) LoggerFactory.getLogger(KeycloakAuthenticationFilter.class);
+            ListAppender<ILoggingEvent> appender = attachAppender(filterLogger, Level.ALL);
+
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/resource");
+            request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            try {
+                // When
+                filter.doFilter(request, response, chain);
+
+                // Then
+                assertThat(chain.getRequest()).isNotNull();
+                long errorCount = appender.list.stream()
+                    .filter(e -> e.getLevel() == Level.ERROR)
+                    .count();
+                assertThat(errorCount).isZero();
+            } finally {
+                detachAppender(appender, filterLogger);
+            }
+        }
+
+        @Test
+        @DisplayName("세션 null + OIDC 쿠키: 예외 미발생, 필터 체인 정상 진행 (AC#1 핵심)")
+        void oidcCookieWithNullSession_shouldNotThrowAndProceed() throws Exception {
+            // Given — 기존 버그 재현 조건: OIDC 쿠키 있음, 세션 없음
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/protected");
+
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+                cookieUtil.when(() -> CookieUtil.getCookieValue(any(), org.mockito.ArgumentMatchers.eq(CookieUtil.ACCESS_TOKEN_NAME)))
+                    .thenReturn(java.util.Optional.of("access-token-value"));
+                cookieUtil.when(() -> CookieUtil.getCookieValue(any(), org.mockito.ArgumentMatchers.eq(CookieUtil.ID_TOKEN_NAME)))
+                    .thenReturn(java.util.Optional.of("id-token-value"));
+
+                // When & Then — 예외 미발생
+                org.assertj.core.api.Assertions.assertThatNoException().isThrownBy(
+                    () -> filter.doFilter(request, response, chain)
+                );
+
+                // 필터 체인 진행 확인
+                assertThat(chain.getRequest()).isNotNull();
+
+                // 인증 시도 없음
+                verify(authenticationManager, never()).authenticate(any());
+            }
+        }
+
+        @Test
+        @DisplayName("세션 null + OIDC 쿠키: result=FAILURE 오탐 없음 (AC#2)")
+        void oidcCookieWithNullSession_shouldNotProduceFailureAuditLog() throws Exception {
+            // Given
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> appender = attachAppender(eventLogger, Level.ALL);
+
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/protected");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+                cookieUtil.when(() -> CookieUtil.getCookieValue(any(), org.mockito.ArgumentMatchers.eq(CookieUtil.ACCESS_TOKEN_NAME)))
+                    .thenReturn(java.util.Optional.of("access-token-value"));
+                cookieUtil.when(() -> CookieUtil.getCookieValue(any(), org.mockito.ArgumentMatchers.eq(CookieUtil.ID_TOKEN_NAME)))
+                    .thenReturn(java.util.Optional.of("id-token-value"));
+
+                try {
+                    // When
+                    filter.doFilter(request, response, chain);
+
+                    // Then — FAILURE 오탐 없음
+                    boolean hasFailure = appender.list.stream()
+                        .anyMatch(e -> e.getFormattedMessage().contains("result=FAILURE"));
+                    assertThat(hasFailure)
+                        .as("세션 없음 OIDC_COOKIE 경로에서 result=FAILURE가 발생하면 안 된다 (AC#2)")
+                        .isFalse();
+
+                    // NO_SESSION 기록 확인
+                    boolean hasNoSession = appender.list.stream()
+                        .anyMatch(e -> e.getFormattedMessage().contains("result=NO_SESSION"));
+                    assertThat(hasNoSession)
+                        .as("세션 없음은 result=NO_SESSION으로 기록되어야 한다")
+                        .isTrue();
+                } finally {
+                    detachAppender(appender, eventLogger);
+                }
+            }
+        }
+    }
+
+    // =========================================================
+    // AC#4: rate-limiter 카운터 미증가 검증 (로그 기반)
+    // =========================================================
+
+    @Nested
+    @DisplayName("AC#4: rate-limiter 오탐 방지 — logNoSession/logSkipped은 FAILURE 미기록")
+    class RateLimiterOvertriggerScenario {
+
+        @Test
+        @DisplayName("세션 없음 이벤트는 result=FAILURE를 기록하지 않아 rate-limiter 카운터가 증가하지 않는다")
+        void noSession_shouldNotTriggerFailureForRateLimiter() throws Exception {
+            // Given
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> appender = attachAppender(eventLogger, Level.ALL);
+
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/protected");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+                cookieUtil.when(() -> CookieUtil.getCookieValue(any(), org.mockito.ArgumentMatchers.eq(CookieUtil.ACCESS_TOKEN_NAME)))
+                    .thenReturn(java.util.Optional.of("access-token-value"));
+                cookieUtil.when(() -> CookieUtil.getCookieValue(any(), org.mockito.ArgumentMatchers.eq(CookieUtil.ID_TOKEN_NAME)))
+                    .thenReturn(java.util.Optional.of("id-token-value"));
+
+                try {
+                    // When
+                    filter.doFilter(request, response, chain);
+
+                    // Then — FAILURE 없음 = rate-limiter 카운터 미증가 조건
+                    long failureCount = appender.list.stream()
+                        .filter(e -> e.getFormattedMessage().contains("result=FAILURE"))
+                        .count();
+                    assertThat(failureCount)
+                        .as("세션 없음은 rate-limiter FAILURE로 집계되면 안 된다 (AC#4)")
+                        .isZero();
+                } finally {
+                    detachAppender(appender, eventLogger);
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("CREDENTIAL_LOGIN 경로는 result=FAILURE를 기록하지 않아 rate-limiter 카운터가 증가하지 않는다")
+        void credentialLogin_shouldNotTriggerFailureForRateLimiter() throws Exception {
+            // Given
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> appender = attachAppender(eventLogger, Level.ALL);
+
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keycloak/login");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            try {
+                // When
+                filter.doFilter(request, response, chain);
+
+                // Then
+                long failureCount = appender.list.stream()
+                    .filter(e -> e.getFormattedMessage().contains("result=FAILURE"))
+                    .count();
+                assertThat(failureCount)
+                    .as("CREDENTIAL_LOGIN 경로는 rate-limiter FAILURE로 집계되면 안 된다 (AC#4)")
+                    .isZero();
+            } finally {
+                detachAppender(appender, eventLogger);
+            }
+        }
+    }
+
+    // =========================================================
+    // 헬퍼 메서드
+    // =========================================================
+
+    private ListAppender<ILoggingEvent> attachAppender(Logger logger, Level level) {
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(level);
+        return appender;
+    }
+
+    private ListAppender<ILoggingEvent> attachAppender(Logger logger1, Logger logger2, Level level) {
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger1.addAppender(appender);
+        logger1.setLevel(level);
+        logger2.addAppender(appender);
+        logger2.setLevel(level);
+        return appender;
+    }
+
+    private void detachAppender(ListAppender<ILoggingEvent> appender, Logger... loggers) {
+        for (Logger logger : loggers) {
+            logger.detachAppender(appender);
+        }
+        appender.stop();
+    }
+}

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakAuthenticationProperties.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakAuthenticationProperties.java
@@ -36,4 +36,21 @@ public class KeycloakAuthenticationProperties {
      * 기본값: "/"
      */
     private String defaultSuccessUrl = "/";
+
+    /**
+     * Credential(body) 기반 로그인 요청으로 판별할 경로 목록.
+     * POST 메서드 + 이 목록에 포함된 경로이면 CREDENTIAL_LOGIN으로 분류하여 OIDC 필터를 우회합니다.
+     * <p>
+     * application.yaml:
+     * <pre>
+     * keycloak:
+     *   security:
+     *     authentication:
+     *       login-paths:
+     *         - /api/keycloak/login
+     *         - /api/auth/login
+     * </pre>
+     * </p>
+     */
+    private List<String> loginPaths = new ArrayList<>(List.of("/api/keycloak/login"));
 }

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/authentication/AuthenticationMethod.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/authentication/AuthenticationMethod.java
@@ -1,0 +1,41 @@
+package com.ids.keycloak.security.authentication;
+
+/**
+ * HTTP 요청에서 감지된 인증 방식을 나타내는 열거형입니다.
+ * <p>
+ * {@link AuthenticationMethodDetector}가 요청을 분석하여 이 값을 반환합니다.
+ * {@code KeycloakAuthenticationFilter}는 이 값에 따라 처리 경로를 분기합니다.
+ * </p>
+ */
+public enum AuthenticationMethod {
+
+    /**
+     * {@code Authorization: Bearer <token>} 헤더가 있는 요청.
+     * BearerTokenAuthenticationFilter가 처리하므로 KeycloakAuthenticationFilter는 pass-through.
+     */
+    BEARER,
+
+    /**
+     * {@code Authorization: Basic <credentials>} 헤더가 있는 요청.
+     * BasicAuthenticationFilter가 처리하므로 KeycloakAuthenticationFilter는 pass-through.
+     */
+    BASIC,
+
+    /**
+     * POST 메서드 + 설정된 login-paths 경로에 해당하는 자격증명 기반 로그인 요청.
+     * 컨트롤러(Resource Owner Password 등)가 처리하므로 KeycloakAuthenticationFilter는 pass-through.
+     */
+    CREDENTIAL_LOGIN,
+
+    /**
+     * {@code access_token} 또는 {@code id_token} 쿠키가 존재하는 요청.
+     * KeycloakAuthenticationFilter가 OIDC 쿠키 기반 인증을 수행합니다.
+     */
+    OIDC_COOKIE,
+
+    /**
+     * 위 어느 방식에도 해당하지 않는 요청 (익명/미인증 상태).
+     * 예외를 발생시키지 않고 pass-through합니다.
+     */
+    NONE
+}

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/authentication/AuthenticationMethodDetector.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/authentication/AuthenticationMethodDetector.java
@@ -1,0 +1,89 @@
+package com.ids.keycloak.security.authentication;
+
+import com.ids.keycloak.security.util.CookieUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * HTTP 요청을 분석하여 인증 방식({@link AuthenticationMethod})을 판별하는 클래스입니다.
+ * <p>
+ * 판별 순서 (우선순위 순):
+ * <ol>
+ *   <li>{@code Authorization: Bearer } 헤더 → {@link AuthenticationMethod#BEARER}</li>
+ *   <li>{@code Authorization: Basic } 헤더 → {@link AuthenticationMethod#BASIC}</li>
+ *   <li>POST 메서드 + 설정된 login-paths 경로 → {@link AuthenticationMethod#CREDENTIAL_LOGIN}
+ *       (body 파싱 없이 URI + HTTP 메서드만 사용)</li>
+ *   <li>{@code access_token} 또는 {@code id_token} 쿠키 존재 → {@link AuthenticationMethod#OIDC_COOKIE}</li>
+ *   <li>그 외 → {@link AuthenticationMethod#NONE}</li>
+ * </ol>
+ * </p>
+ */
+@Slf4j
+public class AuthenticationMethodDetector {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String BASIC_PREFIX = "Basic ";
+    private static final String POST_METHOD = "POST";
+
+    private final List<String> loginPaths;
+
+    /**
+     * @param loginPaths Credential(body) 기반 로그인으로 판별할 경로 목록.
+     *                   기본값으로 {@code /api/keycloak/login}이 포함되어야 합니다.
+     */
+    public AuthenticationMethodDetector(List<String> loginPaths) {
+        this.loginPaths = loginPaths != null ? List.copyOf(loginPaths) : List.of("/api/keycloak/login");
+    }
+
+    /**
+     * 요청에서 인증 방식을 판별합니다.
+     *
+     * @param request HTTP 요청
+     * @return 판별된 {@link AuthenticationMethod}
+     */
+    public AuthenticationMethod detect(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+
+        if (authorization != null && authorization.startsWith(BEARER_PREFIX)) {
+            log.debug("[AuthMethodDetector] Authorization: Bearer 헤더 감지 → BEARER");
+            return AuthenticationMethod.BEARER;
+        }
+
+        if (authorization != null && authorization.startsWith(BASIC_PREFIX)) {
+            log.debug("[AuthMethodDetector] Authorization: Basic 헤더 감지 → BASIC");
+            return AuthenticationMethod.BASIC;
+        }
+
+        if (isCredentialLoginRequest(request)) {
+            log.debug("[AuthMethodDetector] Credential 로그인 경로 감지 → CREDENTIAL_LOGIN (uri={})", request.getRequestURI());
+            return AuthenticationMethod.CREDENTIAL_LOGIN;
+        }
+
+        if (hasTokenCookie(request)) {
+            log.debug("[AuthMethodDetector] OIDC 토큰 쿠키 감지 → OIDC_COOKIE");
+            return AuthenticationMethod.OIDC_COOKIE;
+        }
+
+        log.debug("[AuthMethodDetector] 판별 불가 → NONE");
+        return AuthenticationMethod.NONE;
+    }
+
+    private boolean isCredentialLoginRequest(HttpServletRequest request) {
+        if (!POST_METHOD.equalsIgnoreCase(request.getMethod())) {
+            return false;
+        }
+        String uri = request.getRequestURI();
+        for (String loginPath : loginPaths) {
+            if (uri.equals(loginPath)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasTokenCookie(HttpServletRequest request) {
+        return CookieUtil.getCookieValue(request, CookieUtil.ACCESS_TOKEN_NAME).isPresent()
+            || CookieUtil.getCookieValue(request, CookieUtil.ID_TOKEN_NAME).isPresent();
+    }
+}

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/config/KeycloakHttpConfigurer.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/config/KeycloakHttpConfigurer.java
@@ -260,12 +260,15 @@ public final class KeycloakHttpConfigurer extends AbstractHttpConfigurer<Keycloa
             log.debug("KeycloakAuthenticationFilter 스킵 경로 설정: {}", skipPaths);
         }
 
+        List<String> loginPaths = securityProperties.getAuthentication().getLoginPaths();
+
         KeycloakAuthenticationFilter authenticationFilter = new KeycloakAuthenticationFilter(
             authenticationManager,
             authenticationProvider,
             sessionManager,
             keycloakClient,
-            skipPaths
+            skipPaths,
+            loginPaths
         );
         http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/filter/KeycloakAuthenticationFilter.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/filter/KeycloakAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.ids.keycloak.security.filter;
 
+import com.ids.keycloak.security.authentication.AuthenticationMethod;
+import com.ids.keycloak.security.authentication.AuthenticationMethodDetector;
 import com.ids.keycloak.security.authentication.KeycloakAuthentication;
 import com.ids.keycloak.security.authentication.KeycloakAuthenticationProvider;
 import com.ids.keycloak.security.exception.AuthenticationFailedException;
@@ -35,8 +37,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * HTTP 요청의 쿠키에서 Keycloak 토큰을 읽어 인증을 시도하는 필터입니다.
  * HTTP Session에서 Refresh Token을 조회하여 토큰 재발급에 사용합니다.
  * <p>
- * 온라인 검증 실패 시 Refresh Token을 사용하여 토큰을 재발급받고,
- * 재발급된 토큰으로 직접 인증 객체를 생성합니다.
+ * OIDC 쿠키 방식 전용 필터입니다. Bearer/Basic/Credential-Login 등 stateless 인증 방식은
+ * {@link AuthenticationMethodDetector}가 감지하여 pass-through 처리하므로 세션을 요구하지 않습니다.
  * </p>
  */
 @Slf4j
@@ -47,6 +49,7 @@ public class KeycloakAuthenticationFilter extends OncePerRequestFilter {
     private final KeycloakSessionManager sessionManager;
     private final KeycloakClient keycloakClient;
     private final List<String> skipPaths;
+    private final AuthenticationMethodDetector methodDetector;
 
     public KeycloakAuthenticationFilter(
         AuthenticationManager authenticationManager,
@@ -69,35 +72,42 @@ public class KeycloakAuthenticationFilter extends OncePerRequestFilter {
         this.sessionManager = sessionManager;
         this.keycloakClient = keycloakClient;
         this.skipPaths = skipPaths != null ? skipPaths : List.of();
+        this.methodDetector = new AuthenticationMethodDetector(List.of("/api/keycloak/login"));
     }
 
     /**
-     * Bearer Token 토큰 발급 API 경로는 미인증 상태에서 접근하는 것이 정상이므로
-     * 이 필터의 실행을 건너뜁니다.
-     * <p>
-     * 또한 {@code Authorization: Bearer} 헤더가 포함된 요청은
-     * {@code BearerTokenAuthenticationFilter}가 처리하므로 이 필터를 건너뜁니다.
-     * </p>
+     * 명시적 login-paths를 주입받는 생성자입니다.
+     * {@code KeycloakHttpConfigurer}에서 properties 기반 login-paths를 전달할 때 사용합니다.
+     */
+    public KeycloakAuthenticationFilter(
+        AuthenticationManager authenticationManager,
+        KeycloakAuthenticationProvider authenticationProvider,
+        KeycloakSessionManager sessionManager,
+        KeycloakClient keycloakClient,
+        List<String> skipPaths,
+        List<String> loginPaths
+    ) {
+        this.authenticationManager = authenticationManager;
+        this.authenticationProvider = authenticationProvider;
+        this.sessionManager = sessionManager;
+        this.keycloakClient = keycloakClient;
+        this.skipPaths = skipPaths != null ? skipPaths : List.of();
+        this.methodDetector = new AuthenticationMethodDetector(loginPaths);
+    }
+
+    /**
+     * 명시적으로 등록된 skipPaths에 해당하는 경로만 필터를 건너뜁니다.
+     * 인증 방식별 분기는 {@link #doFilterInternal}의 {@link AuthenticationMethodDetector}가 담당합니다.
      */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-
-        // Bearer Token 토큰 발급 API 경로 스킵
         for (String skipPath : skipPaths) {
             if (path.equals(skipPath)) {
                 log.debug("[Filter] 토큰 API 경로 '{}' — 필터 스킵", path);
                 return true;
             }
         }
-
-        // Authorization: Bearer 헤더가 있는 요청은 BearerTokenAuthenticationFilter가 처리
-        String authorization = request.getHeader("Authorization");
-        if (authorization != null && authorization.startsWith("Bearer ")) {
-            log.debug("[Filter] Bearer 토큰 요청 — 필터 스킵 (BearerTokenAuthenticationFilter에서 처리)");
-            return true;
-        }
-
         return false;
     }
 
@@ -106,8 +116,35 @@ public class KeycloakAuthenticationFilter extends OncePerRequestFilter {
         HttpServletRequest request,
         HttpServletResponse response,
         FilterChain filterChain
-    ) throws ServletException, IOException
-    {
+    ) throws ServletException, IOException {
+
+        // 인증 방식 판별 — 진입부에서 단일 판별, 이후 분기
+        AuthenticationMethod method = methodDetector.detect(request);
+
+        switch (method) {
+            case BEARER, BASIC, CREDENTIAL_LOGIN -> {
+                AuthenticationEventLogger.logSkipped(method.name(), getClientIp(request), "stateless 인증 경로");
+                filterChain.doFilter(request, response);
+                return;
+            }
+            case NONE -> {
+                filterChain.doFilter(request, response);
+                return;
+            }
+            case OIDC_COOKIE -> handleOidcCookieAuth(request, response, filterChain);
+        }
+    }
+
+    /**
+     * OIDC 쿠키 기반 인증을 처리합니다.
+     * 세션 없음은 예외가 아닌 정상 비로그인 상태로 처리합니다.
+     */
+    private void handleOidcCookieAuth(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+
         // 이미 인증된 경우 스킵 (Basic Auth 등 선행 필터에서 인증 완료)
         Authentication existingAuth = SecurityContextHolder.getContext().getAuthentication();
         if (existingAuth != null && existingAuth.isAuthenticated()
@@ -121,11 +158,14 @@ public class KeycloakAuthenticationFilter extends OncePerRequestFilter {
         String accessTokenValue = CookieUtil.getCookieValue(request, CookieUtil.ACCESS_TOKEN_NAME).orElse(null);
 
         try {
-            // HTTP Session에서 Refresh Token 가져오기
             HttpSession session = request.getSession(false);
             if (session == null) {
-                log.debug("[Filter] HTTP Session이 없음 (로그아웃 상태) - 쿠키 삭제 후 다음 필터로 진행");
-                throw new AuthenticationFailedException("HTTP Session이 없음");
+                // 세션 없음은 정상 비로그인 상태 — 예외 발생 없이 pass-through
+                AuthenticationEventLogger.logNoSession(
+                    AuthenticationEventLogger.METHOD_OIDC_COOKIE, getClientIp(request));
+                CookieUtil.deleteAllTokenCookies(response);
+                filterChain.doFilter(request, response);
+                return;
             }
 
             String refreshToken = sessionManager.getRefreshToken(session).orElse(null);
@@ -139,23 +179,21 @@ public class KeycloakAuthenticationFilter extends OncePerRequestFilter {
             log.debug("[Filter] HTTP Session에서 Refresh Token 로드 성공.");
 
             KeycloakPrincipal principal = createPrincipalFromIdToken(idTokenValue);
-            KeycloakAuthentication authRequest = new KeycloakAuthentication(principal, idTokenValue, accessTokenValue, false);
+            KeycloakAuthentication authRequest = new KeycloakAuthentication(
+                principal, idTokenValue, accessTokenValue, false);
             log.debug("[Filter] 인증 전 Authentication 객체 생성: {}", principal.getName());
 
             Authentication successfulAuthentication;
             try {
-                // 인증 수행 (온라인 검증)
                 log.debug("[Filter] AuthenticationManager에 인증 위임...");
                 successfulAuthentication = authenticationManager.authenticate(authRequest);
                 log.debug("[Filter] 인증 성공: {}", successfulAuthentication.getName());
 
             } catch (IntrospectionFailedException | NullPointerException | UserInfoFetchException e) {
-                // 온라인 검증 실패 또는 토큰 파싱 실패 시 Refresh Token으로 재발급 시도
                 log.warn("[Filter] 온라인 검증 실패, Refresh Token으로 재발급 시도. 원인: {}", e.getMessage());
                 successfulAuthentication = refreshAndAuthenticate(session, response, refreshToken);
             }
 
-            // SecurityContext에 인증 정보 설정 (요청 처리 중에만 유효)
             SecurityContext securityContext = SecurityContextHolder.getContext();
             securityContext.setAuthentication(successfulAuthentication);
             log.debug("[Filter] SecurityContext에 인증된 사용자 '{}' 등록 완료.", successfulAuthentication.getName());
@@ -170,8 +208,9 @@ public class KeycloakAuthenticationFilter extends OncePerRequestFilter {
             CookieUtil.deleteAllTokenCookies(response);
             sessionManager.invalidateSession(request.getSession());
         } catch (Exception e) {
+            // 예기치 못한 예외 — warn 레벨로 기록하되 stacktrace 유지
             SecurityContextHolder.clearContext();
-            log.error("[Filter] Keycloak 인증 과정에서 예상치 못한 오류가 발생했습니다.", e);
+            log.warn("[Filter] Keycloak 인증 과정에서 예상치 못한 오류가 발생했습니다.", e);
             AuthenticationEventLogger.logFailure(
                 AuthenticationEventLogger.METHOD_OIDC_COOKIE, getClientIp(request), "unknown", e.getMessage());
             CookieUtil.deleteAllTokenCookies(response);
@@ -196,15 +235,12 @@ public class KeycloakAuthenticationFilter extends OncePerRequestFilter {
         KeycloakTokenInfo newTokens = refreshTokens(refreshToken);
         log.debug("[Filter] 토큰 재발급 성공. 세션 및 쿠키 업데이트.");
 
-        // 새로운 Refresh Token을 세션에 저장
         if (newTokens.getRefreshToken() != null) {
             sessionManager.saveRefreshToken(session, newTokens.getRefreshToken());
         }
 
-        // 쿠키 업데이트
         updateCookies(response, newTokens);
 
-        // Provider를 통해 인증 객체 생성 (검증 없이 토큰 정보로 Principal 생성)
         log.debug("[Filter] 재발급된 토큰으로 인증 객체 생성.");
         return authenticationProvider.createAuthenticatedToken(newTokens.getIdToken(), newTokens.getAccessToken());
     }
@@ -214,7 +250,7 @@ public class KeycloakAuthenticationFilter extends OncePerRequestFilter {
      *
      * @param refreshToken Refresh Token
      * @return 새로 발급된 토큰 정보
-     * @throws RefreshTokenException Refresh Token이 만료되었거나 유효하지 않은 경우
+     * @throws RefreshTokenException         Refresh Token이 만료되었거나 유효하지 않은 경우
      * @throws AuthenticationFailedException 그 외 인증 실패
      */
     private KeycloakTokenInfo refreshTokens(String refreshToken) {
@@ -258,12 +294,10 @@ public class KeycloakAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private KeycloakPrincipal createPrincipalFromIdToken(String idToken) {
-        // 서명 검증 없이 subject만 추출 (온라인 검증에서 유효성 확인)
         String subject = JwtUtil.parseSubjectWithoutValidation(idToken);
         if (subject == null || subject.isBlank()) {
             subject = "unknown";
         }
-        // 인증 전이므로 빈 authorities와 attributes로 생성
         return new KeycloakPrincipal(subject, Collections.emptyList(), null, null);
     }
 }

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/ratelimit/AuthenticationEventLogger.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/ratelimit/AuthenticationEventLogger.java
@@ -72,6 +72,35 @@ public final class AuthenticationEventLogger {
             method, ip, safeUsername(username));
     }
 
+    /**
+     * Stateless 인증 경로(Bearer/Basic/Credential-Login)에서 필터를 건너뛰는 이벤트를 로깅합니다. (INFO 레벨)
+     * <p>
+     * rate-limit 카운터 증가 없이 관찰 목적으로만 기록됩니다.
+     * </p>
+     *
+     * @param method 인증 방식 (BEARER, BASIC, CREDENTIAL_LOGIN 등)
+     * @param ip     클라이언트 IP
+     * @param reason 스킵 사유
+     */
+    public static void logSkipped(String method, String ip, String reason) {
+        log.info("[AUTH] result=SKIPPED method={} ip={} username=unknown reason={}",
+            method, ip, reason);
+    }
+
+    /**
+     * OIDC 쿠키 흐름에서 HTTP Session이 없는 상태를 로깅합니다. (DEBUG 레벨)
+     * <p>
+     * 정상적인 비로그인 상태이므로 감사 통계 집계 및 rate-limit 카운터에서 제외됩니다.
+     * </p>
+     *
+     * @param method 인증 방식 (OIDC_COOKIE)
+     * @param ip     클라이언트 IP
+     */
+    public static void logNoSession(String method, String ip) {
+        log.debug("[AUTH] result=NO_SESSION method={} ip={} username=unknown reason=session_not_found",
+            method, ip);
+    }
+
     private static String safeUsername(String username) {
         return username != null ? username : "unknown";
     }

--- a/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/authentication/AuthenticationMethodDetectorTest.java
+++ b/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/authentication/AuthenticationMethodDetectorTest.java
@@ -1,0 +1,237 @@
+package com.ids.keycloak.security.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * AuthenticationMethodDetector 단위 테스트.
+ * 판별 매트릭스의 각 케이스와 우선순위를 검증합니다.
+ */
+class AuthenticationMethodDetectorTest {
+
+    private AuthenticationMethodDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        detector = new AuthenticationMethodDetector(List.of("/api/keycloak/login"));
+    }
+
+    // ======================================================================
+    // 1. 기본 판별 케이스
+    // ======================================================================
+
+    @Nested
+    class Bearer_헤더_판별 {
+
+        @Test
+        void Authorization_Bearer_헤더가_있으면_BEARER를_반환한다() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer eyJhbGciOiJSUzI1NiIs...");
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.BEARER);
+        }
+
+        @Test
+        void Bearer_prefix가_정확히_일치해야_한다() {
+            // "Bearer"만 있고 공백 없는 경우는 Bearer로 판별되지 않아야 함
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearertoken");
+
+            assertThat(detector.detect(request)).isNotEqualTo(AuthenticationMethod.BEARER);
+        }
+    }
+
+    @Nested
+    class Basic_헤더_판별 {
+
+        @Test
+        void Authorization_Basic_헤더가_있으면_BASIC을_반환한다() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.BASIC);
+        }
+    }
+
+    @Nested
+    class CREDENTIAL_LOGIN_판별 {
+
+        @Test
+        void POST_메서드_와_기본_loginPath_요청은_CREDENTIAL_LOGIN을_반환한다() {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keycloak/login");
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.CREDENTIAL_LOGIN);
+        }
+
+        @Test
+        void GET_메서드_이면_loginPath라도_CREDENTIAL_LOGIN이_아니다() {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/keycloak/login");
+
+            assertThat(detector.detect(request)).isNotEqualTo(AuthenticationMethod.CREDENTIAL_LOGIN);
+        }
+
+        @Test
+        void POST_메서드라도_loginPath가_아니면_CREDENTIAL_LOGIN이_아니다() {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/other");
+
+            assertThat(detector.detect(request)).isNotEqualTo(AuthenticationMethod.CREDENTIAL_LOGIN);
+        }
+
+        @Test
+        void 커스텀_loginPaths_주입_시_해당_경로도_CREDENTIAL_LOGIN으로_판별된다() {
+            AuthenticationMethodDetector customDetector = new AuthenticationMethodDetector(
+                List.of("/api/keycloak/login", "/custom/auth/login")
+            );
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/custom/auth/login");
+
+            assertThat(customDetector.detect(request)).isEqualTo(AuthenticationMethod.CREDENTIAL_LOGIN);
+        }
+
+        @Test
+        void PUT_메서드는_loginPath라도_CREDENTIAL_LOGIN이_아니다() {
+            MockHttpServletRequest request = new MockHttpServletRequest("PUT", "/api/keycloak/login");
+            assertThat(detector.detect(request)).isNotEqualTo(AuthenticationMethod.CREDENTIAL_LOGIN);
+        }
+
+        @Test
+        void DELETE_메서드는_loginPath라도_CREDENTIAL_LOGIN이_아니다() {
+            MockHttpServletRequest request = new MockHttpServletRequest("DELETE", "/api/keycloak/login");
+            assertThat(detector.detect(request)).isNotEqualTo(AuthenticationMethod.CREDENTIAL_LOGIN);
+        }
+    }
+
+    @Nested
+    class OIDC_COOKIE_판별 {
+
+        @Test
+        void access_token_쿠키만_있으면_OIDC_COOKIE를_반환한다() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setCookies(new jakarta.servlet.http.Cookie("access_token", "access-token-value"));
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.OIDC_COOKIE);
+        }
+
+        @Test
+        void id_token_쿠키만_있으면_OIDC_COOKIE를_반환한다() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setCookies(new jakarta.servlet.http.Cookie("id_token", "id-token-value"));
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.OIDC_COOKIE);
+        }
+
+        @Test
+        void access_token과_id_token_쿠키_둘_다_있으면_OIDC_COOKIE를_반환한다() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setCookies(
+                new jakarta.servlet.http.Cookie("access_token", "access-token-value"),
+                new jakarta.servlet.http.Cookie("id_token", "id-token-value")
+            );
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.OIDC_COOKIE);
+        }
+    }
+
+    @Nested
+    class NONE_판별 {
+
+        @Test
+        void 헤더도_쿠키도_없으면_NONE을_반환한다() {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/resource");
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.NONE);
+        }
+
+        @Test
+        void 쿠키가_없는_배열이면_NONE을_반환한다() {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/resource");
+            // 쿠키 명시적으로 비워두기 (setCookies 미호출)
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.NONE);
+        }
+    }
+
+    // ======================================================================
+    // 2. 우선순위 핵심 케이스
+    // ======================================================================
+
+    @Nested
+    class 우선순위_검증 {
+
+        @Test
+        void Bearer_헤더와_OIDC_쿠키가_동시에_있으면_BEARER가_우선된다() {
+            // Bearer + 쿠키 동시 존재 → BEARER 우선 (우선순위 핵심)
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer eyJhbGciOiJSUzI1NiIs...");
+            request.setCookies(new jakarta.servlet.http.Cookie("access_token", "access-token-value"));
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.BEARER);
+        }
+
+        @Test
+        void Basic_헤더와_OIDC_쿠키가_동시에_있으면_BASIC이_우선된다() {
+            // Basic + 쿠키 동시 존재 → BASIC 우선
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+            request.setCookies(new jakarta.servlet.http.Cookie("access_token", "access-token-value"));
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.BASIC);
+        }
+
+        @Test
+        void Bearer_헤더와_loginPath가_동시에_있으면_BEARER가_우선된다() {
+            // POST loginPath + Bearer 헤더 → BEARER 우선
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keycloak/login");
+            request.addHeader("Authorization", "Bearer eyJhbGciOiJSUzI1NiIs...");
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.BEARER);
+        }
+
+        @Test
+        void CREDENTIAL_LOGIN_경로가_OIDC_쿠키보다_우선된다() {
+            // POST loginPath + OIDC 쿠키 → CREDENTIAL_LOGIN 우선 (쿠키보다 URI 판별이 먼저)
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keycloak/login");
+            request.setCookies(new jakarta.servlet.http.Cookie("access_token", "access-token-value"));
+
+            assertThat(detector.detect(request)).isEqualTo(AuthenticationMethod.CREDENTIAL_LOGIN);
+        }
+
+        @Test
+        void 판별_순서는_Bearer_Basic_CREDENTIAL_LOGIN_OIDC_NONE_순이다() {
+            // Bearer 최우선 검증 (모든 조건 동시 충족)
+            MockHttpServletRequest requestWithAll = new MockHttpServletRequest("POST", "/api/keycloak/login");
+            requestWithAll.addHeader("Authorization", "Bearer eyJhbGciOiJSUzI1NiIs...");
+            requestWithAll.setCookies(new jakarta.servlet.http.Cookie("access_token", "at"));
+
+            assertThat(detector.detect(requestWithAll)).isEqualTo(AuthenticationMethod.BEARER);
+        }
+    }
+
+    // ======================================================================
+    // 3. null 경계값
+    // ======================================================================
+
+    @Nested
+    class 경계_케이스 {
+
+        @Test
+        void null_loginPaths_주입_시_기본_경로로_동작한다() {
+            AuthenticationMethodDetector detectorWithNull = new AuthenticationMethodDetector(null);
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keycloak/login");
+
+            assertThat(detectorWithNull.detect(request)).isEqualTo(AuthenticationMethod.CREDENTIAL_LOGIN);
+        }
+
+        @Test
+        void 빈_loginPaths_주입_시_CREDENTIAL_LOGIN이_판별되지_않는다() {
+            AuthenticationMethodDetector detectorWithEmpty = new AuthenticationMethodDetector(List.of());
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/keycloak/login");
+
+            assertThat(detectorWithEmpty.detect(request)).isNotEqualTo(AuthenticationMethod.CREDENTIAL_LOGIN);
+        }
+    }
+}

--- a/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/filter/KeycloakAuthenticationFilterTest.java
+++ b/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/filter/KeycloakAuthenticationFilterTest.java
@@ -1,18 +1,25 @@
 package com.ids.keycloak.security.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.ids.keycloak.security.authentication.KeycloakAuthentication;
 import com.ids.keycloak.security.authentication.KeycloakAuthenticationProvider;
 import com.ids.keycloak.security.exception.IntrospectionFailedException;
 import com.ids.keycloak.security.exception.UserInfoFetchException;
 import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.ids.keycloak.security.ratelimit.AuthenticationEventLogger;
 import com.ids.keycloak.security.session.KeycloakSessionManager;
 import com.ids.keycloak.security.util.CookieUtil;
 import com.ids.keycloak.security.util.JwtUtil;
@@ -26,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -36,9 +42,13 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 
 @ExtendWith(MockitoExtension.class)
 class KeycloakAuthenticationFilterTest {
@@ -143,7 +153,7 @@ class KeycloakAuthenticationFilterTest {
         void 세션이_없으면_쿠키를_삭제하고_인증을_시도하지_않는다() throws Exception {
             // Given
             when(request.getSession(false)).thenReturn(null);
-            when(request.getSession()).thenReturn(session);
+            // request.getSession() 스터빙 제거: Phase 3 이후 세션 없음 경로에서 getSession() 호출 없음
 
             try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
                 cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ID_TOKEN_NAME))
@@ -326,17 +336,21 @@ class KeycloakAuthenticationFilterTest {
             assertThat(result).isTrue();
         }
 
+        /**
+         * Phase 3 재설계 이후: Bearer 헤더 요청은 shouldNotFilter(=skipPaths 기반)가 아닌
+         * doFilterInternal 내부의 AuthenticationMethodDetector가 BEARER로 판별하여 pass-through 처리한다.
+         * shouldNotFilter는 skipPaths 등록 경로만 스킵한다.
+         */
         @Test
-        void Bearer_헤더가_있는_요청은_필터를_스킵한다() throws Exception {
-            // Given
+        void Bearer_헤더가_있는_요청은_shouldNotFilter가_false를_반환한다_doFilterInternal에서_pass_through() throws Exception {
+            // Given — Bearer 요청은 skipPaths에 없으므로 shouldNotFilter=false
             when(request.getRequestURI()).thenReturn("/api/some-resource");
-            when(request.getHeader("Authorization")).thenReturn("Bearer eyJhbGciOiJSUzI1NiIs...");
 
             // When
             boolean result = filter.shouldNotFilter(request);
 
-            // Then
-            assertThat(result).isTrue();
+            // Then: 필터를 건너뛰지 않고 doFilterInternal로 진입 → 내부에서 BEARER 판별 후 pass-through
+            assertThat(result).isFalse();
         }
 
         @Test
@@ -359,7 +373,6 @@ class KeycloakAuthenticationFilterTest {
         void 스킵_경로가_아닌_일반_요청은_필터를_실행한다() throws Exception {
             // Given
             when(request.getRequestURI()).thenReturn("/api/some-resource");
-            when(request.getHeader("Authorization")).thenReturn(null);
 
             // When
             boolean result = filter.shouldNotFilter(request);
@@ -369,10 +382,9 @@ class KeycloakAuthenticationFilterTest {
         }
 
         @Test
-        void Basic_헤더가_있는_요청은_필터를_실행한다() throws Exception {
+        void Basic_헤더가_있는_요청은_shouldNotFilter가_false를_반환한다() throws Exception {
             // Given
             when(request.getRequestURI()).thenReturn("/api/some-resource");
-            when(request.getHeader("Authorization")).thenReturn("Basic dXNlcjpwYXNz");
 
             // When
             boolean result = filter.shouldNotFilter(request);
@@ -413,6 +425,461 @@ class KeycloakAuthenticationFilterTest {
                 verify(filterChain).doFilter(request, response);
                 assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
             }
+        }
+
+        /**
+         * Phase 3 핵심 회귀 — catch(Exception) 블록은 warn 레벨이어야 한다.
+         * 예기치 못한 예외 발생 시 log.error가 아닌 log.warn이 호출되는지 확인한다.
+         */
+        @Test
+        void 예기치_못한_예외는_WARN_레벨로_기록되고_ERROR는_사용되지_않는다() throws Exception {
+            // Given
+            Logger filterLogger = (Logger) LoggerFactory.getLogger(KeycloakAuthenticationFilter.class);
+            ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+            logAppender.start();
+            filterLogger.addAppender(logAppender);
+            filterLogger.setLevel(Level.WARN);
+
+            when(request.getSession(false)).thenReturn(session);
+            when(request.getSession()).thenReturn(session);
+            when(sessionManager.getRefreshToken(session)).thenReturn(Optional.of(REFRESH_TOKEN_VALUE));
+            when(authenticationManager.authenticate(any()))
+                .thenThrow(new RuntimeException("Unexpected error"));
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class);
+                 MockedStatic<JwtUtil> jwtUtil = mockStatic(JwtUtil.class)) {
+
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ID_TOKEN_NAME))
+                    .thenReturn(Optional.of(ID_TOKEN_VALUE));
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ACCESS_TOKEN_NAME))
+                    .thenReturn(Optional.of(ACCESS_TOKEN_VALUE));
+                jwtUtil.when(() -> JwtUtil.parseSubjectWithoutValidation(anyString()))
+                    .thenReturn(USER_SUB);
+
+                // When
+                filter.doFilterInternal(request, response, filterChain);
+
+                // Then: ERROR 레벨 로그 없음 (warn으로 하향됨)
+                boolean hasErrorLog = logAppender.list.stream()
+                    .anyMatch(e -> e.getLevel() == Level.ERROR);
+                assertThat(hasErrorLog).isFalse();
+
+            } finally {
+                filterLogger.detachAppender(logAppender);
+                logAppender.stop();
+            }
+        }
+    }
+
+    // ======================================================================
+    // Phase 4 핵심 회귀 시나리오
+    // ======================================================================
+
+    /**
+     * 핵심 버그 수정 검증:
+     * 세션이 null이고 OIDC 쿠키가 있을 때 AuthenticationFailedException이 발생하지 않아야 한다.
+     * filter chain이 정상 진행되고, logNoSession이 호출되며, 쿠키가 삭제된다.
+     */
+    @Nested
+    class 세션_null_OIDC_COOKIE_핵심_회귀 {
+
+        @Test
+        void 세션_null_OIDC_COOKIE_경로에서_AuthenticationFailedException이_발생하지_않는다() throws Exception {
+            // Given — OIDC 쿠키 있음, 세션 없음
+            when(request.getSession(false)).thenReturn(null);
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ACCESS_TOKEN_NAME))
+                    .thenReturn(Optional.of(ACCESS_TOKEN_VALUE));
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ID_TOKEN_NAME))
+                    .thenReturn(Optional.of(ID_TOKEN_VALUE));
+
+                // When & Then — 예외 미발생이 핵심 요구사항 (AC#1)
+                assertThatNoException().isThrownBy(
+                    () -> filter.doFilterInternal(request, response, filterChain)
+                );
+            }
+        }
+
+        @Test
+        void 세션_null_OIDC_COOKIE_경로에서_chain_doFilter가_호출된다() throws Exception {
+            // Given
+            when(request.getSession(false)).thenReturn(null);
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ACCESS_TOKEN_NAME))
+                    .thenReturn(Optional.of(ACCESS_TOKEN_VALUE));
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ID_TOKEN_NAME))
+                    .thenReturn(Optional.of(ID_TOKEN_VALUE));
+
+                // When
+                filter.doFilterInternal(request, response, filterChain);
+
+                // Then
+                verify(filterChain).doFilter(request, response);
+            }
+        }
+
+        @Test
+        void 세션_null_OIDC_COOKIE_경로에서_authenticationManager가_호출되지_않는다() throws Exception {
+            // Given
+            when(request.getSession(false)).thenReturn(null);
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ACCESS_TOKEN_NAME))
+                    .thenReturn(Optional.of(ACCESS_TOKEN_VALUE));
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ID_TOKEN_NAME))
+                    .thenReturn(Optional.of(ID_TOKEN_VALUE));
+
+                // When
+                filter.doFilterInternal(request, response, filterChain);
+
+                // Then — 세션 없음 상태에서 인증 시도 없음
+                verify(authenticationManager, never()).authenticate(any());
+            }
+        }
+
+        @Test
+        void 세션_null_OIDC_COOKIE_경로에서_쿠키_삭제가_호출된다() throws Exception {
+            // Given
+            when(request.getSession(false)).thenReturn(null);
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ACCESS_TOKEN_NAME))
+                    .thenReturn(Optional.of(ACCESS_TOKEN_VALUE));
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ID_TOKEN_NAME))
+                    .thenReturn(Optional.of(ID_TOKEN_VALUE));
+
+                // When
+                filter.doFilterInternal(request, response, filterChain);
+
+                // Then
+                cookieUtil.verify(() -> CookieUtil.deleteAllTokenCookies(response));
+            }
+        }
+
+        @Test
+        void 세션_null_OIDC_COOKIE_경로에서_logNoSession이_기록된다() throws Exception {
+            // Given
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+            logAppender.start();
+            eventLogger.addAppender(logAppender);
+            eventLogger.setLevel(Level.DEBUG);
+
+            when(request.getSession(false)).thenReturn(null);
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ACCESS_TOKEN_NAME))
+                    .thenReturn(Optional.of(ACCESS_TOKEN_VALUE));
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ID_TOKEN_NAME))
+                    .thenReturn(Optional.of(ID_TOKEN_VALUE));
+
+                try {
+                    // When
+                    filter.doFilterInternal(request, response, filterChain);
+
+                    // Then — NO_SESSION 로그 확인
+                    boolean hasNoSessionLog = logAppender.list.stream()
+                        .anyMatch(e -> e.getFormattedMessage().contains("result=NO_SESSION"));
+                    assertThat(hasNoSessionLog)
+                        .as("세션 없음 시 result=NO_SESSION 로그가 기록되어야 한다")
+                        .isTrue();
+
+                    // FAILURE 오탐 없음 확인 (핵심 — AC#2)
+                    boolean hasFailureLog = logAppender.list.stream()
+                        .anyMatch(e -> e.getFormattedMessage().contains("result=FAILURE"));
+                    assertThat(hasFailureLog)
+                        .as("세션 없음은 FAILURE가 아니어야 한다 — 오탐 방지 (AC#2)")
+                        .isFalse();
+                } finally {
+                    eventLogger.detachAppender(logAppender);
+                    logAppender.stop();
+                }
+            }
+        }
+
+        @Test
+        void 세션_null_OIDC_COOKIE_경로에서_ERROR_레벨_로그가_없다() throws Exception {
+            // Given — AC#1 핵심 검증: 기존 버그에서는 매번 ERROR가 발생했음
+            Logger filterLogger = (Logger) LoggerFactory.getLogger(KeycloakAuthenticationFilter.class);
+            ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+            logAppender.start();
+            filterLogger.addAppender(logAppender);
+            filterLogger.setLevel(Level.ALL);
+
+            when(request.getSession(false)).thenReturn(null);
+
+            try (MockedStatic<CookieUtil> cookieUtil = mockStatic(CookieUtil.class)) {
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ACCESS_TOKEN_NAME))
+                    .thenReturn(Optional.of(ACCESS_TOKEN_VALUE));
+                cookieUtil.when(() -> CookieUtil.getCookieValue(request, CookieUtil.ID_TOKEN_NAME))
+                    .thenReturn(Optional.of(ID_TOKEN_VALUE));
+
+                try {
+                    // When
+                    filter.doFilterInternal(request, response, filterChain);
+
+                    // Then — 핵심: ERROR 레벨 로그 0건 (기존 버그에서는 ERROR가 발생했음)
+                    boolean hasErrorLog = logAppender.list.stream()
+                        .anyMatch(e -> e.getLevel() == Level.ERROR);
+                    assertThat(hasErrorLog)
+                        .as("세션 없음 OIDC_COOKIE 경로에서 ERROR 로그가 발생하면 안 된다 (AC#1 검증)")
+                        .isFalse();
+                } finally {
+                    filterLogger.detachAppender(logAppender);
+                    logAppender.stop();
+                }
+            }
+        }
+    }
+
+    /**
+     * POST /api/keycloak/login (CREDENTIAL_LOGIN) 경로 회귀 시나리오.
+     * stateless 로그인 요청에서 세션 검사 없이 pass-through되어야 한다.
+     */
+    @Nested
+    class CREDENTIAL_LOGIN_경로_회귀 {
+
+        @Test
+        void POST_loginPath_요청은_세션_검사_없이_chain_doFilter가_호출된다() throws Exception {
+            // Given — mock request에 POST + loginPath 설정 (Bearer/Basic 없음, getCookies 호출 안 됨)
+            when(request.getHeader("Authorization")).thenReturn(null);
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getRequestURI()).thenReturn("/api/keycloak/login");
+
+            // When
+            filter.doFilterInternal(request, response, filterChain);
+
+            // Then
+            verify(filterChain).doFilter(request, response);
+            verify(authenticationManager, never()).authenticate(any());
+        }
+
+        @Test
+        void POST_loginPath_요청은_logSkipped가_기록된다() throws Exception {
+            // Given
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+            logAppender.start();
+            eventLogger.addAppender(logAppender);
+            eventLogger.setLevel(Level.INFO);
+
+            when(request.getHeader("Authorization")).thenReturn(null);
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getRequestURI()).thenReturn("/api/keycloak/login");
+
+            try {
+                // When
+                filter.doFilterInternal(request, response, filterChain);
+
+                // Then — SKIPPED 로그 확인
+                boolean hasSkippedLog = logAppender.list.stream()
+                    .anyMatch(e -> e.getFormattedMessage().contains("result=SKIPPED"));
+                assertThat(hasSkippedLog)
+                    .as("CREDENTIAL_LOGIN 경로는 result=SKIPPED로 기록되어야 한다")
+                    .isTrue();
+            } finally {
+                eventLogger.detachAppender(logAppender);
+                logAppender.stop();
+            }
+        }
+
+        @Test
+        void POST_loginPath_요청에서_ERROR_레벨_로그가_없다() throws Exception {
+            // Given — AC#1 핵심 검증
+            Logger filterLogger = (Logger) LoggerFactory.getLogger(KeycloakAuthenticationFilter.class);
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+            logAppender.start();
+            filterLogger.addAppender(logAppender);
+            eventLogger.addAppender(logAppender);
+            filterLogger.setLevel(Level.ALL);
+            eventLogger.setLevel(Level.ALL);
+
+            when(request.getHeader("Authorization")).thenReturn(null);
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getRequestURI()).thenReturn("/api/keycloak/login");
+
+            try {
+                // When
+                filter.doFilterInternal(request, response, filterChain);
+
+                // Then — 핵심: ERROR 로그 0건 (기존 버그에서는 매 로그인마다 ERROR가 발생)
+                boolean hasErrorLog = logAppender.list.stream()
+                    .anyMatch(e -> e.getLevel() == Level.ERROR);
+                assertThat(hasErrorLog)
+                    .as("POST /api/keycloak/login에서 ERROR 로그가 발생하면 안 된다 (AC#1)")
+                    .isFalse();
+            } finally {
+                filterLogger.detachAppender(logAppender);
+                eventLogger.detachAppender(logAppender);
+                logAppender.stop();
+            }
+        }
+
+        @Test
+        void POST_loginPath_요청에서_FAILURE_감사_로그가_없다() throws Exception {
+            // Given — AC#2 핵심 검증 (result=FAILURE method=OIDC_COOKIE 오탐 방지)
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+            logAppender.start();
+            eventLogger.addAppender(logAppender);
+            eventLogger.setLevel(Level.ALL);
+
+            when(request.getHeader("Authorization")).thenReturn(null);
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getRequestURI()).thenReturn("/api/keycloak/login");
+
+            try {
+                // When
+                filter.doFilterInternal(request, response, filterChain);
+
+                // Then — FAILURE 오탐 없음 (AC#2)
+                boolean hasFailureLog = logAppender.list.stream()
+                    .anyMatch(e -> e.getFormattedMessage().contains("result=FAILURE"));
+                assertThat(hasFailureLog)
+                    .as("[AUTH] result=FAILURE 오탐이 발생하면 안 된다 (AC#2)")
+                    .isFalse();
+            } finally {
+                eventLogger.detachAppender(logAppender);
+                logAppender.stop();
+            }
+        }
+    }
+
+    /**
+     * Bearer 리소스 호출 회귀 시나리오 (AC#3).
+     * Bearer 헤더 요청은 세션 검사 없이 logSkipped 후 pass-through되어야 한다.
+     */
+    @Nested
+    class Bearer_리소스_호출_회귀 {
+
+        @Test
+        void Bearer_헤더_요청은_chain_doFilter가_호출된다() throws Exception {
+            // Given — Bearer 헤더가 있으면 getCookies 호출 없이 즉시 반환
+            when(request.getHeader("Authorization")).thenReturn("Bearer eyJhbGciOiJSUzI1NiIs...");
+
+            // When
+            filter.doFilterInternal(request, response, filterChain);
+
+            // Then
+            verify(filterChain).doFilter(request, response);
+        }
+
+        @Test
+        void Bearer_헤더_요청은_세션_검사를_하지_않는다() throws Exception {
+            // Given
+            when(request.getHeader("Authorization")).thenReturn("Bearer eyJhbGciOiJSUzI1NiIs...");
+
+            // When
+            filter.doFilterInternal(request, response, filterChain);
+
+            // Then
+            verify(authenticationManager, never()).authenticate(any());
+        }
+
+        @Test
+        void Bearer_헤더_요청은_SKIPPED_로그가_BEARER_메서드로_기록된다() throws Exception {
+            // Given
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+            logAppender.start();
+            eventLogger.addAppender(logAppender);
+            eventLogger.setLevel(Level.INFO);
+
+            when(request.getHeader("Authorization")).thenReturn("Bearer eyJhbGciOiJSUzI1NiIs...");
+
+            try {
+                // When
+                filter.doFilterInternal(request, response, filterChain);
+
+                // Then
+                boolean hasSkippedBearerLog = logAppender.list.stream()
+                    .anyMatch(e -> e.getFormattedMessage().contains("result=SKIPPED")
+                        && e.getFormattedMessage().contains("method=BEARER"));
+                assertThat(hasSkippedBearerLog)
+                    .as("Bearer 요청은 result=SKIPPED method=BEARER로 기록되어야 한다")
+                    .isTrue();
+            } finally {
+                eventLogger.detachAppender(logAppender);
+                logAppender.stop();
+            }
+        }
+    }
+
+    /**
+     * Basic 인증 요청 회귀 시나리오 (AC#3).
+     */
+    @Nested
+    class Basic_인증_요청_회귀 {
+
+        @Test
+        void Basic_헤더_요청은_chain_doFilter가_호출된다() throws Exception {
+            // Given — Basic 헤더가 있으면 getCookies 호출 없이 즉시 반환
+            when(request.getHeader("Authorization")).thenReturn("Basic dXNlcjpwYXNz");
+
+            // When
+            filter.doFilterInternal(request, response, filterChain);
+
+            // Then
+            verify(filterChain).doFilter(request, response);
+        }
+
+        @Test
+        void Basic_헤더_요청은_SKIPPED_로그가_BASIC_메서드로_기록된다() throws Exception {
+            // Given
+            Logger eventLogger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+            ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+            logAppender.start();
+            eventLogger.addAppender(logAppender);
+            eventLogger.setLevel(Level.INFO);
+
+            when(request.getHeader("Authorization")).thenReturn("Basic dXNlcjpwYXNz");
+
+            try {
+                // When
+                filter.doFilterInternal(request, response, filterChain);
+
+                // Then
+                boolean hasSkippedBasicLog = logAppender.list.stream()
+                    .anyMatch(e -> e.getFormattedMessage().contains("result=SKIPPED")
+                        && e.getFormattedMessage().contains("method=BASIC"));
+                assertThat(hasSkippedBasicLog)
+                    .as("Basic 요청은 result=SKIPPED method=BASIC으로 기록되어야 한다")
+                    .isTrue();
+            } finally {
+                eventLogger.detachAppender(logAppender);
+                logAppender.stop();
+            }
+        }
+    }
+
+    /**
+     * 커스텀 loginPaths 주입 시나리오.
+     * 6-arg 생성자를 통해 커스텀 경로도 CREDENTIAL_LOGIN으로 처리되어야 한다.
+     */
+    @Nested
+    class 커스텀_loginPaths_생성자_회귀 {
+
+        @Test
+        void 커스텀_loginPaths_주입_시_해당_경로도_CREDENTIAL_LOGIN으로_처리된다() throws Exception {
+            // Given
+            KeycloakAuthenticationFilter filterWithCustomLogin = new KeycloakAuthenticationFilter(
+                authenticationManager, authenticationProvider, sessionManager, keycloakClient,
+                List.of(), List.of("/api/keycloak/login", "/custom/login")
+            );
+
+            when(request.getHeader("Authorization")).thenReturn(null);
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getRequestURI()).thenReturn("/custom/login");
+
+            // When
+            filterWithCustomLogin.doFilterInternal(request, response, filterChain);
+
+            // Then — 세션 검사 없이 pass-through
+            verify(filterChain).doFilter(request, response);
+            verify(authenticationManager, never()).authenticate(any());
         }
     }
 }

--- a/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/ratelimit/AuthenticationEventLoggerTest.java
+++ b/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/ratelimit/AuthenticationEventLoggerTest.java
@@ -1,0 +1,200 @@
+package com.ids.keycloak.security.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AuthenticationEventLogger 단위 테스트.
+ * logSkipped / logNoSession 신규 메서드의 로그 포맷, 레벨, 내용을 검증합니다.
+ * 기존 메서드(logSuccess/logFailure/logRateLimited)의 하위 호환도 확인합니다.
+ */
+class AuthenticationEventLoggerTest {
+
+    private ListAppender<ILoggingEvent> listAppender;
+    private Logger logger;
+
+    @BeforeEach
+    void setUp() {
+        logger = (Logger) LoggerFactory.getLogger(AuthenticationEventLogger.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+        // DEBUG까지 캡처하도록 설정
+        logger.setLevel(Level.DEBUG);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(listAppender);
+        listAppender.stop();
+    }
+
+    // ======================================================================
+    // 1. logSkipped - INFO 레벨, 포맷 검증
+    // ======================================================================
+
+    @Nested
+    class logSkipped_신규_메서드 {
+
+        @Test
+        void logSkipped는_INFO_레벨로_기록된다() {
+            AuthenticationEventLogger.logSkipped("BEARER", "10.0.0.1", "stateless 인증 경로");
+
+            assertThat(listAppender.list).hasSize(1);
+            assertThat(listAppender.list.get(0).getLevel()).isEqualTo(Level.INFO);
+        }
+
+        @Test
+        void logSkipped는_SKIPPED_결과를_포함한다() {
+            AuthenticationEventLogger.logSkipped("BEARER", "10.0.0.1", "stateless 인증 경로");
+
+            String message = listAppender.list.get(0).getFormattedMessage();
+            assertThat(message).contains("result=SKIPPED");
+        }
+
+        @Test
+        void logSkipped는_method_ip_reason을_포함하는_구조화된_포맷으로_기록된다() {
+            AuthenticationEventLogger.logSkipped("BEARER", "192.168.1.100", "stateless 인증 경로");
+
+            String message = listAppender.list.get(0).getFormattedMessage();
+            assertThat(message)
+                .contains("[AUTH]")
+                .contains("result=SKIPPED")
+                .contains("method=BEARER")
+                .contains("ip=192.168.1.100")
+                .contains("reason=stateless 인증 경로");
+        }
+
+        @Test
+        void logSkipped_BASIC_호출시_메서드명이_포함된다() {
+            AuthenticationEventLogger.logSkipped("BASIC", "10.1.2.3", "stateless 인증 경로");
+
+            String message = listAppender.list.get(0).getFormattedMessage();
+            assertThat(message).contains("method=BASIC");
+        }
+
+        @Test
+        void logSkipped_CREDENTIAL_LOGIN_호출시_메서드명이_포함된다() {
+            AuthenticationEventLogger.logSkipped("CREDENTIAL_LOGIN", "10.1.2.3", "stateless 인증 경로");
+
+            String message = listAppender.list.get(0).getFormattedMessage();
+            assertThat(message).contains("method=CREDENTIAL_LOGIN");
+        }
+    }
+
+    // ======================================================================
+    // 2. logNoSession - DEBUG 레벨, 포맷 검증
+    // ======================================================================
+
+    @Nested
+    class logNoSession_신규_메서드 {
+
+        @Test
+        void logNoSession은_DEBUG_레벨로_기록된다() {
+            AuthenticationEventLogger.logNoSession("OIDC_COOKIE", "10.0.0.1");
+
+            assertThat(listAppender.list).hasSize(1);
+            assertThat(listAppender.list.get(0).getLevel()).isEqualTo(Level.DEBUG);
+        }
+
+        @Test
+        void logNoSession은_NO_SESSION_결과를_포함한다() {
+            AuthenticationEventLogger.logNoSession("OIDC_COOKIE", "10.0.0.1");
+
+            String message = listAppender.list.get(0).getFormattedMessage();
+            assertThat(message).contains("result=NO_SESSION");
+        }
+
+        @Test
+        void logNoSession은_method_ip를_포함하는_구조화된_포맷으로_기록된다() {
+            AuthenticationEventLogger.logNoSession("OIDC_COOKIE", "172.16.0.5");
+
+            String message = listAppender.list.get(0).getFormattedMessage();
+            assertThat(message)
+                .contains("[AUTH]")
+                .contains("result=NO_SESSION")
+                .contains("method=OIDC_COOKIE")
+                .contains("ip=172.16.0.5");
+        }
+    }
+
+    // ======================================================================
+    // 3. 기존 메서드 하위 호환 검증 (시그니처 변경 없음)
+    // ======================================================================
+
+    @Nested
+    class 기존_메서드_하위_호환 {
+
+        @Test
+        void logSuccess는_INFO_레벨로_SUCCESS를_기록한다() {
+            AuthenticationEventLogger.logSuccess("OIDC_COOKIE", "10.0.0.1", "testuser");
+
+            assertThat(listAppender.list).hasSize(1);
+            ILoggingEvent event = listAppender.list.get(0);
+            assertThat(event.getLevel()).isEqualTo(Level.INFO);
+            assertThat(event.getFormattedMessage()).contains("result=SUCCESS");
+        }
+
+        @Test
+        void logFailure는_WARN_레벨로_FAILURE를_기록한다() {
+            AuthenticationEventLogger.logFailure("OIDC_COOKIE", "10.0.0.1", "unknown", "token expired");
+
+            assertThat(listAppender.list).hasSize(1);
+            ILoggingEvent event = listAppender.list.get(0);
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getFormattedMessage()).contains("result=FAILURE");
+        }
+
+        @Test
+        void logRateLimited는_WARN_레벨로_RATE_LIMITED를_기록한다() {
+            AuthenticationEventLogger.logRateLimited("BASIC", "10.0.0.1", "admin");
+
+            assertThat(listAppender.list).hasSize(1);
+            ILoggingEvent event = listAppender.list.get(0);
+            assertThat(event.getLevel()).isEqualTo(Level.WARN);
+            assertThat(event.getFormattedMessage()).contains("result=RATE_LIMITED");
+        }
+    }
+
+    // ======================================================================
+    // 4. logSkipped/logNoSession은 FAILURE/RATE_LIMITED가 아님을 검증
+    //    (rate-limit 오탐 방지 확인 — 로그 레벨이 아닌 포맷 기반)
+    // ======================================================================
+
+    @Nested
+    class 오탐_방지_검증 {
+
+        @Test
+        void logSkipped는_FAILURE를_포함하지_않는다() {
+            AuthenticationEventLogger.logSkipped("BEARER", "10.0.0.1", "stateless");
+
+            String message = listAppender.list.get(0).getFormattedMessage();
+            assertThat(message).doesNotContain("result=FAILURE");
+        }
+
+        @Test
+        void logNoSession은_FAILURE를_포함하지_않는다() {
+            AuthenticationEventLogger.logNoSession("OIDC_COOKIE", "10.0.0.1");
+
+            String message = listAppender.list.get(0).getFormattedMessage();
+            assertThat(message).doesNotContain("result=FAILURE");
+        }
+
+        @Test
+        void logSkipped는_RATE_LIMITED를_포함하지_않는다() {
+            AuthenticationEventLogger.logSkipped("BASIC", "10.0.0.1", "stateless");
+
+            String message = listAppender.list.get(0).getFormattedMessage();
+            assertThat(message).doesNotContain("result=RATE_LIMITED");
+        }
+    }
+}


### PR DESCRIPTION
Closes #35

## 요약

Bearer/Basic/CREDENTIAL_LOGIN 등 stateless 인증 요청에서 `KeycloakAuthenticationFilter`가 HTTP Session 부재를 예외로 처리하던 이분법 구조를 **`AuthenticationMethod` Enum 기반 판별 구조**로 재설계했습니다. `:128`의 `throw new AuthenticationFailedException("HTTP Session이 없음")`을 제거하고, 세션 검사는 OIDC_COOKIE 분기 내부에서만 수행하도록 격리했습니다.

## 변경 내역

### 신규
- `AuthenticationMethod` enum (`BEARER`/`BASIC`/`CREDENTIAL_LOGIN`/`OIDC_COOKIE`/`NONE`)
- `AuthenticationMethodDetector` — 헤더/URI/쿠키 기반 판별, body 파싱 없음
- `AuthenticationEventLogger.logSkipped(INFO)`, `logNoSession(DEBUG)` — rate-limit 카운터 제외
- `KeycloakAuthenticationProperties.loginPaths` (기본값 `["/api/keycloak/login"]`)
- `docs/10-stateless-인증-HttpSession-분리.md`

### 수정
- `KeycloakAuthenticationFilter.doFilterInternal` 재설계
  - 진입부에서 `AuthenticationMethod` 판별
  - `BEARER/BASIC/CREDENTIAL_LOGIN` → `logSkipped` + pass-through
  - `NONE` → pass-through (throw 없음)
  - `OIDC_COOKIE` → `handleOidcCookieAuth`. session null 시 `logNoSession` + 쿠키 삭제 + `chain.doFilter`
- `catch(Exception)` 블록 `log.error` → `log.warn` 하향 (stacktrace 유지)
- `KeycloakHttpConfigurer` — 6-arg 생성자에 `loginPaths` 주입

## 판별 순서 (우선순위)

1. `Authorization: Bearer` → `BEARER`
2. `Authorization: Basic` → `BASIC`
3. `POST` + `loginPaths` URI 매칭 → `CREDENTIAL_LOGIN`
4. `access_token` 또는 `id_token` 쿠키 존재 → `OIDC_COOKIE`
5. 그 외 → `NONE`

Bearer/Basic이 쿠키보다 앞에 있어, 쿠키 탈취 + Bearer 위조 시나리오에서도 Bearer가 우선 처리되어 `BearerTokenAuthenticationFilter`의 introspection을 거치게 됩니다.

## 수용 기준 (AC) 검증

| # | 요구사항 | 검증 테스트 |
|---|---------|------------|
| 1 | `POST /api/keycloak/login` 시 `AuthenticationFailedException: HTTP Session이 없음` ERROR 0건 | `KeycloakAuthenticationFilterTest.세션_null_OIDC_COOKIE_경로에서_ERROR_레벨_로그가_없다` + `OidcLoginIntegrationTest.postLoginRequest_shouldProduceZeroErrorLogs` |
| 2 | `result=FAILURE method=OIDC_COOKIE reason=HTTP Session이 없음` 0건 | `세션_null_OIDC_COOKIE_경로에서_logNoSession이_기록된다` + `postLoginRequest_shouldProduceZeroFailureAuditLogs` |
| 3 | Bearer / OIDC 쿠키 / Basic / Credential-Login 4경로 회귀 없음 | `FourPathRegressionScenario` (4케이스) |
| 4 | rate-limiter 카운터가 "세션 없음"으로 증가하지 않음 | `RateLimiterOvertriggerScenario` (2케이스) + `AuthenticationEventLoggerTest.오탐_방지_검증` |

## 테스트 결과

- `keycloak-spring-security-web:test` → BUILD SUCCESSFUL (217건 / 0 failures)
- `integration-tests:servlet-app:test` → BUILD SUCCESSFUL (14건 / 0 failures)

### 신규/보강 테스트
| 파일 | 케이스 수 |
|------|-----------|
| `AuthenticationMethodDetectorTest` | 21 |
| `AuthenticationEventLoggerTest` | 14 |
| `KeycloakAuthenticationFilterTest` (Phase 4 Nested 6세트) | — |
| `OidcLoginIntegrationTest` | 10 |

## 코드 리뷰 결과

**Approve with minor** (Critical 없음, Major 4건, Minor 다수)

머지 가능 상태이며 Major 지적사항은 아래 후속 개선 항목으로 분리합니다.

## 버전 업

`1.4.0` → `1.4.1` (patch — 공개 API 시그니처 파괴 없음)

## 후속 개선 사항 (별도 이슈/태스크 분리 예정)

- [ ] `KeycloakAuthenticationFilter` catch 블록 `request.getSession()` → `getSession(false)` 방어 (세션 자동 생성 위험)
- [ ] `loginPaths` 하드코딩 중복 3곳(`Properties`/`Filter`/`Detector`) → 상수 통일
- [ ] `auth.unexpected_error` 메트릭 분리 — OIDC 검증 중 예외를 FAILURE와 구분
- [ ] 통합 테스트 `@SpringBootTest`/`MockMvc` 실 HTTP 레벨 보강 (현재는 필터 직접 호출)
- [ ] `AntPathMatcher` 도입으로 `loginPaths` 패턴 매칭 확장
- [ ] Phase 5 — `SecurityFilterChain` stateless(`/api/**`) vs stateful `@Order` 분리 (별도 태스크)

## 운영 배포 후 검증 계획 (Phase 6)

배포 후 **3일 연속** 아래 쿼리 0건 확인:
```
"AuthenticationFailedException: HTTP Session이 없음"
result=FAILURE method=OIDC_COOKIE reason=HTTP Session이 없음
```

## 관련 문서

- 태스크: `02.Tasks/keycloak-spring-security/14-Bearer-로그인-엔드포인트-세션없음-오탐-수정.md`
- 산출물: `06.Notes/keycloak-spring-security/stateless-인증-HttpSession-분리.md`
- 코드 문서: `docs/10-stateless-인증-HttpSession-분리.md`
