### PR TITLE
[#37] fix: SecurityFilterChain Fail-Open 수정 (CVSS 8.1 High)

### DIFF
--- a/docs/12-SecurityFilterChain-FailOpen-수정.md
+++ b/docs/12-SecurityFilterChain-FailOpen-수정.md
@@ -1,0 +1,119 @@
+# 12. SecurityFilterChain Fail-Open 수정 (v1.5.0)
+
+> **보안 수정 (Security Fix)** — CVSS v3.1 **8.1 High** (`AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N`)
+> CWE-1188 (Insecure Default Initialization of Resource), CWE-863 (Incorrect Authorization)
+
+## 1. 배경 — 무엇이 문제였나
+
+`KeycloakServletAutoConfiguration`이 등록하는 `keycloakSecurityFilterChain` Bean은
+과거 다음 조건으로 등록되었습니다.
+
+```java
+@Bean
+@ConditionalOnMissingBean(SecurityFilterChain.class)   // ⚠️ Fail-Open
+public SecurityFilterChain keycloakSecurityFilterChain(...) { ... }
+```
+
+`@ConditionalOnMissingBean(SecurityFilterChain.class)`는 **컨텍스트에 `SecurityFilterChain` 타입 Bean이
+하나도 없을 때만** Keycloak 체인을 등록합니다. 따라서 사용자가 actuator 분리, 관리 API, SSO 전용 등의 목적으로
+**자체 `SecurityFilterChain`을 단 하나라도 추가하는 순간** Keycloak의 전체 필터 체인(인증 필터·Bearer
+Introspect·AuthorizationManager·CSRF 설정 등)이 **통째로 비활성화**되었습니다.
+
+Spring Boot 환경에서 `/actuator/**` 경로 분리는 매우 흔한 패턴이라, 이 조건은 현실적으로 도달 가능하며
+도달 시 **비즈니스 API가 인증 없이 노출**됩니다(Fail-Open).
+
+### 재현 시나리오 (수정 전)
+1. 앱이 `spring-boot-starter-actuator` 추가.
+2. 사용자가 `/actuator/**`를 별도 정책으로 묶기 위해 `@Bean SecurityFilterChain actuatorChain(...)` 등록.
+3. `@ConditionalOnMissingBean(SecurityFilterChain.class)` 조건 실패 → Keycloak 체인 **미등록**.
+4. 비즈니스 API가 인증 필터 없이 노출.
+
+## 2. 수정 내용 (v1.5.0)
+
+```java
+@Bean("keycloakSecurityFilterChain")
+@ConditionalOnMissingBean(name = "keycloakSecurityFilterChain")
+@ConditionalOnProperty(prefix = "keycloak.security", name = "auto-filter-chain",
+                       havingValue = "true", matchIfMissing = true)
+@Order(Ordered.LOWEST_PRECEDENCE)
+public SecurityFilterChain keycloakSecurityFilterChain(...) throws Exception {
+    http.securityMatcher(KeycloakSecurityMatcherFactory.from(securityProperties.getMatcher()));
+    ...
+}
+```
+
+| 변경 | 효과 |
+|------|------|
+| **Bean 이름 기반 조건** `@ConditionalOnMissingBean(name = "keycloakSecurityFilterChain")` | 사용자가 다른 `SecurityFilterChain`을 추가해도 Keycloak 체인이 **함께 등록**되어 공존합니다. (타입 충돌로 꺼지지 않음) |
+| **`securityMatcher` 경로 분리** | Keycloak 체인이 담당할 경로를 명시적으로 선언합니다(기본 `/**`). 사용자가 더 구체적인 matcher(예: `/actuator/**`)를 가진 체인을 등록하면 그 경로는 사용자 체인이 담당합니다. |
+| **`@Order(LOWEST_PRECEDENCE)`** | catch-all 체인이므로 가장 낮은 우선순위로 두어, 사용자의 구체적 체인이 먼저 평가되도록 합니다. |
+| **`@ConditionalOnProperty(matchIfMissing = true)`** | 이중 안전망. `keycloak.security.auto-filter-chain=false`로 **명시적으로 끈 경우에만** 미등록됩니다(기본은 등록). |
+
+> ⚠️ **`@Order` 방향에 주의**: Spring Security의 다중 `SecurityFilterChain`은 `@Order` **오름차순**으로 평가하고
+> **첫 번째로 매칭되는 체인**이 요청을 처리합니다. Keycloak 체인은 `/**`(catch-all)이므로 반드시
+> `LOWEST_PRECEDENCE`(맨 뒤)여야 사용자의 구체적 체인이 우선합니다. `LOWEST_PRECEDENCE - 100` 같은 값을 쓰면
+> Keycloak이 먼저 매칭해버려 경로 분리가 깨집니다.
+
+## 3. 신규 설정 프로퍼티
+
+```yaml
+keycloak:
+  security:
+    # Keycloak 기본 SecurityFilterChain 자동 등록 여부 (기본: true)
+    # false면 Keycloak 기본 체인을 등록하지 않고 사용자가 전체 구성을 책임진다.
+    auto-filter-chain: true
+
+    # Keycloak 체인이 담당할 경로 (기본: 전체 /**)
+    matcher:
+      include:
+        - /**
+      exclude:
+        - /actuator/**     # 이 경로는 사용자가 등록한 다른 체인이 담당
+        - /public/**
+```
+
+| 프로퍼티 | 기본값 | 설명 |
+|----------|--------|------|
+| `keycloak.security.auto-filter-chain` | `true` | Keycloak 기본 체인 자동 등록 여부 |
+| `keycloak.security.matcher.include` | `["/**"]` | Keycloak 체인 담당 포함 경로(Ant) |
+| `keycloak.security.matcher.exclude` | `[]` | Keycloak 체인에서 제외할 경로(Ant) — 다른 체인이 담당 |
+
+## 4. Migration 가이드 (v1.4.x → v1.5.0)
+
+### 기존 사용자 (커스텀 SecurityFilterChain 없음)
+**조치 불필요.** 기본값(`auto-filter-chain=true`, `matcher.include=/**`)으로 기존과 **동일하게 동작**합니다.
+
+### actuator 등 별도 체인을 쓰던 사용자
+이전에는 사용자 체인을 추가하면 Keycloak이 (의도치 않게) 꺼졌습니다. v1.5.0부터는 **Keycloak 체인이 함께 살아납니다.**
+
+1. **권장 (경로 분리)**: 사용자 체인에 `securityMatcher("/actuator/**")`를 명시하고, Keycloak이 그 경로를 건드리지
+   않도록 `keycloak.security.matcher.exclude: [/actuator/**]`를 설정합니다.
+
+   ```java
+   @Bean
+   @Order(0)   // Keycloak(LOWEST_PRECEDENCE)보다 앞
+   SecurityFilterChain actuatorChain(HttpSecurity http) throws Exception {
+       http.securityMatcher("/actuator/**")
+           .authorizeHttpRequests(a -> a.anyRequest().permitAll());
+       return http.build();
+   }
+   ```
+
+2. **호환 모드 (opt-out)**: 이전처럼 Keycloak 기본 체인을 끄고 전체를 직접 구성하려면:
+
+   ```yaml
+   keycloak:
+     security:
+       auto-filter-chain: false
+   ```
+
+> ⚠️ **Breaking change 주의**: 기존에 "사용자 체인 추가 → Keycloak 자동 비활성화"라는 **숨은 동작에 의존**하던
+> 앱은, v1.5.0에서 Keycloak 체인이 활성화되어 보호 경로에서 401/403이 증가할 수 있습니다. 이 경우
+> 위 1(경로 분리) 또는 2(opt-out)로 대응하세요. minor bump(1.4.x → 1.5.0)인 이유입니다.
+
+## 5. 검증 (테스트)
+
+| 테스트 | 검증 내용 |
+|--------|-----------|
+| `KeycloakSecurityMatcherFactoryTest` | include/exclude → RequestMatcher 매칭 동작 (경로 분리 핵심 로직) |
+| `KeycloakSecurityFilterChainConditionsTest` | Bean 조건/순서 어노테이션 고정 — (a) 기본 등록, (b) 사용자 체인 공존, (c) opt-out, `@Order` 맨 뒤 |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version Management
-projectVersion=1.4.1
+projectVersion=1.5.0
 
 # Maven Publishing Info
 mavenGroupId=io.github.l-dxd

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakMatcherProperties.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakMatcherProperties.java
@@ -1,0 +1,47 @@
+package com.ids.keycloak.security.config;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Keycloak {@code SecurityFilterChain}이 담당할 요청 경로를 정의하는 Properties 클래스입니다.
+ * <p>
+ * 사용자가 자체 {@code SecurityFilterChain}(예: {@code /actuator} 전용)을 추가하더라도
+ * Keycloak 체인이 함께 등록되어 담당 경로를 책임지도록 {@code securityMatcher} 기반으로 경로를 분리합니다.
+ * 기본값은 전체 경로({@code /**})이며, 사용자가 include/exclude로 재정의할 수 있습니다.
+ * </p>
+ * <p>
+ * application.yaml:
+ * <pre>
+ * keycloak:
+ *   security:
+ *     matcher:
+ *       include:
+ *         - /**
+ *       exclude:
+ *         - /actuator/**
+ *         - /public/**
+ * </pre>
+ * </p>
+ * <p>
+ * RequestMatcher 변환은 spring-security-web 의존성이 있는 web-starter의 AutoConfiguration에서 수행합니다.
+ * (core 모듈은 순수 로직 모듈로 Servlet/Web 의존성을 갖지 않습니다.)
+ * </p>
+ */
+@Getter
+@Setter
+public class KeycloakMatcherProperties {
+
+    /**
+     * Keycloak 체인이 담당할 포함 경로 (Ant 패턴). 기본값: 전체 경로({@code /**}).
+     */
+    private List<String> include = new ArrayList<>(List.of("/**"));
+
+    /**
+     * Keycloak 체인에서 제외할 경로 (Ant 패턴). 제외된 경로는 사용자가 등록한 다른 체인이 담당합니다.
+     */
+    private List<String> exclude = new ArrayList<>();
+}

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakSecurityProperties.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakSecurityProperties.java
@@ -92,4 +92,24 @@ public class KeycloakSecurityProperties {
      */
     @NestedConfigurationProperty
     private KeycloakRateLimitProperties rateLimit = new KeycloakRateLimitProperties();
+
+    /**
+     * Keycloak {@code SecurityFilterChain}이 담당할 요청 경로 매처 설정.
+     * <p>
+     * 사용자가 자체 {@code SecurityFilterChain}(예: {@code /actuator} 전용)을 추가하더라도
+     * Keycloak 체인이 함께 등록되어 담당 경로를 책임지도록 분리합니다. 기본값은 전체 경로({@code /**}).
+     * </p>
+     */
+    @NestedConfigurationProperty
+    private KeycloakMatcherProperties matcher = new KeycloakMatcherProperties();
+
+    /**
+     * Keycloak 기본 {@code SecurityFilterChain} 자동 등록 여부 (기본값: {@code true}).
+     * <p>
+     * {@code false}로 설정하면 Keycloak 기본 체인이 등록되지 않으며, 사용자가 전체
+     * {@code SecurityFilterChain} 구성을 직접 책임집니다. (필요 시에만 명시적으로 opt-out)
+     * </p>
+     */
+    @Setter
+    private boolean autoFilterChain = true;
 }

--- a/keycloak-spring-security-web-starter/build.gradle
+++ b/keycloak-spring-security-web-starter/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     // 라이브러리 사용자가 Redis를 원할 때만 자신의 프로젝트에 추가하면 됨
     compileOnly 'org.springframework.boot:spring-boot-starter-data-redis'
     compileOnly 'org.springframework.session:spring-session-data-redis'
+
+    // 테스트 전용: securityMatcher 동작 검증을 위한 Servlet API + MockHttpServletRequest
+    // (compileOnly 의존성을 테스트 클래스패스에 노출, production 산출물에는 전이되지 않음)
+    testImplementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework:spring-test'
 }
 
 signing {

--- a/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/KeycloakSecurityMatcherFactory.java
+++ b/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/KeycloakSecurityMatcherFactory.java
@@ -1,0 +1,52 @@
+package com.ids.keycloak.security.config;
+
+import org.springframework.security.web.util.matcher.AndRequestMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link KeycloakMatcherProperties}의 include/exclude(Ant 패턴)를 {@link RequestMatcher}로 변환하는 팩토리입니다.
+ * <p>
+ * Keycloak {@code SecurityFilterChain}의 {@code securityMatcher}로 사용되어, 사용자가 등록한 다른
+ * {@code SecurityFilterChain}과 담당 경로를 분리합니다(Fail-Open 방지).
+ * </p>
+ * <ul>
+ *   <li>exclude가 비어 있으면 {@code (include)} OR 매처를 반환합니다.</li>
+ *   <li>exclude가 있으면 {@code (include) AND NOT(exclude)} 형태로 결합합니다.</li>
+ * </ul>
+ * <p>
+ * RequestMatcher 조합은 spring-security-web 의존성이 있는 web-starter에서 수행합니다.
+ * (core 모듈은 순수 로직 모듈로 Servlet/Web 의존성을 갖지 않으므로 Properties에 변환 로직을 두지 않습니다.)
+ * </p>
+ */
+final class KeycloakSecurityMatcherFactory {
+
+    private KeycloakSecurityMatcherFactory() {
+    }
+
+    static RequestMatcher from(KeycloakMatcherProperties properties) {
+        RequestMatcher includeMatcher = toOrMatcher(properties.getInclude());
+
+        List<String> exclude = properties.getExclude();
+        if (exclude == null || exclude.isEmpty()) {
+            return includeMatcher;
+        }
+
+        RequestMatcher excludeMatcher = toOrMatcher(exclude);
+        return new AndRequestMatcher(includeMatcher, new NegatedRequestMatcher(excludeMatcher));
+    }
+
+    private static RequestMatcher toOrMatcher(List<String> patterns) {
+        List<RequestMatcher> matchers = new ArrayList<>();
+        for (String pattern : patterns) {
+            matchers.add(new AntPathRequestMatcher(pattern));
+        }
+        // 단일 패턴이면 OrRequestMatcher(빈/단일 요소 시 예외)로 감싸지 않고 그대로 반환
+        return matchers.size() == 1 ? matchers.get(0) : new OrRequestMatcher(matchers);
+    }
+}

--- a/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/KeycloakServletAutoConfiguration.java
+++ b/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/KeycloakServletAutoConfiguration.java
@@ -46,6 +46,9 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.Session;
@@ -284,15 +287,45 @@ public class KeycloakServletAutoConfiguration {
             return new KeycloakAuthorizationManager(keycloakClient);
         }
 
-        @Bean
-        @ConditionalOnMissingBean(SecurityFilterChain.class)
+        /**
+         * Keycloak 기본 SecurityFilterChain을 등록합니다.
+         * <p>
+         * <b>Fail-Open 방지 설계 (CVSS 8.1, CWE-1188/863):</b>
+         * 과거 {@code @ConditionalOnMissingBean(SecurityFilterChain.class)}는 사용자가
+         * actuator 등 다른 용도의 SecurityFilterChain을 단 하나라도 추가하면 Keycloak 체인 전체가
+         * 비활성화되어 인증이 통째로 사라지는 Fail-Open 결함이 있었습니다. 이를 다음과 같이 보강합니다.
+         * <ul>
+         *   <li><b>Bean 이름 기반 조건</b>: {@code @ConditionalOnMissingBean(name = "keycloakSecurityFilterChain")}로
+         *       사용자가 추가한 다른 체인과 공존합니다.</li>
+         *   <li><b>securityMatcher 경로 분리</b>: 이 체인이 담당할 경로를 명시적으로 선언합니다(기본 {@code /**}).
+         *       사용자가 더 구체적인 matcher(예: {@code /actuator/**})를 가진 체인을 등록하면 그 경로는 사용자 체인이 담당합니다.</li>
+         *   <li><b>@Order(LOWEST_PRECEDENCE)</b>: catch-all 체인이므로 가장 낮은 우선순위로 두어,
+         *       사용자의 구체적 체인이 먼저 평가되도록 합니다.</li>
+         *   <li><b>이중 안전망</b>: {@code keycloak.security.auto-filter-chain=false}로 명시적으로 끈 경우에만 미등록됩니다(기본 등록).</li>
+         * </ul>
+         * </p>
+         */
+        @Bean("keycloakSecurityFilterChain")
+        @ConditionalOnMissingBean(name = "keycloakSecurityFilterChain")
+        @ConditionalOnProperty(
+            prefix = "keycloak.security",
+            name = "auto-filter-chain",
+            havingValue = "true",
+            matchIfMissing = true
+        )
+        @Order(Ordered.LOWEST_PRECEDENCE)
         public SecurityFilterChain keycloakSecurityFilterChain(
             HttpSecurity http,
             KeycloakSecurityProperties securityProperties,
             ObjectProvider<FindByIndexNameSessionRepository<? extends Session>> sessionRepositoryProvider,
             KeycloakAuthorizationManager keycloakAuthorizationManager
         ) throws Exception {
-            log.info("핵심 Bean을 등록합니다: [SecurityFilterChain]");
+            RequestMatcher securityMatcher = KeycloakSecurityMatcherFactory.from(securityProperties.getMatcher());
+            log.info("핵심 Bean을 등록합니다: [SecurityFilterChain] (담당 경로 include={}, exclude={})",
+                securityProperties.getMatcher().getInclude(), securityProperties.getMatcher().getExclude());
+
+            // 0. 이 체인이 담당할 경로를 명시적으로 선언 (사용자 커스텀 체인과 공존, Fail-Open 방지)
+            http.securityMatcher(securityMatcher);
 
             // 1. Keycloak 핵심 설정을 Configurer에서 적용
             // (인증 필터, 프로바이더, 로그인, 로그아웃, 세션, CSRF 등)

--- a/keycloak-spring-security-web-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/keycloak-spring-security-web-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,23 @@
+{
+  "properties": [
+    {
+      "name": "keycloak.security.auto-filter-chain",
+      "type": "java.lang.Boolean",
+      "description": "Keycloak 기본 SecurityFilterChain 자동 등록 여부입니다. false로 설정하면 Keycloak 기본 체인이 등록되지 않으며, 사용자가 전체 SecurityFilterChain 구성을 직접 책임집니다.",
+      "sourceType": "com.ids.keycloak.security.config.KeycloakSecurityProperties",
+      "defaultValue": true
+    },
+    {
+      "name": "keycloak.security.matcher.include",
+      "type": "java.util.List<java.lang.String>",
+      "description": "Keycloak SecurityFilterChain이 담당할 포함 경로(Ant 패턴)입니다. 기본값은 전체 경로(/**)이며, 사용자가 더 구체적인 matcher를 가진 체인을 등록하면 그 경로는 사용자 체인이 담당합니다.",
+      "sourceType": "com.ids.keycloak.security.config.KeycloakMatcherProperties"
+    },
+    {
+      "name": "keycloak.security.matcher.exclude",
+      "type": "java.util.List<java.lang.String>",
+      "description": "Keycloak SecurityFilterChain에서 제외할 경로(Ant 패턴)입니다. 제외된 경로는 사용자가 등록한 다른 SecurityFilterChain이 담당합니다.",
+      "sourceType": "com.ids.keycloak.security.config.KeycloakMatcherProperties"
+    }
+  ]
+}

--- a/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/KeycloakSecurityFilterChainConditionsTest.java
+++ b/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/KeycloakSecurityFilterChainConditionsTest.java
@@ -1,0 +1,82 @@
+package com.ids.keycloak.security.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ids.keycloak.security.manager.KeycloakAuthorizationManager;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+/**
+ * {@code keycloakSecurityFilterChain} Bean의 조건/순서 어노테이션이 Fail-Open 방지 설계를 유지하는지 검증합니다.
+ * <p>
+ * (CVSS 8.1, CWE-1188/863) 회귀 방지 — 다음 보증이 깨지면 인증이 통째로 사라질 수 있으므로 어노테이션 수준에서 고정합니다.
+ * 전체 AutoConfiguration은 Keycloak/OAuth2 협력 빈이 많아 풀 컨텍스트 기동이 비현실적이라, 조건을 직접 검증합니다.
+ * </p>
+ * <ul>
+ *   <li>(a) 기본 등록: {@code @ConditionalOnProperty(matchIfMissing=true)} → 프로퍼티 미설정 시에도 등록</li>
+ *   <li>(b) 사용자 체인 공존: {@code @ConditionalOnMissingBean(name=...)} → SecurityFilterChain.class 타입 충돌로 비활성화되지 않음</li>
+ *   <li>(c) 명시적 opt-out: {@code auto-filter-chain=false} 일 때만 미등록</li>
+ *   <li>순서: {@code @Order(LOWEST_PRECEDENCE)} → catch-all 체인이 맨 뒤, 사용자의 구체적 체인이 우선</li>
+ * </ul>
+ */
+class KeycloakSecurityFilterChainConditionsTest {
+
+    private Method filterChainMethod() throws NoSuchMethodException {
+        return KeycloakServletAutoConfiguration.KeycloakWebSecurityConfiguration.class.getDeclaredMethod(
+            "keycloakSecurityFilterChain",
+            HttpSecurity.class,
+            KeycloakSecurityProperties.class,
+            ObjectProvider.class,
+            KeycloakAuthorizationManager.class
+        );
+    }
+
+    @Test
+    @DisplayName("(b) Bean 이름 기반 @ConditionalOnMissingBean — 사용자가 다른 SecurityFilterChain을 추가해도 공존")
+    void conditionalOnMissingBeanByName() throws Exception {
+        ConditionalOnMissingBean annotation = filterChainMethod().getAnnotation(ConditionalOnMissingBean.class);
+
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.name()).containsExactly("keycloakSecurityFilterChain");
+        // 타입 기반 조건(SecurityFilterChain.class)이 남아 있으면 Fail-Open이 재발하므로 비어 있어야 한다
+        assertThat(annotation.value()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("(a)(c) @ConditionalOnProperty — 기본 등록(matchIfMissing), auto-filter-chain=false 일 때만 미등록")
+    void conditionalOnProperty() throws Exception {
+        ConditionalOnProperty annotation = filterChainMethod().getAnnotation(ConditionalOnProperty.class);
+
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.prefix()).isEqualTo("keycloak.security");
+        assertThat(annotation.name()).containsExactly("auto-filter-chain");
+        assertThat(annotation.havingValue()).isEqualTo("true");
+        assertThat(annotation.matchIfMissing()).isTrue();
+    }
+
+    @Test
+    @DisplayName("@Order(LOWEST_PRECEDENCE) — catch-all 체인이 맨 뒤, 사용자 체인이 우선 평가됨")
+    void orderIsLowestPrecedence() throws Exception {
+        Order annotation = filterChainMethod().getAnnotation(Order.class);
+
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.value()).isEqualTo(Ordered.LOWEST_PRECEDENCE);
+    }
+
+    @Test
+    @DisplayName("@Bean 이름이 'keycloakSecurityFilterChain'으로 고정 (조건의 name과 일치)")
+    void beanNameMatches() throws Exception {
+        Bean annotation = filterChainMethod().getAnnotation(Bean.class);
+
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.value()).containsExactly("keycloakSecurityFilterChain");
+    }
+}

--- a/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/KeycloakSecurityMatcherFactoryTest.java
+++ b/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/KeycloakSecurityMatcherFactoryTest.java
@@ -1,0 +1,104 @@
+package com.ids.keycloak.security.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+/**
+ * {@link KeycloakSecurityMatcherFactory}가 include/exclude 설정을 올바른 매칭 동작으로 변환하는지 검증합니다.
+ * <p>
+ * 이 매처는 Keycloak SecurityFilterChain의 담당 경로를 결정하므로, Fail-Open 방지 설계의 핵심 로직입니다.
+ * </p>
+ */
+class KeycloakSecurityMatcherFactoryTest {
+
+    private static MockHttpServletRequest request(String uri) {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
+        // AntPathRequestMatcher는 servletPath 기반으로 매칭하므로 명시적으로 설정
+        request.setServletPath(uri);
+        return request;
+    }
+
+    private static boolean matches(RequestMatcher matcher, String uri) {
+        HttpServletRequest request = request(uri);
+        return matcher.matches(request);
+    }
+
+    private static KeycloakMatcherProperties props(List<String> include, List<String> exclude) {
+        KeycloakMatcherProperties p = new KeycloakMatcherProperties();
+        p.setInclude(include);
+        p.setExclude(exclude);
+        return p;
+    }
+
+    @Nested
+    @DisplayName("기본값(include=/**, exclude 없음)")
+    class DefaultMatcher {
+
+        @Test
+        @DisplayName("모든 경로를 담당한다")
+        void matchesEverything() {
+            RequestMatcher matcher = KeycloakSecurityMatcherFactory.from(new KeycloakMatcherProperties());
+
+            assertThat(matches(matcher, "/")).isTrue();
+            assertThat(matches(matcher, "/api/users")).isTrue();
+            assertThat(matches(matcher, "/actuator/health")).isTrue();
+            assertThat(matches(matcher, "/anything/deep/path")).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("exclude 지정 시 (include=/**, exclude=/actuator/**)")
+    class WithExclude {
+
+        private final RequestMatcher matcher =
+            KeycloakSecurityMatcherFactory.from(props(List.of("/**"), List.of("/actuator/**")));
+
+        @Test
+        @DisplayName("제외 경로는 Keycloak 체인이 담당하지 않는다 (다른 체인으로 위임)")
+        void excludedPathNotMatched() {
+            assertThat(matches(matcher, "/actuator/health")).isFalse();
+            assertThat(matches(matcher, "/actuator/info")).isFalse();
+        }
+
+        @Test
+        @DisplayName("그 외 경로는 Keycloak 체인이 담당한다")
+        void otherPathsMatched() {
+            assertThat(matches(matcher, "/api/users")).isTrue();
+            assertThat(matches(matcher, "/")).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("복수 include / 복수 exclude")
+    class MultiplePatterns {
+
+        @Test
+        @DisplayName("include 목록 중 하나라도 매칭되면 담당한다")
+        void multipleIncludes() {
+            RequestMatcher matcher =
+                KeycloakSecurityMatcherFactory.from(props(List.of("/api/**", "/admin/**"), List.of()));
+
+            assertThat(matches(matcher, "/api/users")).isTrue();
+            assertThat(matches(matcher, "/admin/dashboard")).isTrue();
+            assertThat(matches(matcher, "/public/home")).isFalse();
+        }
+
+        @Test
+        @DisplayName("exclude 목록 중 하나라도 매칭되면 제외한다")
+        void multipleExcludes() {
+            RequestMatcher matcher =
+                KeycloakSecurityMatcherFactory.from(props(List.of("/**"), List.of("/actuator/**", "/public/**")));
+
+            assertThat(matches(matcher, "/actuator/health")).isFalse();
+            assertThat(matches(matcher, "/public/home")).isFalse();
+            assertThat(matches(matcher, "/api/users")).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
Closes #37

## 배경
`KeycloakServletAutoConfiguration`의 `keycloakSecurityFilterChain`이 `@ConditionalOnMissingBean(SecurityFilterChain.class)`로 등록되어, 사용자가 actuator 등 **자체 SecurityFilterChain을 하나라도 추가하면 Keycloak 필터 체인 전체가 비활성화**되는 Fail-Open 결함.

- CVSS v3.1 **8.1 High** (`AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N`)
- CWE-1188 / CWE-863

## 변경
| 항목 | 효과 |
|------|------|
| `@ConditionalOnMissingBean(name = "keycloakSecurityFilterChain")` | 사용자 체인과 **공존** (타입 충돌로 꺼지지 않음) |
| `@ConditionalOnProperty(auto-filter-chain, matchIfMissing=true)` | `auto-filter-chain=false` 일 때만 미등록(opt-out) |
| `@Order(LOWEST_PRECEDENCE)` | catch-all 체인을 맨 뒤로 → 사용자의 구체적 체인 우선 |
| `securityMatcher(matcher.include/exclude)` | 담당 경로 명시 분리 |

> ⚠️ `@Order`는 명세의 `LOWEST_PRECEDENCE - 100`이 아니라 `LOWEST_PRECEDENCE`로 구현했습니다. 다중 체인은 Order 오름차순 평가 + 첫 매칭 처리이므로, catch-all(`/**`)은 맨 뒤여야 사용자 체인이 우선합니다.

## 신규 프로퍼티
- `keycloak.security.auto-filter-chain` (기본 `true`)
- `keycloak.security.matcher.include` / `exclude`

## 테스트
- `KeycloakSecurityMatcherFactoryTest` (5) — include/exclude 경로 분리 동작
- `KeycloakSecurityFilterChainConditionsTest` (4) — 조건/순서 어노테이션 고정 (기본등록/공존/opt-out/Order)
- 기존 단위 테스트 회귀 0

## Breaking change
- `1.4.1` → `1.5.0` (minor bump)
- Migration 가이드: `docs/12-SecurityFilterChain-FailOpen-수정.md`
- 기존에 "사용자 체인 추가 → Keycloak 자동 비활성화"에 의존하던 앱은 `auto-filter-chain=false`로 opt-out 가능