### PR TITLE
[#39] feat: MDC 로깅 사내표준 위임 v1.6.0 (clear 누수 보정 + PII 마스킹 + userAgent/query 정제 + X-Request-Id)

### DIFF
--- a/docs/13-MDC-로깅-사내표준-위임.md
+++ b/docs/13-MDC-로깅-사내표준-위임.md
@@ -1,0 +1,89 @@
+# 13. MDC 로깅 사내표준 위임 (v1.6.0)
+
+> 사내 로깅 표준을 본 라이브러리(`keycloak-spring-security-web-starter`) 단일 위임으로 통합하기 위한 MDC 보강.
+> 요구사항 R1~R3 + PII 마스킹 + X-Request-Id 회신을 포함합니다. (R4 응답 메트릭·R6 excludePatterns는 v1.7.0 예정)
+
+## 1. 변경 요약
+
+| 항목 | 내용 |
+|------|------|
+| **R1 (P0)** | `WebMdcContextAccessor.clear()`가 `MDC.clear()`로 외부 키까지 비우던 누수 버그 수정 → 라이브러리가 put한 키만 추적/제거 |
+| **PII 마스킹** | `LoggingValueSanitizer` SPI 도입 + `DefaultPiiMaskingSanitizer` **기본 등록(on)** |
+| **R2** | `userAgent` MDC 추가 (마스킹 + 256자 제한) |
+| **R3** | `queryString` 정제 (URL 디코딩 + 512자 제한 + 마스킹) |
+| **X-Request-Id** | traceId를 응답 헤더로 회신 |
+
+## 2. R1 — clear() 키 누수 보정
+
+**문제**: `WebMdcContextAccessor.clear()`가 `MDC.clear()`를 호출해, 사용자 코드/타 라이브러리가 넣은 MDC 키(도메인 컨텍스트 등)까지 전부 삭제했습니다.
+
+**수정**: 어댑터를 통해 put한 키만 `ThreadLocal<Set<String>>`으로 추적하고, `clear()` 시 그 키들만 `MDC.remove`합니다. 사용자가 직접 `MDC.put`한 키는 보존됩니다. (스레드풀 재사용 시 `ThreadLocal`도 정리)
+
+## 3. PII 마스킹 — `LoggingValueSanitizer` SPI
+
+```java
+@FunctionalInterface
+public interface LoggingValueSanitizer {
+    String sanitize(String key, String value);
+}
+```
+
+- 기본 빈 `DefaultPiiMaskingSanitizer` — 이메일/휴대폰/주민번호/카드/Bearer 토큰 마스킹 (**기본 on**)
+- `MdcRequestFilter`가 `query`/`userAgent`를 MDC에 넣기 직전 `sanitize(...)` 호출
+- 사용자가 `LoggingValueSanitizer` 빈을 등록하면 자동 교체(`@ConditionalOnMissingBean`)
+
+| 종류 | 원본 | 마스킹 |
+|------|------|--------|
+| 이메일 | `alice@example.com` | `a***@example.com` |
+| 휴대폰 | `010-1234-5678` | `010-****-5678` |
+| 주민번호 | `900101-1234567` | `900101-1******` |
+| 카드 | `1234-5678-9012-3456` | `1234-****-****-3456` |
+| Bearer | `Bearer eyJ...` | `Bearer ***` |
+
+## 4. 신규 프로퍼티
+
+```yaml
+keycloak:
+  security:
+    logging:
+      include-user-agent: true       # userAgent MDC 포함 (기본 true)
+      return-trace-id-header: true   # 응답 X-Request-Id 회신 (기본 true)
+      max-query-length: 512          # query 최대 길이
+      max-user-agent-length: 256     # userAgent 최대 길이
+      include-query-string: false    # (기존) query MDC 포함
+```
+
+## 5. Migration 가이드 (v1.5.x → v1.6.0)
+
+### ⚠️ Breaking change — PII 마스킹 기본 on
+- 기존에는 query/userAgent가 마스킹 없이 기록됐습니다. v1.6.0부터 **기본으로 PII가 마스킹**됩니다.
+- 로그에서 이메일/전화번호 등이 `***`로 보이는 것은 정상 동작입니다.
+- **마스킹을 끄려면** `NoOpLoggingValueSanitizer`를 빈으로 등록:
+  ```java
+  @Bean
+  LoggingValueSanitizer loggingValueSanitizer() {
+      return new NoOpLoggingValueSanitizer();
+  }
+  ```
+- **마스킹 패턴을 바꾸려면** `LoggingValueSanitizer`를 직접 구현해 빈으로 등록.
+
+### 동작 변화 정리
+| 변경 | 영향 | 대응 |
+|------|------|------|
+| `clear()` 키 추적 | 외부 MDC 키가 더 이상 라이브러리에 의해 지워지지 않음 (개선) | 없음 |
+| query/userAgent 마스킹 | 로그 PII가 마스킹됨 | 원치 않으면 `NoOpLoggingValueSanitizer` |
+| query URL 디코딩 | 인코딩된 쿼리가 평문으로 기록 | 없음 |
+| X-Request-Id 응답 회신 | 응답 헤더 추가 | 원치 않으면 `return-trace-id-header: false` |
+
+## 6. 검증 (테스트)
+
+| 테스트 | 검증 |
+|--------|------|
+| `WebMdcContextAccessorTest` (키 누수 방지) | 외부 키 보존, owned 키만 제거, 스레드 재사용 누수 없음 |
+| `DefaultPiiMaskingSanitizerTest` | 이메일/폰/주민/카드/Bearer 마스킹 + 경계 케이스 |
+| `MdcRequestFilterTest` | userAgent 저장/truncate, query 디코딩/마스킹, X-Request-Id 회신/토글 |
+
+## 7. 후속 (v1.7.0 예정)
+
+- R4: 응답 메트릭(`status`/`durationMs`, `include-response-metrics` 토글, 기본 off)
+- R6: `exclude-patterns`(`/actuator/**`) — MDC 필터 제외 경로

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version Management
-projectVersion=1.5.0
+projectVersion=1.6.0
 
 # Maven Publishing Info
 mavenGroupId=io.github.l-dxd

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakLoggingProperties.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakLoggingProperties.java
@@ -28,6 +28,18 @@ public class KeycloakLoggingProperties {
     /** 클라이언트 IP 포함 여부 (기본값: true) */
     private boolean includeClientIp = true;
 
+    /** User-Agent 포함 여부 (기본값: true) — 마스킹 + 256자 제한 적용 */
+    private boolean includeUserAgent = true;
+
+    /** 쿼리 스트링 최대 길이 (초과 시 truncate, 기본값: 512) */
+    private int maxQueryLength = 512;
+
+    /** User-Agent 최대 길이 (초과 시 truncate, 기본값: 256) */
+    private int maxUserAgentLength = 256;
+
+    /** 응답 헤더 X-Request-Id 로 traceId 회신 여부 (기본값: true) */
+    private boolean returnTraceIdHeader = true;
+
     /** 사용자 ID 포함 여부 (기본값: true) */
     private boolean includeUserId = true;
 

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/logging/DefaultPiiMaskingSanitizer.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/logging/DefaultPiiMaskingSanitizer.java
@@ -1,0 +1,57 @@
+package com.ids.keycloak.security.logging;
+
+import java.util.regex.Pattern;
+
+/**
+ * 로그 출력 전 PII/민감정보를 마스킹하는 기본 {@link LoggingValueSanitizer} 구현체.
+ * <p>
+ * 사내 로깅 표준의 PiiMasker 패턴을 라이브러리 기본값으로 내장합니다.
+ * </p>
+ * 지원 패턴
+ * <ul>
+ *   <li>이메일      : {@code a***@example.com}</li>
+ *   <li>휴대폰      : {@code 010-****-5678}</li>
+ *   <li>주민번호     : {@code 900101-1******}</li>
+ *   <li>Bearer 토큰 : {@code Bearer ***}</li>
+ *   <li>카드/계좌    : {@code 1234-****-****-3456}</li>
+ * </ul>
+ * <p>
+ * <b>원칙</b> — 로그에 민감정보를 안 넣는 것이 1차 방어, 마스킹은 2차 방어선입니다.
+ * </p>
+ */
+public class DefaultPiiMaskingSanitizer implements LoggingValueSanitizer {
+
+    private static final Pattern EMAIL = Pattern.compile(
+            "([A-Za-z0-9])[A-Za-z0-9._%+-]*(@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})"
+    );
+    private static final Pattern PHONE = Pattern.compile(
+            "(01[016789])[-. ]?\\d{3,4}[-. ]?(\\d{4})"
+    );
+    private static final Pattern RRN = Pattern.compile(
+            "(\\d{6})-([1-4])\\d{6}"
+    );
+    private static final Pattern BEARER = Pattern.compile(
+            "Bearer\\s+[A-Za-z0-9._~+/=-]+",
+            Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern CARD = Pattern.compile(
+            "(\\d{4})[-. ]?\\d{4}[-. ]?\\d{4}[-. ]?(\\d{4})"
+    );
+
+    @Override
+    public String sanitize(String key, String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+
+        String result = value;
+        // 적용 순서: Bearer → 주민번호 → 카드 → 이메일 → 휴대폰
+        // (Bearer 토큰은 내부에 숫자/기호가 많아 다른 패턴에 먼저 매칭될 수 있어 가장 먼저)
+        result = BEARER.matcher(result).replaceAll("Bearer ***");
+        result = RRN.matcher(result).replaceAll("$1-$2******");
+        result = CARD.matcher(result).replaceAll("$1-****-****-$2");
+        result = EMAIL.matcher(result).replaceAll("$1***$2");
+        result = PHONE.matcher(result).replaceAll("$1-****-$2");
+        return result;
+    }
+}

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/logging/LoggingContextKeys.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/logging/LoggingContextKeys.java
@@ -24,6 +24,9 @@ public final class LoggingContextKeys {
     /** 클라이언트 IP 주소 */
     public static final String CLIENT_IP = "clientIp";
 
+    /** User-Agent 헤더 (마스킹 + 길이 제한 적용) */
+    public static final String USER_AGENT = "userAgent";
+
     // ===== 인증 정보 (인증 후 설정) =====
 
     /** 인증된 사용자 ID (Keycloak sub claim) */

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/logging/LoggingValueSanitizer.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/logging/LoggingValueSanitizer.java
@@ -1,0 +1,25 @@
+package com.ids.keycloak.security.logging;
+
+/**
+ * 로그(MDC 등)에 기록되기 전에 값에서 민감정보(PII/시크릿)를 정제(마스킹)하는 SPI.
+ * <p>
+ * 라이브러리는 기본 구현으로 {@code DefaultPiiMaskingSanitizer}(이메일/휴대폰/주민번호/카드/Bearer 토큰 마스킹)를
+ * 등록합니다. 사용자가 이 인터페이스를 구현한 빈을 등록하면 자동으로 교체됩니다.
+ * 마스킹을 끄려면 {@code NoOpLoggingValueSanitizer}를 빈으로 등록하세요.
+ * </p>
+ * <p>
+ * <b>원칙</b>: 로그에 민감정보를 안 넣는 것이 1차 방어, 본 마스킹은 2차 방어선입니다.
+ * </p>
+ */
+@FunctionalInterface
+public interface LoggingValueSanitizer {
+
+    /**
+     * 주어진 값에서 민감정보를 마스킹하여 반환합니다.
+     *
+     * @param key   MDC 키 (키별 차등 처리가 필요할 때 활용, 기본 구현은 무시)
+     * @param value 원본 값 (null 가능)
+     * @return 마스킹된 값 (null 입력 시 null)
+     */
+    String sanitize(String key, String value);
+}

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/logging/NoOpLoggingValueSanitizer.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/logging/NoOpLoggingValueSanitizer.java
@@ -1,0 +1,16 @@
+package com.ids.keycloak.security.logging;
+
+/**
+ * 마스킹을 수행하지 않고 값을 그대로 통과시키는 {@link LoggingValueSanitizer} 구현체.
+ * <p>
+ * PII 마스킹을 비활성화하려는 사용자가 명시적으로 빈으로 등록하여 기본
+ * {@code DefaultPiiMaskingSanitizer}를 대체할 때 사용합니다.
+ * </p>
+ */
+public class NoOpLoggingValueSanitizer implements LoggingValueSanitizer {
+
+    @Override
+    public String sanitize(String key, String value) {
+        return value;
+    }
+}

--- a/keycloak-spring-security-core/src/test/java/com/ids/keycloak/security/logging/DefaultPiiMaskingSanitizerTest.java
+++ b/keycloak-spring-security-core/src/test/java/com/ids/keycloak/security/logging/DefaultPiiMaskingSanitizerTest.java
@@ -1,0 +1,82 @@
+package com.ids.keycloak.security.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link DefaultPiiMaskingSanitizer}의 PII 마스킹 패턴을 검증합니다.
+ */
+class DefaultPiiMaskingSanitizerTest {
+
+    private final DefaultPiiMaskingSanitizer sanitizer = new DefaultPiiMaskingSanitizer();
+
+    private String mask(String value) {
+        return sanitizer.sanitize("anyKey", value);
+    }
+
+    @Nested
+    @DisplayName("PII 패턴 마스킹")
+    class Patterns {
+
+        @Test
+        @DisplayName("이메일")
+        void email() {
+            assertThat(mask("alice@example.com")).isEqualTo("a***@example.com");
+            assertThat(mask("user=bob@test.co.kr")).isEqualTo("user=b***@test.co.kr");
+        }
+
+        @Test
+        @DisplayName("휴대폰 (하이픈/무하이픈)")
+        void phone() {
+            assertThat(mask("010-1234-5678")).isEqualTo("010-****-5678");
+            assertThat(mask("01012345678")).isEqualTo("010-****-5678");
+        }
+
+        @Test
+        @DisplayName("주민번호")
+        void rrn() {
+            assertThat(mask("900101-1234567")).isEqualTo("900101-1******");
+        }
+
+        @Test
+        @DisplayName("카드번호 16자리")
+        void card() {
+            assertThat(mask("1234-5678-9012-3456")).isEqualTo("1234-****-****-3456");
+        }
+
+        @Test
+        @DisplayName("Bearer 토큰")
+        void bearer() {
+            assertThat(mask("Bearer eyJhbGciOiJIUzI1Ni9.abc-def_123"))
+                .isEqualTo("Bearer ***");
+        }
+    }
+
+    @Nested
+    @DisplayName("경계 케이스")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("null/빈 문자열은 그대로 반환")
+        void nullOrEmpty() {
+            assertThat(mask(null)).isNull();
+            assertThat(mask("")).isEmpty();
+        }
+
+        @Test
+        @DisplayName("민감정보가 없으면 원본 유지")
+        void noPii() {
+            assertThat(mask("name=John&page=1")).isEqualTo("name=John&page=1");
+        }
+
+        @Test
+        @DisplayName("여러 PII가 섞여 있어도 각각 마스킹")
+        void multiple() {
+            String input = "email=alice@example.com&phone=010-1234-5678";
+            assertThat(mask(input)).isEqualTo("email=a***@example.com&phone=010-****-5678");
+        }
+    }
+}

--- a/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/KeycloakServletAutoConfiguration.java
+++ b/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/KeycloakServletAutoConfiguration.java
@@ -11,6 +11,8 @@ import com.ids.keycloak.security.exception.KeycloakAccessDeniedHandler;
 import com.ids.keycloak.security.ratelimit.InMemoryRateLimiter;
 import com.ids.keycloak.security.ratelimit.RateLimiter;
 import com.ids.keycloak.security.manager.KeycloakAuthorizationManager;
+import com.ids.keycloak.security.logging.DefaultPiiMaskingSanitizer;
+import com.ids.keycloak.security.logging.LoggingValueSanitizer;
 import com.ids.keycloak.security.session.KeycloakSessionManager;
 import com.ids.keycloak.security.util.CookieUtil;
 import com.ids.keycloak.security.exception.KeycloakAuthenticationEntryPoint;
@@ -123,6 +125,17 @@ public class KeycloakServletAutoConfiguration {
         public ObjectMapper keycloakObjectMapper() {
             log.debug("지원 Bean을 등록합니다: [ObjectMapper]");
             return new ObjectMapper();
+        }
+
+        /**
+         * 로그 마스킹 SPI 기본 빈. 사용자가 {@link LoggingValueSanitizer} 빈을 등록하면 교체됩니다.
+         * 마스킹을 끄려면 {@code NoOpLoggingValueSanitizer}를 빈으로 등록하세요.
+         */
+        @Bean
+        @ConditionalOnMissingBean(LoggingValueSanitizer.class)
+        public LoggingValueSanitizer keycloakLoggingValueSanitizer() {
+            log.debug("지원 Bean을 등록합니다: [LoggingValueSanitizer] (DefaultPiiMaskingSanitizer, PII 마스킹 기본 on)");
+            return new DefaultPiiMaskingSanitizer();
         }
 
         @Configuration(proxyBeanMethods = false)

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/config/KeycloakHttpConfigurer.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/config/KeycloakHttpConfigurer.java
@@ -14,6 +14,8 @@ import com.ids.keycloak.security.filter.MdcRequestFilter;
 import com.ids.keycloak.security.filter.RateLimitFilter;
 import com.ids.keycloak.security.ratelimit.RateLimiter;
 import com.ids.keycloak.security.logging.LoggingContextAccessor;
+import com.ids.keycloak.security.logging.LoggingValueSanitizer;
+import com.ids.keycloak.security.logging.DefaultPiiMaskingSanitizer;
 import com.ids.keycloak.security.logging.WebMdcContextAccessor;
 import com.ids.keycloak.security.exception.KeycloakAccessDeniedHandler;
 import com.sd.KeycloakClient.factory.KeycloakClient;
@@ -241,8 +243,11 @@ public final class KeycloakHttpConfigurer extends AbstractHttpConfigurer<Keycloa
       );
 
         // 7. MDC 로깅 필터 등록
-        // 7-1. MdcRequestFilter: 인증 전 (최상단) - traceId, httpMethod, requestUri, clientIp
-        MdcRequestFilter mdcRequestFilter = new MdcRequestFilter(loggingContextAccessor, securityProperties);
+        // 7-1. MdcRequestFilter: 인증 전 (최상단) - traceId, httpMethod, requestUri, clientIp, query, userAgent
+        // 민감정보 마스킹은 LoggingValueSanitizer 빈에 위임(없으면 기본 PII 마스킹)
+        LoggingValueSanitizer loggingValueSanitizer = getBeanOrDefault(
+            context, LoggingValueSanitizer.class, new DefaultPiiMaskingSanitizer());
+        MdcRequestFilter mdcRequestFilter = new MdcRequestFilter(loggingContextAccessor, securityProperties, loggingValueSanitizer);
         http.addFilterBefore(mdcRequestFilter, SecurityContextHolderFilter.class);
 
         // 7-2. MdcAuthenticationFilter: 인증 후 (AuthorizationFilter 앞) - userId, username, sessionId

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/filter/MdcRequestFilter.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/filter/MdcRequestFilter.java
@@ -4,6 +4,7 @@ import com.ids.keycloak.security.config.KeycloakLoggingProperties;
 import com.ids.keycloak.security.config.KeycloakSecurityProperties;
 import com.ids.keycloak.security.logging.LoggingContextAccessor;
 import com.ids.keycloak.security.logging.LoggingContextKeys;
+import com.ids.keycloak.security.logging.LoggingValueSanitizer;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,6 +12,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -19,12 +22,15 @@ import java.util.UUID;
  * <p>
  * SecurityFilterChain 최상단에 위치하여 인증 실패 요청도 추적 가능하게 합니다.
  * <ul>
- *   <li>{@code traceId}: X-Request-Id 헤더 또는 자동 생성 UUID</li>
+ *   <li>{@code traceId}: X-Request-Id 헤더 또는 자동 생성 UUID (응답 헤더로도 회신)</li>
  *   <li>{@code httpMethod}: HTTP 메서드 (GET, POST 등)</li>
  *   <li>{@code requestUri}: 요청 경로</li>
  *   <li>{@code clientIp}: 클라이언트 IP 주소</li>
+ *   <li>{@code queryString}: 쿼리 스트링 (URL 디코딩 + 길이 제한 + 마스킹)</li>
+ *   <li>{@code userAgent}: User-Agent 헤더 (길이 제한 + 마스킹)</li>
  * </ul>
  * <p>
+ * 민감정보 마스킹은 {@link LoggingValueSanitizer}에 위임합니다(기본 PII 마스킹, 사용자 교체 가능).
  * 요청이 완료되면 finally 블록에서 MDC를 정리합니다.
  *
  * @author LeeBongSeung
@@ -34,13 +40,18 @@ public class MdcRequestFilter extends OncePerRequestFilter {
 
     private static final String X_REQUEST_ID_HEADER = "X-Request-Id";
     private static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+    private static final String USER_AGENT_HEADER = "User-Agent";
 
     private final LoggingContextAccessor contextAccessor;
     private final KeycloakSecurityProperties securityProperties;
+    private final LoggingValueSanitizer sanitizer;
 
-    public MdcRequestFilter(LoggingContextAccessor contextAccessor, KeycloakSecurityProperties securityProperties) {
+    public MdcRequestFilter(LoggingContextAccessor contextAccessor,
+                            KeycloakSecurityProperties securityProperties,
+                            LoggingValueSanitizer sanitizer) {
         this.contextAccessor = contextAccessor;
         this.securityProperties = securityProperties;
+        this.sanitizer = sanitizer;
     }
 
     @Override
@@ -48,22 +59,26 @@ public class MdcRequestFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain chain) throws ServletException, IOException {
         try {
-            populateRequestContext(request);
+            populateRequestContext(request, response);
             chain.doFilter(request, response);
         } finally {
             contextAccessor.clear();
         }
     }
 
-    private void populateRequestContext(HttpServletRequest request) {
+    private void populateRequestContext(HttpServletRequest request, HttpServletResponse response) {
         KeycloakLoggingProperties loggingProps = securityProperties.getLogging();
 
-        // traceId 설정
+        // traceId 설정 (+ 응답 헤더 회신)
         if (loggingProps.isIncludeTraceId()) {
             String traceId = Optional.ofNullable(request.getHeader(X_REQUEST_ID_HEADER))
                     .filter(s -> !s.isBlank())
                     .orElseGet(() -> UUID.randomUUID().toString());
             contextAccessor.put(LoggingContextKeys.TRACE_ID, traceId);
+
+            if (loggingProps.isReturnTraceIdHeader()) {
+                response.setHeader(X_REQUEST_ID_HEADER, traceId);
+            }
         }
 
         // 요청 메타데이터
@@ -77,9 +92,26 @@ public class MdcRequestFilter extends OncePerRequestFilter {
             contextAccessor.put(LoggingContextKeys.CLIENT_IP, getClientIp(request));
         }
 
-        // 쿼리 스트링
+        // 쿼리 스트링: URL 디코딩 → 길이 제한 → 마스킹
         if (loggingProps.isIncludeQueryString()) {
-            contextAccessor.put(LoggingContextKeys.QUERY_STRING, request.getQueryString());
+            String query = request.getQueryString();
+            if (query != null) {
+                String sanitized = sanitizer.sanitize(
+                        LoggingContextKeys.QUERY_STRING,
+                        truncate(decode(query), loggingProps.getMaxQueryLength()));
+                contextAccessor.put(LoggingContextKeys.QUERY_STRING, sanitized);
+            }
+        }
+
+        // User-Agent: 길이 제한 → 마스킹
+        if (loggingProps.isIncludeUserAgent()) {
+            String userAgent = request.getHeader(USER_AGENT_HEADER);
+            if (userAgent != null) {
+                String sanitized = sanitizer.sanitize(
+                        LoggingContextKeys.USER_AGENT,
+                        truncate(userAgent, loggingProps.getMaxUserAgentLength()));
+                contextAccessor.put(LoggingContextKeys.USER_AGENT, sanitized);
+            }
         }
     }
 
@@ -90,5 +122,26 @@ public class MdcRequestFilter extends OncePerRequestFilter {
             return xff.split(",")[0].trim();
         }
         return request.getRemoteAddr();
+    }
+
+    private String decode(String raw) {
+        if (raw == null || raw.isEmpty()) {
+            return raw;
+        }
+        try {
+            return URLDecoder.decode(raw, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            return raw;
+        }
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength) + "...[truncated]";
     }
 }

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/logging/WebMdcContextAccessor.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/logging/WebMdcContextAccessor.java
@@ -4,23 +4,33 @@ import org.slf4j.MDC;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Web 환경용 MDC 직접 연동 어댑터.
  * <p>
  * ThreadLocal 기반 MDC를 그대로 활용합니다.
  * Web(Servlet) 환경에서는 요청당 하나의 스레드가 점유되므로, MDC를 직접 사용해도 안전합니다.
+ * <p>
+ * <b>키 누수 방지 (1.6.0+)</b>: 이 어댑터를 통해 put한 키만 추적하여 {@link #clear()} 시 그 키들만
+ * 제거합니다. 따라서 사용자 코드/타 라이브러리가 직접 {@code MDC.put}한 키(도메인 컨텍스트 등)는
+ * {@code clear()}가 건드리지 않아 보존됩니다. (이전에는 {@code MDC.clear()}로 전부 비워 누수가 있었음)
  *
  * @author LeeBongSeung
  * @since 1.0.0
  */
 public class WebMdcContextAccessor implements LoggingContextAccessor, LoggingContextPropagator {
 
+    /** 이 어댑터가 put한 키 목록. clear() 시 이 키들만 MDC에서 제거한다. */
+    private static final ThreadLocal<Set<String>> OWNED_KEYS = ThreadLocal.withInitial(HashSet::new);
+
     @Override
     public void put(String key, String value) {
         if (key != null && value != null) {
             MDC.put(key, value);
+            OWNED_KEYS.get().add(key);
         }
     }
 
@@ -33,12 +43,18 @@ public class WebMdcContextAccessor implements LoggingContextAccessor, LoggingCon
     public void remove(String key) {
         if (key != null) {
             MDC.remove(key);
+            OWNED_KEYS.get().remove(key);
         }
     }
 
     @Override
     public void clear() {
-        MDC.clear();
+        Set<String> owned = OWNED_KEYS.get();
+        for (String key : owned) {
+            MDC.remove(key);
+        }
+        // ThreadLocal 자체도 정리하여 스레드풀 재사용 시 누수를 방지한다.
+        OWNED_KEYS.remove();
     }
 
     @Override

--- a/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/filter/MdcRequestFilterTest.java
+++ b/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/filter/MdcRequestFilterTest.java
@@ -2,13 +2,16 @@ package com.ids.keycloak.security.filter;
 
 import com.ids.keycloak.security.config.KeycloakLoggingProperties;
 import com.ids.keycloak.security.config.KeycloakSecurityProperties;
+import com.ids.keycloak.security.logging.DefaultPiiMaskingSanitizer;
 import com.ids.keycloak.security.logging.LoggingContextAccessor;
 import com.ids.keycloak.security.logging.LoggingContextKeys;
+import com.ids.keycloak.security.logging.NoOpLoggingValueSanitizer;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +23,7 @@ import org.mockito.quality.Strictness;
 import java.io.IOException;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -47,7 +51,8 @@ class MdcRequestFilterTest {
     void setUp() {
         securityProperties = new KeycloakSecurityProperties();
         loggingProperties = securityProperties.getLogging();
-        mdcRequestFilter = new MdcRequestFilter(contextAccessor, securityProperties);
+        // 기본 필터는 마스킹 비활성(NoOp)으로 두어 변환 로직(디코딩/truncate)만 격리 검증
+        mdcRequestFilter = new MdcRequestFilter(contextAccessor, securityProperties, new NoOpLoggingValueSanitizer());
     }
 
     @Nested
@@ -95,8 +100,6 @@ class MdcRequestFilterTest {
         void 쿼리스트링_설정이_비활성화된_경우_저장되지_않는다() throws ServletException, IOException {
             // Given
             loggingProperties.setIncludeQueryString(false);
-            // when(request.getQueryString()).thenReturn("param=value"); // 호출되지 않으므로 제거
-
             when(request.getMethod()).thenReturn("GET"); // 기본 로깅 메서드 호출 방어
 
             // When
@@ -149,6 +152,106 @@ class MdcRequestFilterTest {
 
             // Then
             verify(contextAccessor).put(LoggingContextKeys.CLIENT_IP, "10.0.0.1");
+        }
+    }
+
+    @Nested
+    @DisplayName("X-Request-Id 응답 회신")
+    class TraceIdHeader {
+
+        @Test
+        @DisplayName("기본값(true)이면 응답 헤더에 traceId를 회신한다")
+        void 응답_헤더에_회신() throws ServletException, IOException {
+            when(request.getHeader("X-Request-Id")).thenReturn("trace-abc");
+            when(request.getMethod()).thenReturn("GET");
+
+            mdcRequestFilter.doFilter(request, response, filterChain);
+
+            verify(response).setHeader("X-Request-Id", "trace-abc");
+        }
+
+        @Test
+        @DisplayName("returnTraceIdHeader=false이면 회신하지 않는다")
+        void 회신_비활성화() throws ServletException, IOException {
+            loggingProperties.setReturnTraceIdHeader(false);
+            when(request.getHeader("X-Request-Id")).thenReturn("trace-abc");
+            when(request.getMethod()).thenReturn("GET");
+
+            mdcRequestFilter.doFilter(request, response, filterChain);
+
+            verify(response, never()).setHeader(eq("X-Request-Id"), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("userAgent (R2)")
+    class UserAgent {
+
+        @Test
+        @DisplayName("기본 활성화 시 User-Agent를 MDC에 저장한다")
+        void userAgent_저장() throws ServletException, IOException {
+            when(request.getHeader("User-Agent")).thenReturn("Mozilla/5.0");
+            when(request.getMethod()).thenReturn("GET");
+
+            mdcRequestFilter.doFilter(request, response, filterChain);
+
+            verify(contextAccessor).put(LoggingContextKeys.USER_AGENT, "Mozilla/5.0");
+        }
+
+        @Test
+        @DisplayName("최대 길이(256)를 초과하면 truncate된다")
+        void userAgent_truncate() throws ServletException, IOException {
+            String longUa = "A".repeat(300);
+            when(request.getHeader("User-Agent")).thenReturn(longUa);
+            when(request.getMethod()).thenReturn("GET");
+
+            mdcRequestFilter.doFilter(request, response, filterChain);
+
+            verify(contextAccessor).put(eq(LoggingContextKeys.USER_AGENT),
+                argThat(v -> v.length() == 256 + "...[truncated]".length() && v.endsWith("...[truncated]")));
+        }
+
+        @Test
+        @DisplayName("includeUserAgent=false이면 저장하지 않는다")
+        void userAgent_비활성화() throws ServletException, IOException {
+            loggingProperties.setIncludeUserAgent(false);
+            when(request.getMethod()).thenReturn("GET");
+
+            mdcRequestFilter.doFilter(request, response, filterChain);
+
+            verify(contextAccessor, never()).put(eq(LoggingContextKeys.USER_AGENT), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("queryString 정제 (R3)")
+    class QueryStringSanitize {
+
+        @Test
+        @DisplayName("URL 인코딩된 쿼리는 디코딩되어 저장된다")
+        void query_디코딩() throws ServletException, IOException {
+            loggingProperties.setIncludeQueryString(true);
+            when(request.getQueryString()).thenReturn("name%3DJohn%20Doe");
+            when(request.getMethod()).thenReturn("GET");
+
+            mdcRequestFilter.doFilter(request, response, filterChain);
+
+            verify(contextAccessor).put(LoggingContextKeys.QUERY_STRING, "name=John Doe");
+        }
+
+        @Test
+        @DisplayName("PII 마스킹 sanitizer가 적용되면 쿼리의 이메일이 마스킹된다")
+        void query_마스킹() throws ServletException, IOException {
+            // 마스킹 sanitizer를 적용한 별도 필터
+            MdcRequestFilter maskingFilter =
+                new MdcRequestFilter(contextAccessor, securityProperties, new DefaultPiiMaskingSanitizer());
+            loggingProperties.setIncludeQueryString(true);
+            when(request.getQueryString()).thenReturn("email=alice@example.com");
+            when(request.getMethod()).thenReturn("GET");
+
+            maskingFilter.doFilter(request, response, filterChain);
+
+            verify(contextAccessor).put(LoggingContextKeys.QUERY_STRING, "email=a***@example.com");
         }
     }
 }

--- a/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/logging/WebMdcContextAccessorTest.java
+++ b/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/logging/WebMdcContextAccessorTest.java
@@ -74,4 +74,53 @@ class WebMdcContextAccessorTest {
             assertThat(value).isNull();
         }
     }
+
+    @Nested
+    @org.junit.jupiter.api.DisplayName("clear() 키 누수 방지 (R1)")
+    class 키_누수_방지 {
+
+        @Test
+        @org.junit.jupiter.api.DisplayName("clear()는 어댑터가 put한 키만 제거하고 외부 키는 보존한다")
+        void clear는_어댑터가_put한_키만_제거한다() {
+            // Given: 어댑터로 넣은 키 + 외부에서 직접 넣은 키(도메인 컨텍스트 등)
+            contextAccessor.put("libKey", "libValue");
+            MDC.put("externalKey", "externalValue");
+
+            // When
+            contextAccessor.clear();
+
+            // Then: 라이브러리 키만 제거, 외부 키는 보존
+            assertThat(MDC.get("libKey")).isNull();
+            assertThat(MDC.get("externalKey")).isEqualTo("externalValue");
+        }
+
+        @Test
+        @org.junit.jupiter.api.DisplayName("remove한 키는 이후 clear 대상에서 빠진다")
+        void remove된_키는_추적에서_제거된다() {
+            contextAccessor.put("k1", "v1");
+            contextAccessor.put("k2", "v2");
+            contextAccessor.remove("k1");
+            MDC.put("k1", "외부재설정"); // remove 후 외부가 같은 키를 재사용한 상황
+
+            contextAccessor.clear();
+
+            // clear는 추적 중인 k2만 제거, remove된 k1(외부 재설정분)은 보존
+            assertThat(MDC.get("k2")).isNull();
+            assertThat(MDC.get("k1")).isEqualTo("외부재설정");
+        }
+
+        @Test
+        @org.junit.jupiter.api.DisplayName("clear 후 같은 스레드를 재사용해도 키가 누수되지 않는다")
+        void clear_후_스레드_재사용시_누수없음() {
+            // 1차 사용
+            contextAccessor.put("first", "1");
+            contextAccessor.clear();
+            // 같은 스레드 재사용 (스레드풀 시나리오)
+            contextAccessor.put("second", "2");
+            contextAccessor.clear();
+
+            assertThat(MDC.get("first")).isNull();
+            assertThat(MDC.get("second")).isNull();
+        }
+    }
 }


### PR DESCRIPTION
Closes #39

## 배경
사내 로깅 표준을 `keycloak-spring-security-web-starter` 단일 위임으로 통합하기 위한 MDC 보강 (요구사항 R1~R3 + 마스킹 + X-Request-Id).

## 변경
| 항목 | 내용 |
|------|------|
| **R1 (P0)** | `WebMdcContextAccessor.clear()`가 `MDC.clear()`로 외부 키까지 비우던 누수 → `ThreadLocal`로 라이브러리 소유 키만 추적/제거 |
| **마스킹 SPI** | `LoggingValueSanitizer` + `DefaultPiiMaskingSanitizer` 기본 on (이메일/폰/주민/카드/Bearer), `NoOpLoggingValueSanitizer`로 opt-out |
| **R2** | `userAgent` MDC (마스킹 + 256자) |
| **R3** | `queryString` 정제 (URL 디코딩 + 512자 + 마스킹) |
| **X-Request-Id** | traceId 응답 헤더 회신 (`returnTraceIdHeader` 토글) |

## 신규 프로퍼티
`keycloak.security.logging.{include-user-agent, return-trace-id-header, max-query-length, max-user-agent-length}`

## 테스트
- `DefaultPiiMaskingSanitizerTest` — 마스킹 패턴 + 경계
- `WebMdcContextAccessorTest` — clear() 키 누수 방지(외부 키 보존/owned만 제거/스레드 재사용)
- `MdcRequestFilterTest` — userAgent 저장·truncate, query 디코딩·마스킹, X-Request-Id 회신·토글
- 기존 단위 테스트 회귀 0

## Breaking change
- `1.5.0` → `1.6.0`. PII 마스킹 기본 on은 현행 무마스킹 대비 동작 변화.
- Migration: `docs/13-MDC-로깅-사내표준-위임.md` (NoOp 등록으로 opt-out)

## 후속 (v1.7.0)
R4 응답 메트릭(status/durationMs), R6 excludePatterns(/actuator)