### PR TITLE
[#41] feat: MDC 로깅 v1.7.0 — 응답 메트릭(R4) + 제외 경로(R6) + 호환성 정책(R7)

### DIFF
--- a/docs/14-MDC-로깅-응답메트릭-제외경로.md
+++ b/docs/14-MDC-로깅-응답메트릭-제외경로.md
@@ -1,0 +1,80 @@
+# 14. MDC 로깅 — 응답 메트릭 · 제외 경로 · 호환성 정책 (v1.7.0)
+
+> v1.6.0([13](13-MDC-로깅-사내표준-위임.md))에 이어 MDC 로깅 사내표준 위임을 마무리합니다.
+> 요구사항 R4(응답 메트릭) · R6(제외 경로) · R7(호환성 정책).
+
+## 1. 변경 요약
+
+| 항목 | 내용 |
+|------|------|
+| **R4** | 요청 종료 시 `status`/`durationMs` MDC + `"request completed"` 종료 로그 (토글, **기본 off**) |
+| **R6** | `exclude-patterns`(기본 `/actuator/**`)로 MDC 필터 제외 — `shouldNotFilter` + AntPathMatcher |
+| **R7** | MDC 키 호환성 정책 문서화 |
+
+## 2. R4 — 응답 메트릭 (status / durationMs)
+
+`MdcRequestFilter`가 요청 종료 시점(finally)에 응답 상태와 처리 시간을 MDC에 넣고 종료 로그를 남깁니다.
+
+```yaml
+keycloak:
+  security:
+    logging:
+      include-response-metrics: false   # 기본 off
+```
+
+- 켜면 JSON 비즈니스 로그 한 줄(`"request completed"`)에 `status`/`durationMs`가 MDC 전체(traceId·userId 등)와 함께 묶여, Loki에서 조인 없이 요청 단위 추적이 됩니다.
+- **기본 off인 이유**: 모든 요청에 종료 로그 1줄이 추가되고 Tomcat AccessLog와 정보가 중복됩니다. AccessLog를 쓰지 않거나 로그를 일원화하려는 환경에서만 켜세요.
+
+| 키 | 값 | 세팅 시점 |
+|----|----|----------|
+| `status` | HTTP 응답 상태 코드 | 요청 종료 |
+| `durationMs` | 처리 소요 시간(ms) | 요청 종료 |
+
+## 3. R6 — 제외 경로 (shouldNotFilter)
+
+```yaml
+keycloak:
+  security:
+    logging:
+      exclude-patterns:
+        - /actuator/**     # 기본값
+```
+
+- `MdcRequestFilter.shouldNotFilter()`가 `AntPathMatcher`로 매칭하여 해당 경로는 MDC 필터를 통과하지 않습니다.
+- actuator 헬스/메트릭 스크랩(Prometheus 폴링)의 요청 로그 노이즈를 제거합니다.
+- 빈 리스트로 두면 모든 경로에 필터를 적용합니다.
+
+## 4. R7 — MDC 키 호환성 정책
+
+라이브러리가 노출하는 MDC 키(`LoggingContextKeys`)는 사내 표준 로그 스키마의 일부이므로 다음 버저닝 규칙을 따릅니다.
+
+| 변경 | 허용 버전 | 비고 |
+|------|----------|------|
+| 새 키 **추가** | minor | 기존 로그 파이프라인 호환 |
+| 키명 **변경/삭제** | major | Loki 쿼리·대시보드 영향 → breaking |
+| 키 값 포맷 변경 | minor + 문서 명시 | 예: durationMs 단위 변경 |
+
+- 키를 추가/변경할 때는 사내 로깅 표준 프로세스 문서의 MDC 키 표를 **동시에 갱신**합니다.
+- 현재 키 목록: `traceId`, `httpMethod`, `requestUri`, `queryString`, `clientIp`, `userAgent`, `status`, `durationMs`, `userId`, `username`, `sessionId`
+
+## 5. 신규 프로퍼티
+
+```yaml
+keycloak:
+  security:
+    logging:
+      include-response-metrics: false   # status/durationMs + 종료 로그 (기본 off)
+      exclude-patterns:                  # MDC 필터 제외 경로 (기본 [/actuator/**])
+        - /actuator/**
+```
+
+## 6. 검증 (테스트)
+
+| 테스트 | 검증 |
+|--------|------|
+| `MdcRequestFilterTest` (응답 메트릭 R4) | 토글 on 시 status/durationMs 저장, off 시 미저장 |
+| `MdcRequestFilterTest` (제외 경로 R6) | `/actuator/**` 제외, 일반 경로 적용, 커스텀 패턴 |
+
+## 7. MDC 로깅 표준 위임 — 완료
+
+R1~R7 + X-Request-Id가 v1.6.0~v1.7.0으로 모두 반영되어, `keycloak-spring-security-web-starter`가 사내 로깅 표준의 MDC 단일 소유자로 동작합니다. 자체 `MdcLoggingFilter` 구현은 더 이상 필요하지 않습니다.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version Management
-projectVersion=1.6.0
+projectVersion=1.7.0
 
 # Maven Publishing Info
 mavenGroupId=io.github.l-dxd

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakLoggingProperties.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakLoggingProperties.java
@@ -3,6 +3,9 @@ package com.ids.keycloak.security.config;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Keycloak Security 로깅 관련 설정을 담는 Properties 클래스입니다.
  * <p>
@@ -39,6 +42,22 @@ public class KeycloakLoggingProperties {
 
     /** 응답 헤더 X-Request-Id 로 traceId 회신 여부 (기본값: true) */
     private boolean returnTraceIdHeader = true;
+
+    /**
+     * 응답 메트릭(status, durationMs) 포함 + "request completed" 종료 로그 발행 여부 (기본값: false).
+     * <p>
+     * Tomcat AccessLog와 정보가 중복되므로 기본 off. AccessLog 미사용/일원화 환경에서만 켭니다.
+     * </p>
+     */
+    private boolean includeResponseMetrics = false;
+
+    /**
+     * MDC 필터를 적용하지 않을 경로 패턴 (Ant 패턴, 기본값: {@code ["/actuator/**"]}).
+     * <p>
+     * actuator 헬스/메트릭 스크랩(Prometheus 폴링)의 요청 로그 노이즈를 제거합니다.
+     * </p>
+     */
+    private List<String> excludePatterns = new ArrayList<>(List.of("/actuator/**"));
 
     /** 사용자 ID 포함 여부 (기본값: true) */
     private boolean includeUserId = true;

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/logging/LoggingContextKeys.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/logging/LoggingContextKeys.java
@@ -27,6 +27,14 @@ public final class LoggingContextKeys {
     /** User-Agent 헤더 (마스킹 + 길이 제한 적용) */
     public static final String USER_AGENT = "userAgent";
 
+    // ===== 응답 메트릭 (요청 종료 시 설정) =====
+
+    /** HTTP 응답 상태 코드 */
+    public static final String STATUS = "status";
+
+    /** 요청 처리 소요 시간 (밀리초) */
+    public static final String DURATION_MS = "durationMs";
+
     // ===== 인증 정보 (인증 후 설정) =====
 
     /** 인증된 사용자 ID (Keycloak sub claim) */

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/filter/MdcRequestFilter.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/filter/MdcRequestFilter.java
@@ -9,11 +9,14 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -36,11 +39,13 @@ import java.util.UUID;
  * @author LeeBongSeung
  * @see MdcAuthenticationFilter
  */
+@Slf4j
 public class MdcRequestFilter extends OncePerRequestFilter {
 
     private static final String X_REQUEST_ID_HEADER = "X-Request-Id";
     private static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
     private static final String USER_AGENT_HEADER = "User-Agent";
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 
     private final LoggingContextAccessor contextAccessor;
     private final KeycloakSecurityProperties securityProperties;
@@ -54,14 +59,45 @@ public class MdcRequestFilter extends OncePerRequestFilter {
         this.sanitizer = sanitizer;
     }
 
+    /**
+     * 로깅 제외 경로({@code keycloak.security.logging.exclude-patterns}, 기본 {@code /actuator/**})는
+     * MDC 필터를 적용하지 않습니다. 헬스/메트릭 스크랩의 요청 로그 노이즈를 제거합니다.
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        List<String> excludePatterns = securityProperties.getLogging().getExcludePatterns();
+        if (excludePatterns == null || excludePatterns.isEmpty()) {
+            return false;
+        }
+        String uri = request.getRequestURI();
+        if (uri == null) {
+            return false;
+        }
+        for (String pattern : excludePatterns) {
+            if (PATH_MATCHER.match(pattern, uri)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain chain) throws ServletException, IOException {
+        long startTime = System.currentTimeMillis();
+        KeycloakLoggingProperties loggingProps = securityProperties.getLogging();
         try {
             populateRequestContext(request, response);
             chain.doFilter(request, response);
         } finally {
+            // 응답 메트릭 (status, durationMs) + 종료 로그 — 기본 off (Tomcat AccessLog와 중복)
+            if (loggingProps.isIncludeResponseMetrics()) {
+                contextAccessor.put(LoggingContextKeys.STATUS, String.valueOf(response.getStatus()));
+                contextAccessor.put(LoggingContextKeys.DURATION_MS,
+                        String.valueOf(System.currentTimeMillis() - startTime));
+                log.info("request completed");
+            }
             contextAccessor.clear();
         }
     }

--- a/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/filter/MdcRequestFilterTest.java
+++ b/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/filter/MdcRequestFilterTest.java
@@ -22,6 +22,7 @@ import org.mockito.quality.Strictness;
 
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -252,6 +253,65 @@ class MdcRequestFilterTest {
             maskingFilter.doFilter(request, response, filterChain);
 
             verify(contextAccessor).put(LoggingContextKeys.QUERY_STRING, "email=a***@example.com");
+        }
+    }
+
+    @Nested
+    @DisplayName("응답 메트릭 (R4)")
+    class ResponseMetrics {
+
+        @Test
+        @DisplayName("includeResponseMetrics=true이면 status/durationMs를 저장한다")
+        void 메트릭_저장() throws ServletException, IOException {
+            loggingProperties.setIncludeResponseMetrics(true);
+            when(request.getMethod()).thenReturn("GET");
+            when(response.getStatus()).thenReturn(200);
+
+            mdcRequestFilter.doFilter(request, response, filterChain);
+
+            verify(contextAccessor).put(LoggingContextKeys.STATUS, "200");
+            verify(contextAccessor).put(eq(LoggingContextKeys.DURATION_MS), anyString());
+        }
+
+        @Test
+        @DisplayName("기본값(false)이면 메트릭을 저장하지 않는다")
+        void 기본_미저장() throws ServletException, IOException {
+            when(request.getMethod()).thenReturn("GET");
+
+            mdcRequestFilter.doFilter(request, response, filterChain);
+
+            verify(contextAccessor, never()).put(eq(LoggingContextKeys.STATUS), anyString());
+            verify(contextAccessor, never()).put(eq(LoggingContextKeys.DURATION_MS), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("제외 경로 shouldNotFilter (R6)")
+    class ExcludePatterns {
+
+        @Test
+        @DisplayName("기본 제외 경로(/actuator/**)는 필터를 적용하지 않는다")
+        void actuator_제외() {
+            when(request.getRequestURI()).thenReturn("/actuator/health");
+
+            assertThat(mdcRequestFilter.shouldNotFilter(request)).isTrue();
+        }
+
+        @Test
+        @DisplayName("일반 경로는 필터를 적용한다")
+        void 일반경로_적용() {
+            when(request.getRequestURI()).thenReturn("/api/users");
+
+            assertThat(mdcRequestFilter.shouldNotFilter(request)).isFalse();
+        }
+
+        @Test
+        @DisplayName("excludePatterns를 커스텀하면 해당 경로가 제외된다")
+        void 커스텀_제외() {
+            loggingProperties.setExcludePatterns(java.util.List.of("/internal/**"));
+            when(request.getRequestURI()).thenReturn("/internal/ping");
+
+            assertThat(mdcRequestFilter.shouldNotFilter(request)).isTrue();
         }
     }
 }


### PR DESCRIPTION
Closes #41

MDC 로깅 사내표준 위임 마무리 (v1.6.0 후속).

## 변경
| 항목 | 내용 |
|------|------|
| **R4** | 요청 종료 시 `status`/`durationMs` MDC + `"request completed"` 종료 로그. `include-response-metrics` 토글 (**기본 off** — AccessLog 중복) |
| **R6** | `exclude-patterns`(기본 `/actuator/**`)로 MDC 필터 제외 — `shouldNotFilter` + AntPathMatcher |
| **R7** | MDC 키 호환성 정책 문서화 (`docs/14`) |

## 신규 프로퍼티
`keycloak.security.logging.{include-response-metrics, exclude-patterns}`

## 테스트
- 응답 메트릭 토글 on/off
- 제외 경로 매칭 (기본 `/actuator/**` / 일반 경로 / 커스텀)
- 기존 단위 테스트 회귀 0

## 버전
`1.6.0` → `1.7.0`. R1~R7 + X-Request-Id 전부 반영되어 MDC 로깅 표준 위임 완료.