### PR TITLE
docs: 라이브러리 통합 사용 가이드 추가 (docs/GUIDE.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Architecture & Development Guidelines
 
+> 📖 **라이브러리를 도입하는 개발자라면 → [사용 가이드 (docs/GUIDE.md)](docs/GUIDE.md)** 를 보세요.
+> (빠른 시작 · 전체 설정 레퍼런스 · 기능별 가이드 · 마이그레이션 · 트러블슈팅)
+>
+> 아래 문서는 **라이브러리 기여자용** 아키텍처/개발 규칙입니다.
+
 이 문서는 **Keycloak Spring Security Open Source Library**의 아키텍처 원칙, 프로젝트 구조, 배포 전략, 그리고 설정 가이드를 정의합니다.
 본 프로젝트는 **Spring Security 공식 GitHub 리포지토리의 구조**를 따르며, **Servlet(Blocking)** 과 **Reactive(Non-blocking)** 스택을 모두 지원하는 것을 목표로 합니다.
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,0 +1,305 @@
+# keycloak-spring-security 사용 가이드
+
+Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 하나와 최소 설정으로 OIDC 로그인·세션·로그아웃·인가가 자동 구성됩니다.
+
+- **지원**: JDK 17+, Spring Boot 3.5.x, Spring Security 6.5.x
+- **현재 버전**: `1.7.0`
+- 이 문서는 **도입 개발자용 사용 가이드**입니다. 아키텍처/기여 규칙은 [README](../README.md) 참고.
+
+---
+
+## 목차
+1. [빠른 시작](#1-빠른-시작)
+2. [동작 방식](#2-동작-방식)
+3. [설정 레퍼런스](#3-설정-레퍼런스)
+4. [기능별 가이드](#4-기능별-가이드)
+5. [확장점](#5-확장점)
+6. [버전 노트 / 마이그레이션](#6-버전-노트--마이그레이션)
+7. [트러블슈팅](#7-트러블슈팅)
+
+---
+
+## 1. 빠른 시작
+
+### 1.1 의존성 (Servlet / Spring MVC)
+
+```gradle
+implementation("io.github.l-dxd:keycloak-spring-security-web-starter:1.7.0")
+```
+> Redis 세션을 쓸 경우에만 추가:
+> ```gradle
+> implementation("org.springframework.boot:spring-boot-starter-data-redis")
+> implementation("org.springframework.session:spring-session-data-redis")
+> ```
+
+### 1.2 필수 설정
+
+Keycloak 연결 정보와 OIDC 클라이언트 등록은 **필수**입니다.
+
+```yaml
+keycloak:
+  realm-name: my-realm
+  base-url: https://keycloak.example.com
+  relative-path: ""                 # Keycloak 컨텍스트 경로 (보통 "" 또는 "/auth")
+  response:
+    type: code
+  logout:
+    redirect:
+      uri: https://app.example.com/
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          keycloak:
+            client-id: my-client
+            client-secret: ${KEYCLOAK_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/keycloak"
+```
+
+### 1.3 끝
+
+별도 `SecurityConfig` 없이 기동하면 기본 `SecurityFilterChain`이 자동 등록됩니다.
+- 모든 요청은 인증 필요 (`permit-all-paths` 제외)
+- 미인증 시 Keycloak 로그인으로 리다이렉트 (OIDC Authorization Code)
+- 로그인 성공 시 세션 생성, 이후 쿠키 기반 인증
+
+```yaml
+keycloak:
+  security:
+    authentication:
+      permit-all-paths:
+        - /public/**
+        - /health
+```
+
+---
+
+## 2. 동작 방식
+
+### 인증 모델
+기본은 **OIDC Authorization Code + 서버 세션(쿠키)** 입니다. 매 요청마다 `KeycloakAuthenticationFilter`가 세션의 인증을 확인합니다. 추가로 옵션에 따라 **Bearer Token**(API), **Basic Auth**(머신 클라이언트)를 병렬 지원합니다.
+
+### 필터 체인 (요약)
+```
+MdcRequestFilter (traceId 등 MDC)
+  → RateLimitFilter (옵션)
+  → BasicAuthenticationFilter (옵션)
+  → KeycloakAuthenticationFilter (세션 인증)
+  → MdcAuthenticationFilter (userId 등 MDC)
+  → AuthorizationFilter (인가)
+```
+
+### SecurityFilterChain 공존 (v1.5.0+)
+라이브러리 체인은 `securityMatcher`(기본 `/**`) + `@Order(LOWEST_PRECEDENCE)`로 등록되어, **사용자가 자체 `SecurityFilterChain`(예: `/actuator` 전용)을 추가해도 공존**합니다. ([4.8](#48-securityfilterchain-공존) 참고)
+
+---
+
+## 3. 설정 레퍼런스
+
+모든 설정은 `keycloak.security.*` 네임스페이스입니다.
+
+### 3.1 인증 (`authentication`)
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `authentication.permit-all-paths` | `[]` | 인증 없이 허용할 경로 (Ant) |
+| `authentication.default-success-url` | `/` | 로그인 성공 후 리다이렉트 |
+| `authentication.login-paths` | `[/api/keycloak/login]` | body 기반 로그인으로 분류할 경로 |
+
+### 3.2 인가 (`authorization`)
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `authorization.enabled` | `false` | Keycloak Authorization Services로 모든 요청 인가 검증 |
+
+### 3.3 세션 (`session`)
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `session.store-type` | `MEMORY` | `MEMORY` 또는 `REDIS` |
+| `session.timeout` | `30m` | 세션 만료 시간 |
+
+### 3.4 쿠키 (`cookie`)
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `cookie.http-only` | `true` | |
+| `cookie.secure` | `false` | HTTPS 환경은 `true` 권장 |
+| `cookie.domain` | (없음) | |
+| `cookie.path` | `/` | |
+| `cookie.same-site` | (없음) | `Lax`/`Strict`/`None` |
+
+### 3.5 에러 처리 (`error`)
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `error.redirect-enabled` | `false` | 인증 실패 시 리다이렉트 사용 |
+| `error.ajax-returns-json` | `false` | AJAX 요청은 JSON 응답 |
+| `error.authentication-failed-redirect-url` | `/login` | |
+| `error.session-expired-redirect-url` | (auth 실패 URL 따름) | |
+| `error.access-denied-redirect-url` | `/error/403` | |
+
+### 3.6 Basic Auth (`basic-auth`)
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `basic-auth.enabled` | `false` | Direct Access Grants 기반 Basic 인증 |
+
+### 3.7 Bearer Token (`bearer-token`)
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `bearer-token.enabled` | `false` | Resource Server(Introspect) + 토큰 발급 API |
+| `bearer-token.token-endpoint.prefix` | `/auth` | 토큰 발급 엔드포인트 prefix (`/auth/token` 등) |
+
+### 3.8 CSRF (`csrf`)
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `csrf.enabled` | `true` | |
+| `csrf.ignore-paths` | `[]` | 추가 면제 경로 |
+
+### 3.9 Rate Limiting (`rate-limit`)
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `rate-limit.enabled` | `false` | |
+| `rate-limit.max-requests` | `5` | 윈도우 내 최대 요청 |
+| `rate-limit.window-seconds` | `60` | 윈도우(초) |
+| `rate-limit.block-duration-seconds` | `300` | 차단 지속(초) |
+| `rate-limit.key-strategy` | `IP_AND_USERNAME` | `IP`/`USERNAME`/`IP_AND_USERNAME` |
+| `rate-limit.include-basic-auth` | `true` | Basic Auth에도 적용 |
+
+### 3.10 로깅/MDC (`logging`) — v1.6.0/1.7.0
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `logging.include-trace-id` | `true` | traceId MDC |
+| `logging.include-http-method` | `true` | |
+| `logging.include-request-uri` | `true` | |
+| `logging.include-query-string` | `false` | 쿼리스트링(디코딩+길이제한+마스킹) |
+| `logging.include-client-ip` | `true` | |
+| `logging.include-user-agent` | `true` | userAgent(마스킹+256) |
+| `logging.include-user-id` / `-username` / `-session-id` | `true` | 인증 후 사용자 정보 |
+| `logging.max-query-length` | `512` | |
+| `logging.max-user-agent-length` | `256` | |
+| `logging.return-trace-id-header` | `true` | 응답 `X-Request-Id` 회신 |
+| `logging.include-response-metrics` | `false` | status/durationMs + 종료 로그 |
+| `logging.exclude-patterns` | `[/actuator/**]` | MDC 필터 제외 경로 |
+
+### 3.11 SecurityFilterChain (`matcher`, `auto-filter-chain`) — v1.5.0
+| 키 | 기본값 | 설명 |
+|----|--------|------|
+| `auto-filter-chain` | `true` | Keycloak 기본 체인 자동 등록 (false=직접 구성) |
+| `matcher.include` | `[/**]` | Keycloak 체인 담당 경로 |
+| `matcher.exclude` | `[]` | 제외 경로(다른 체인이 담당) |
+
+---
+
+## 4. 기능별 가이드
+
+### 4.1 OIDC 로그인 (기본)
+설정만으로 동작. 미인증 요청은 Keycloak으로 리다이렉트, 로그인 후 세션 쿠키 발급. 로그아웃은 `POST /logout`(Front-Channel) + Back-Channel(`/logout/connect/back-channel/keycloak`) 자동.
+
+### 4.2 세션 저장소 (Memory / Redis)
+```yaml
+keycloak:
+  security:
+    session:
+      store-type: redis      # 기본 memory. redis 시 위 의존성 추가 필요
+      timeout: 30m
+```
+`memory`는 단일 인스턴스 전제. 다중 인스턴스(HA)는 `redis` 권장.
+
+### 4.3 Bearer Token (API)
+```yaml
+keycloak:
+  security:
+    bearer-token:
+      enabled: true
+      token-endpoint:
+        prefix: /auth
+```
+- Introspect(RFC 7662) 기반 온라인 검증
+- 토큰 발급/갱신/로그아웃: `POST {prefix}/token`, `/refresh`, `/logout` (미인증 허용)
+
+### 4.4 Basic Auth (머신 클라이언트)
+```yaml
+keycloak:
+  security:
+    basic-auth:
+      enabled: true
+```
+`Authorization: Basic` 요청은 Keycloak Direct Access Grants로 인증되고 CSRF 자동 면제.
+
+### 4.5 인가 (Authorization Services)
+```yaml
+keycloak:
+  security:
+    authorization:
+      enabled: true
+```
+켜면 모든 요청을 Keycloak Authorization Services로 인가 검증. OIDC/Bearer/Basic 모든 인증 타입 지원(v1.4.0+). 메서드 보안은 `@EnableMethodSecurity`가 기본 활성이라 `@PreAuthorize` 등 사용 가능.
+
+### 4.6 CSRF
+기본 활성. 로그아웃·Bearer 토큰 엔드포인트·Basic Auth 요청은 자동 면제. 추가 면제는 `csrf.ignore-paths`.
+
+### 4.7 MDC 로깅 + PII 마스킹 (v1.6.0/1.7.0)
+모든 요청에 `traceId` 등이 MDC로 자동 주입되고 응답 `X-Request-Id`로 회신됩니다. query/userAgent는 **PII 마스킹**(이메일/폰/주민/카드/Bearer)이 기본 적용됩니다. 마스킹 교체/해제는 [5. 확장점](#5-확장점) 참고. 자세한 내용은 [13](13-MDC-로깅-사내표준-위임.md)/[14](14-MDC-로깅-응답메트릭-제외경로.md).
+
+### 4.8 SecurityFilterChain 공존
+`/actuator` 등 별도 체인을 추가해도 Keycloak 체인이 함께 동작합니다. 경로를 나누려면:
+```yaml
+keycloak:
+  security:
+    matcher:
+      exclude: [/actuator/**]    # 이 경로는 사용자 체인이 담당
+```
+```java
+@Bean
+@Order(0)                         // Keycloak(LOWEST_PRECEDENCE)보다 앞
+SecurityFilterChain actuatorChain(HttpSecurity http) throws Exception {
+    http.securityMatcher("/actuator/**").authorizeHttpRequests(a -> a.anyRequest().permitAll());
+    return http.build();
+}
+```
+Keycloak 기본 체인을 끄고 직접 구성하려면 `auto-filter-chain: false`. 자세히는 [12](12-SecurityFilterChain-FailOpen-수정.md).
+
+---
+
+## 5. 확장점
+
+라이브러리의 모든 빈은 `@ConditionalOnMissingBean`이라 **같은 타입 빈을 등록하면 교체**됩니다.
+
+| 확장 | 방법 |
+|------|------|
+| 보안 설정 일부만 추가 | 자체 `SecurityFilterChain`에서 `http.with(KeycloakHttpConfigurer.keycloak(), Customizer.withDefaults())` |
+| PII 마스킹 교체/해제 | `LoggingValueSanitizer` 빈 등록 (`NoOpLoggingValueSanitizer`로 해제) |
+| Rate Limiter 구현 교체 | `RateLimiter` 빈 등록 (예: 분산 Redis 기반) |
+| 로깅 컨텍스트 접근자 | `LoggingContextAccessor` 빈 등록 |
+
+```java
+// 예: PII 마스킹 끄기
+@Bean
+LoggingValueSanitizer loggingValueSanitizer() {
+    return new NoOpLoggingValueSanitizer();
+}
+```
+
+---
+
+## 6. 버전 노트 / 마이그레이션
+
+| 버전 | 변경 | 주의 |
+|------|------|------|
+| **1.7.0** | 응답 메트릭(status/durationMs, 기본 off) + exclude-patterns(/actuator) | — |
+| **1.6.0** | MDC PII 마스킹 **기본 on** + userAgent/query 정제 + X-Request-Id 회신 | 로그 PII가 마스킹됨. 해제는 `NoOpLoggingValueSanitizer` |
+| **1.5.0** | SecurityFilterChain Fail-Open 수정 (Bean 이름 조건 + securityMatcher) | actuator 등 자체 체인 쓰던 앱은 Keycloak 체인이 함께 켜짐 → `matcher.exclude` 또는 `auto-filter-chain: false` |
+| **1.4.x** | Bearer/Basic 인가 지원, stateless 세션 분리 | — |
+
+상세: `docs/12`, `docs/13`, `docs/14`
+
+---
+
+## 7. 트러블슈팅
+
+| 증상 | 원인 / 조치 |
+|------|-------------|
+| 로그인 무한 리다이렉트 | `redirect-uri`/Keycloak 클라이언트 Valid Redirect URIs 불일치 확인 |
+| actuator가 갑자기 401/403 (1.5.0 업그레이드 후) | Keycloak 체인이 함께 켜진 것 → `matcher.exclude: [/actuator/**]` |
+| 로그에 이메일/전화가 `***`로 (1.6.0 후) | PII 마스킹 기본 on (정상). 해제는 `NoOpLoggingValueSanitizer` |
+| Redis 세션인데 `NoClassDefFoundError` | `spring-boot-starter-data-redis` + `spring-session-data-redis` 의존성 누락 |
+| 다중 인스턴스에서 로그아웃이 일부만 전파 | `session.store-type: redis`로 전환 |
+| 토큰 발급 API 404 | `bearer-token.enabled: true` 확인, prefix(`/auth`) 경로 확인 |


### PR DESCRIPTION
도입 개발자용 통합 사용 가이드 신규 작성.

## 내용
- **빠른 시작**: 의존성 + 필수 설정(keycloak 연결/OIDC 클라이언트) + Redis 옵션
- **설정 레퍼런스**: `keycloak.security.*` 전체 프로퍼티 11개 섹션 표(기본값 포함)
- **기능별 가이드**: OIDC·세션(Memory/Redis)·Bearer·Basic·인가·CSRF·MDC 로깅+마스킹·SecurityFilterChain 공존
- **확장점**: @ConditionalOnMissingBean 교체 포인트
- **버전 노트(1.4~1.7) / 트러블슈팅**
- README 상단에 가이드 링크 추가 (기여자용 문서와 역할 분리)

문서 전용 변경(코드/버전 변경 없음).