### PR TITLE
[#44] feat: Reactive(WebFlux) 스택 전체 구현 (servlet 기능 동등, v1.8.0)

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3,7 +3,8 @@
 Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 하나와 최소 설정으로 OIDC 로그인·세션·로그아웃·인가가 자동 구성됩니다.
 
 - **지원**: JDK 17+, Spring Boot 3.5.x, Spring Security 6.5.x
-- **현재 버전**: `1.7.0`
+- **현재 버전**: `1.8.0`
+- **스택**: Servlet(Spring MVC) / **Reactive(WebFlux) — v1.8.0부터 servlet과 기능 동등** ([8. Reactive](#8-reactivewebflux))
 - 이 문서는 **도입 개발자용 사용 가이드**입니다. 아키텍처/기여 규칙은 [README](../README.md) 참고.
 
 ---
@@ -16,15 +17,20 @@ Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 
 5. [확장점](#5-확장점)
 6. [버전 노트 / 마이그레이션](#6-버전-노트--마이그레이션)
 7. [트러블슈팅](#7-트러블슈팅)
+8. [Reactive(WebFlux)](#8-reactivewebflux)
 
 ---
 
 ## 1. 빠른 시작
 
-### 1.1 의존성 (Servlet / Spring MVC)
+### 1.1 의존성
 
 ```gradle
-implementation("io.github.l-dxd:keycloak-spring-security-web-starter:1.7.0")
+// Servlet (Spring MVC)
+implementation("io.github.l-dxd:keycloak-spring-security-web-starter:1.8.0")
+
+// 또는 Reactive (WebFlux)
+implementation("io.github.l-dxd:keycloak-spring-security-webflux-starter:1.8.0")
 ```
 > Redis 세션을 쓸 경우에만 추가:
 > ```gradle
@@ -284,6 +290,7 @@ LoggingValueSanitizer loggingValueSanitizer() {
 
 | 버전 | 변경 | 주의 |
 |------|------|------|
+| **1.8.0** | **Reactive(WebFlux) 스택 추가** — servlet과 기능 동등 (OIDC 로그인·세션·인가·Bearer·Basic·RateLimit·CSRF·로그아웃·MDC 로깅) | `keycloak-spring-security-webflux-starter` 신규. servlet 사용자는 영향 없음 |
 | **1.7.0** | 응답 메트릭(status/durationMs, 기본 off) + exclude-patterns(/actuator) | — |
 | **1.6.0** | MDC PII 마스킹 **기본 on** + userAgent/query 정제 + X-Request-Id 회신 | 로그 PII가 마스킹됨. 해제는 `NoOpLoggingValueSanitizer` |
 | **1.5.0** | SecurityFilterChain Fail-Open 수정 (Bean 이름 조건 + securityMatcher) | actuator 등 자체 체인 쓰던 앱은 Keycloak 체인이 함께 켜짐 → `matcher.exclude` 또는 `auto-filter-chain: false` |
@@ -303,3 +310,28 @@ LoggingValueSanitizer loggingValueSanitizer() {
 | Redis 세션인데 `NoClassDefFoundError` | `spring-boot-starter-data-redis` + `spring-session-data-redis` 의존성 누락 |
 | 다중 인스턴스에서 로그아웃이 일부만 전파 | `session.store-type: redis`로 전환 |
 | 토큰 발급 API 404 | `bearer-token.enabled: true` 확인, prefix(`/auth`) 경로 확인 |
+
+---
+
+## 8. Reactive(WebFlux)
+
+v1.8.0부터 **WebFlux 스택을 servlet과 동등하게 지원**합니다. 의존성만 `webflux-starter`로 바꾸면 됩니다.
+
+```gradle
+implementation("io.github.l-dxd:keycloak-spring-security-webflux-starter:1.8.0")
+```
+
+- **설정은 servlet과 100% 공유**합니다 — `keycloak.*`, `keycloak.security.*` 프로퍼티(§1.2, §3)가 그대로 적용됩니다. (core 모듈의 Properties를 양쪽이 공유)
+- **기능 동등**: OIDC 로그인(`oauth2Login` + 쿠키/세션) · Bearer · Basic · 인가(Authorization Services) · Rate Limiting · CSRF · Front/Back-Channel 로그아웃 · MDC 로깅 · SecurityFilterChain 공존(Fail-Open 방지).
+
+### servlet과의 차이 (아키텍처 특성상)
+
+| 항목 | 차이 |
+|------|------|
+| 보안 체인 | `SecurityWebFilterChain`(reactive). 사용자 커스텀 체인 공존 시 `auto-filter-chain`/`matcher` 동일하게 동작 |
+| 세션 | reactive `WebSession`. 다중 인스턴스는 Spring Session Reactive(Redis) 권장 |
+| OAuth2 AuthorizedClient | 기본 `InMemoryReactiveOAuth2AuthorizedClientService` — **프로덕션은 Redis 기반 구현으로 교체 권장**(재시작 시 인메모리 소실) |
+| MDC 로깅 | Reactor Context ↔ MDC 자동 전파는 **기본 비활성**. 활성화하려면 `keycloak.security.logging.mdc-propagation-enabled=true` (전역 Reactor `Hooks` 사용) |
+
+### 확장점
+servlet과 동일하게 `@ConditionalOnMissingBean`으로 교체 가능: `ReactiveAuthenticationManager`, `LoggingValueSanitizer`, `RateLimiter`, `SecurityWebFilterChain`(이름 `keycloakSecurityWebFilterChain`) 등.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version Management
-projectVersion=1.7.0
+projectVersion=1.8.0
 
 # Maven Publishing Info
 mavenGroupId=io.github.l-dxd

--- a/keycloak-spring-security-webflux-starter/build.gradle
+++ b/keycloak-spring-security-webflux-starter/build.gradle
@@ -22,6 +22,22 @@ dependencies {
 
     // 사용자의 프로젝트 환경에 따라 필요한 의존성만 전이되도록 compileOnly로 설정
     compileOnly 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // Spring Session Reactive Back-Channel 로그아웃 조건부 등록용
+    // webflux 모듈과 동일하게 compileOnly: 사용자가 Spring Session을 사용할 때만 활성화
+    compileOnly 'org.springframework.session:spring-session-core'
+
+    // MDC Context Propagation 조건부 등록용 (ContextRegistry 임포트 필요)
+    // webflux 모듈에서 implementation으로 전이되므로 compileOnly로 충분
+    compileOnly 'io.micrometer:context-propagation'
+
+    // OAuth2 Client (OIDC 로그인/로그아웃 빈 등록, ReactiveClientRegistrationRepository 조건부 처리)
+    compileOnly 'org.springframework.security:spring-security-oauth2-client'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
+    testImplementation 'org.springframework:spring-test'
+    testImplementation 'org.springframework.security:spring-security-oauth2-client'
 }
 
 signing {

--- a/keycloak-spring-security-webflux-starter/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxAutoConfiguration.java
+++ b/keycloak-spring-security-webflux-starter/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxAutoConfiguration.java
@@ -1,0 +1,495 @@
+package com.ids.keycloak.security.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ids.keycloak.security.authentication.KeycloakReactiveAuthenticationManager;
+import com.ids.keycloak.security.authentication.ReactiveOidcBackChannelLogoutHandler;
+import com.ids.keycloak.security.filter.ReactiveAuthLoggingFilter;
+import com.ids.keycloak.security.filter.ReactiveBackChannelLogoutEndpointFilter;
+import com.ids.keycloak.security.filter.ReactiveLoggingFilter;
+import com.ids.keycloak.security.logging.DefaultPiiMaskingSanitizer;
+import com.ids.keycloak.security.logging.LoggingValueSanitizer;
+import com.ids.keycloak.security.logging.MdcContextPropagationAccessor;
+import com.ids.keycloak.security.ratelimit.InMemoryRateLimiter;
+import com.ids.keycloak.security.ratelimit.RateLimiter;
+import com.ids.keycloak.security.session.ReactiveSessionManager;
+import com.ids.keycloak.security.web.reactive.KeycloakServerAccessDeniedHandler;
+import com.ids.keycloak.security.web.reactive.KeycloakServerAuthenticationEntryPoint;
+import com.sd.KeycloakClient.config.AbstractKeycloakConfig;
+import com.sd.KeycloakClient.config.ClientConfiguration;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import io.micrometer.context.ContextRegistry;
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.client.InMemoryReactiveOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.server.AuthenticatedPrincipalServerOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
+import org.springframework.session.ReactiveFindByIndexNameSessionRepository;
+
+/**
+ * Keycloak Spring Security의 WebFlux(Reactive) 환경 자동 설정 진입점입니다.
+ *
+ * <p>servlet 모듈의 {@code KeycloakServletAutoConfiguration}에 대응합니다.
+ * Fail-Open 방지 설계를 동일하게 적용합니다.</p>
+ *
+ * <p><b>Fail-Open 방지 설계 (CVSS 8.1, CWE-1188/863):</b>
+ * <ul>
+ *   <li>{@code @ConditionalOnMissingBean(name = "keycloakSecurityWebFilterChain")}으로 Bean 이름 기반 조건</li>
+ *   <li>{@code securityMatcher}로 이 체인이 담당할 경로를 명시적으로 선언</li>
+ *   <li>{@code @Order(LOWEST_PRECEDENCE)} — catch-all 체인은 가장 낮은 우선순위</li>
+ *   <li>{@code keycloak.security.auto-filter-chain=false}로 명시적 opt-out 가능</li>
+ * </ul>
+ * </p>
+ */
+@AutoConfiguration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+@EnableConfigurationProperties(KeycloakSecurityProperties.class)
+@EnableReactiveMethodSecurity
+@Slf4j
+public class KeycloakWebFluxAutoConfiguration {
+
+  public KeycloakWebFluxAutoConfiguration() {
+    log.info("Keycloak Spring Security: WebFlux(Reactive) 환경 자동 설정이 활성화되었습니다.");
+  }
+
+  // ==========================================================================
+  // 기반 시설 (Infrastructure)
+  // ==========================================================================
+
+  @Configuration(proxyBeanMethods = false)
+  @Slf4j
+  protected static class KeycloakInfrastructureConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(ObjectMapper.class)
+    public ObjectMapper keycloakObjectMapper() {
+      log.debug("지원 Bean을 등록합니다: [ObjectMapper]");
+      return new ObjectMapper();
+    }
+
+    /**
+     * KeycloakClient 설정 및 빈 등록.
+     */
+    @Configuration(proxyBeanMethods = false)
+    @Getter
+    @Slf4j
+    protected static class KeycloakConfig extends AbstractKeycloakConfig {
+
+      @Value("${keycloak.realm-name}")
+      public String realmName;
+
+      @Value("${keycloak.base-url}")
+      public String baseUrl;
+
+      @Value("${keycloak.relative-path}")
+      public String relativePath;
+
+      @Value("${spring.security.oauth2.client.registration.keycloak.client-id}")
+      public String clientId;
+
+      @Value("${spring.security.oauth2.client.registration.keycloak.redirect-uri:#{null}}")
+      public String redirectUri;
+
+      @Value("${keycloak.logout.redirect.uri:#{null}}")
+      public String logoutRedirectUri;
+
+      @Value("${keycloak.response.type:code}")
+      public String responseType;
+
+      @Value("${spring.security.oauth2.client.registration.keycloak.client-secret}")
+      public String clientSecret;
+
+      @Override
+      @Bean
+      @ConditionalOnMissingBean(KeycloakClient.class)
+      public KeycloakClient keycloakClient() {
+        log.info("핵심 Bean을 등록합니다: [KeycloakClient]");
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+            .baseUrl(baseUrl)
+            .realmName(realmName)
+            .relativePath(relativePath)
+            .clientId(clientId)
+            .redirectUri(redirectUri)
+            .logoutRedirectUri(logoutRedirectUri)
+            .responseType(responseType)
+            .clientSecret(clientSecret)
+            .build();
+        return new KeycloakClient(clientConfiguration);
+      }
+    }
+  }
+
+  // ==========================================================================
+  // 인증 처리 (Authentication)
+  // ==========================================================================
+
+  @Configuration(proxyBeanMethods = false)
+  @Slf4j
+  protected static class KeycloakAuthenticationConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(ReactiveAuthenticationManager.class)
+    public ReactiveAuthenticationManager keycloakReactiveAuthenticationManager(
+        KeycloakClient keycloakClient,
+        KeycloakInfrastructureConfiguration.KeycloakConfig keycloakConfig) {
+      log.info("핵심 Bean을 등록합니다: [ReactiveAuthenticationManager] (KeycloakReactiveAuthenticationManager)");
+      return new KeycloakReactiveAuthenticationManager(
+          keycloakClient, keycloakConfig.getClientId());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(ReactiveSessionManager.class)
+    public ReactiveSessionManager reactiveSessionManager() {
+      log.debug("지원 Bean을 등록합니다: [ReactiveSessionManager]");
+      return new ReactiveSessionManager();
+    }
+  }
+
+  // ==========================================================================
+  // OAuth2 Client 빈 (OIDC 로그인/로그아웃에 필요 — C-1)
+  // ==========================================================================
+
+  /**
+   * OIDC 로그인 플로우를 지원하기 위한 Reactive OAuth2 Client 협력 빈입니다.
+   *
+   * <p>Spring Boot가 {@code spring.security.oauth2.client.registration.keycloak.*} 설정으로
+   * {@link ReactiveClientRegistrationRepository}를 자동 구성하므로 그대로 활용합니다.
+   * 누락된 협력 빈({@link ReactiveOAuth2AuthorizedClientService},
+   * {@link ServerOAuth2AuthorizedClientRepository})만 {@code @ConditionalOnMissingBean}으로 보강합니다.</p>
+   */
+  @Configuration(proxyBeanMethods = false)
+  @ConditionalOnBean(ReactiveClientRegistrationRepository.class)
+  @Slf4j
+  protected static class KeycloakOAuth2ClientConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(ReactiveOAuth2AuthorizedClientService.class)
+    public ReactiveOAuth2AuthorizedClientService reactiveOAuth2AuthorizedClientService(
+        ReactiveClientRegistrationRepository clientRegistrationRepository) {
+      log.debug("지원 Bean을 등록합니다: [ReactiveOAuth2AuthorizedClientService]");
+      return new InMemoryReactiveOAuth2AuthorizedClientService(clientRegistrationRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(ServerOAuth2AuthorizedClientRepository.class)
+    public ServerOAuth2AuthorizedClientRepository serverOAuth2AuthorizedClientRepository(
+        ReactiveOAuth2AuthorizedClientService authorizedClientService) {
+      log.debug("지원 Bean을 등록합니다: [ServerOAuth2AuthorizedClientRepository]");
+      return new AuthenticatedPrincipalServerOAuth2AuthorizedClientRepository(authorizedClientService);
+    }
+  }
+
+  // ==========================================================================
+  // 로깅 (Logging)
+  // ==========================================================================
+
+  @Configuration(proxyBeanMethods = false)
+  @Slf4j
+  protected static class KeycloakLoggingConfiguration {
+
+    /**
+     * 기본 PII 마스킹 Sanitizer 등록.
+     */
+    @Bean
+    @ConditionalOnMissingBean(LoggingValueSanitizer.class)
+    public LoggingValueSanitizer defaultLoggingValueSanitizer() {
+      log.debug("지원 Bean을 등록합니다: [LoggingValueSanitizer] (DefaultPiiMaskingSanitizer)");
+      return new DefaultPiiMaskingSanitizer();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(ReactiveLoggingFilter.class)
+    public ReactiveLoggingFilter reactiveLoggingFilter(
+        KeycloakSecurityProperties securityProperties,
+        LoggingValueSanitizer sanitizer) {
+      log.debug("지원 Bean을 등록합니다: [ReactiveLoggingFilter]");
+      return new ReactiveLoggingFilter(securityProperties, sanitizer);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(ReactiveAuthLoggingFilter.class)
+    public ReactiveAuthLoggingFilter reactiveAuthLoggingFilter(
+        KeycloakSecurityProperties securityProperties) {
+      log.debug("지원 Bean을 등록합니다: [ReactiveAuthLoggingFilter]");
+      return new ReactiveAuthLoggingFilter(securityProperties);
+    }
+  }
+
+  // ==========================================================================
+  // MDC Context Propagation (Reactor Context ↔ MDC 자동 브릿지)
+  // ==========================================================================
+
+  /**
+   * Micrometer Context Propagation 기반 MDC 자동 브릿지 설정.
+   *
+   * <p>{@code io.micrometer:context-propagation} 클래스패스에 존재할 때만 활성화됩니다.
+   * {@link MdcContextPropagationAccessor}를 {@link ContextRegistry}에 등록하고
+   * {@code Hooks.enableAutomaticContextPropagation()}을 1회 활성화합니다.</p>
+   *
+   * <p><b>전역 Hooks 부작용:</b> M-3에 따라 {@code matchIfMissing=false}로 변경.
+   * 사용자가 명시적으로 {@code keycloak.security.logging.mdc-propagation-enabled=true}를 설정해야 합니다.</p>
+   */
+  @Configuration(proxyBeanMethods = false)
+  @ConditionalOnClass(name = "io.micrometer.context.ContextRegistry")
+  @ConditionalOnProperty(
+      prefix = "keycloak.security.logging",
+      name = "mdc-propagation-enabled",
+      havingValue = "true",
+      matchIfMissing = false)
+  @Slf4j
+  protected static class KeycloakMdcPropagationConfiguration {
+
+    @PostConstruct
+    public void enableMdcPropagation() {
+      ContextRegistry.getInstance().registerThreadLocalAccessor(
+          new MdcContextPropagationAccessor());
+      reactor.core.publisher.Hooks.enableAutomaticContextPropagation();
+
+      log.info("[MDCPropagation] Reactor Context ↔ MDC 자동 브릿지 활성화 완료. "
+          + "(MdcContextPropagationAccessor 등록, Hooks.enableAutomaticContextPropagation 설정)");
+    }
+  }
+
+  // ==========================================================================
+  // Back-Channel 로그아웃 (Spring Session Reactive가 활성화된 경우에만)
+  // ==========================================================================
+
+  /**
+   * Spring Session Reactive({@link ReactiveFindByIndexNameSessionRepository}) 빈이 존재할 때
+   * Back-Channel 로그아웃 핸들러와 엔드포인트 필터를 등록합니다.
+   *
+   * <p>의존성은 compileOnly로 선언되어 있으므로 사용자가 Redis Reactive 등을 사용할 때만 활성화됩니다.
+   * H-2: 필터는 전역 WebFilter 빈으로 자동 등록하지 않고, Configurer 내에서 명시 등록합니다.</p>
+   */
+  @Configuration(proxyBeanMethods = false)
+  @ConditionalOnClass(name = "org.springframework.session.ReactiveFindByIndexNameSessionRepository")
+  @ConditionalOnBean(type = "org.springframework.session.ReactiveFindByIndexNameSessionRepository")
+  @Slf4j
+  protected static class KeycloakBackChannelLogoutConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(ReactiveOidcBackChannelLogoutHandler.class)
+    @SuppressWarnings("unchecked")
+    public ReactiveOidcBackChannelLogoutHandler reactiveOidcBackChannelLogoutHandler(
+        ReactiveFindByIndexNameSessionRepository<?> sessionRepository) {
+      log.info("핵심 Bean을 등록합니다: [ReactiveOidcBackChannelLogoutHandler]");
+      return new ReactiveOidcBackChannelLogoutHandler(sessionRepository);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(ReactiveBackChannelLogoutEndpointFilter.class)
+    public ReactiveBackChannelLogoutEndpointFilter reactiveBackChannelLogoutEndpointFilter(
+        ReactiveOidcBackChannelLogoutHandler logoutHandler) {
+      log.info("핵심 Bean을 등록합니다: [ReactiveBackChannelLogoutEndpointFilter]");
+      return new ReactiveBackChannelLogoutEndpointFilter(logoutHandler);
+    }
+  }
+
+  // ==========================================================================
+  // Rate Limiting (조건부)
+  // ==========================================================================
+
+  @Configuration(proxyBeanMethods = false)
+  @ConditionalOnProperty(
+      prefix = "keycloak.security.rate-limit",
+      name = "enabled",
+      havingValue = "true")
+  @Slf4j
+  protected static class KeycloakRateLimitConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(RateLimiter.class)
+    public RateLimiter keycloakInMemoryRateLimiter(KeycloakSecurityProperties securityProperties) {
+      KeycloakRateLimitProperties props = securityProperties.getRateLimit();
+      log.info("지원 Bean을 등록합니다: [RateLimiter] (InMemoryRateLimiter) maxRequests={} window={}s block={}s",
+          props.getMaxRequests(), props.getWindowSeconds(), props.getBlockDurationSeconds());
+      return new InMemoryRateLimiter(
+          props.getMaxRequests(), props.getWindowSeconds(), props.getBlockDurationSeconds());
+    }
+  }
+
+  // ==========================================================================
+  // Bearer Token 컨트롤러 (조건부)
+  // ==========================================================================
+
+  @Configuration(proxyBeanMethods = false)
+  @ConditionalOnProperty(
+      prefix = "keycloak.security.bearer-token",
+      name = "enabled",
+      havingValue = "true")
+  @Slf4j
+  protected static class KeycloakBearerTokenConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(com.ids.keycloak.security.controller.KeycloakReactiveTokenController.class)
+    public com.ids.keycloak.security.controller.KeycloakReactiveTokenController keycloakReactiveTokenController(
+        KeycloakClient keycloakClient,
+        KeycloakSecurityProperties securityProperties) {
+      String prefix = securityProperties.getBearerToken().getTokenEndpoint().getPrefix();
+      log.info("핵심 Bean을 등록합니다: [KeycloakReactiveTokenController] (prefix={})", prefix);
+      return new com.ids.keycloak.security.controller.KeycloakReactiveTokenController(
+          keycloakClient, prefix);
+    }
+  }
+
+  // ==========================================================================
+  // 웹 보안 (Web Security)
+  // ==========================================================================
+
+  @Configuration(proxyBeanMethods = false)
+  @Slf4j
+  protected static class KeycloakWebSecurityConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(KeycloakServerAuthenticationEntryPoint.class)
+    public KeycloakServerAuthenticationEntryPoint keycloakServerAuthenticationEntryPoint(
+        ObjectMapper objectMapper,
+        KeycloakSecurityProperties securityProperties,
+        KeycloakInfrastructureConfiguration.KeycloakConfig keycloakConfig) {
+      log.debug("지원 Bean을 등록합니다: [KeycloakServerAuthenticationEntryPoint]");
+      return new KeycloakServerAuthenticationEntryPoint(
+          objectMapper,
+          securityProperties.getError(),
+          securityProperties.getBasicAuth().isEnabled(),
+          keycloakConfig.getRealmName());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(KeycloakServerAccessDeniedHandler.class)
+    public KeycloakServerAccessDeniedHandler keycloakServerAccessDeniedHandler(
+        ObjectMapper objectMapper) {
+      log.debug("지원 Bean을 등록합니다: [KeycloakServerAccessDeniedHandler]");
+      return new KeycloakServerAccessDeniedHandler(objectMapper);
+    }
+
+    /**
+     * Keycloak 기본 {@link SecurityWebFilterChain}을 등록합니다.
+     *
+     * <p><b>Fail-Open 방지</b>: Bean 이름 기반 조건 + securityMatcher + {@code @Order(LOWEST_PRECEDENCE)}</p>
+     */
+    @Bean("keycloakSecurityWebFilterChain")
+    @ConditionalOnMissingBean(name = "keycloakSecurityWebFilterChain")
+    @ConditionalOnProperty(
+        prefix = "keycloak.security",
+        name = "auto-filter-chain",
+        havingValue = "true",
+        matchIfMissing = true)
+    @Order(Ordered.LOWEST_PRECEDENCE)
+    public SecurityWebFilterChain keycloakSecurityWebFilterChain(
+        ServerHttpSecurity http,
+        ReactiveAuthenticationManager reactiveAuthenticationManager,
+        KeycloakServerAuthenticationEntryPoint entryPoint,
+        KeycloakServerAccessDeniedHandler accessDeniedHandler,
+        KeycloakSecurityProperties securityProperties,
+        KeycloakClient keycloakClient,
+        KeycloakInfrastructureConfiguration.KeycloakConfig keycloakConfig,
+        ReactiveSessionManager sessionManager,
+        org.springframework.beans.factory.ObjectProvider<RateLimiter> rateLimiterProvider,
+        org.springframework.beans.factory.ObjectProvider<ReactiveLoggingFilter> loggingFilterProvider,
+        org.springframework.beans.factory.ObjectProvider<ReactiveAuthLoggingFilter> authLoggingFilterProvider,
+        org.springframework.beans.factory.ObjectProvider<ReactiveClientRegistrationRepository> clientRegistrationRepoProvider,
+        org.springframework.beans.factory.ObjectProvider<ReactiveOAuth2AuthorizedClientService> authorizedClientServiceProvider,
+        org.springframework.beans.factory.ObjectProvider<ReactiveBackChannelLogoutEndpointFilter> backChannelFilterProvider)
+        throws Exception {
+
+      ServerWebExchangeMatcher securityMatcher = buildSecurityMatcher(securityProperties.getMatcher());
+
+      log.info("핵심 Bean을 등록합니다: [SecurityWebFilterChain] (담당 경로 include={}, exclude={})",
+          securityProperties.getMatcher().getInclude(),
+          securityProperties.getMatcher().getExclude());
+
+      http.securityMatcher(securityMatcher);
+
+      RateLimiter rateLimiter = rateLimiterProvider.getIfAvailable();
+      ReactiveLoggingFilter loggingFilter = loggingFilterProvider.getIfAvailable();
+      ReactiveAuthLoggingFilter authLoggingFilter = authLoggingFilterProvider.getIfAvailable();
+      ReactiveClientRegistrationRepository clientRegistrationRepo =
+          clientRegistrationRepoProvider.getIfAvailable();
+      ReactiveOAuth2AuthorizedClientService authorizedClientService =
+          authorizedClientServiceProvider.getIfAvailable();
+      ReactiveBackChannelLogoutEndpointFilter backChannelFilter =
+          backChannelFilterProvider.getIfAvailable();
+
+      return KeycloakWebFluxSecurityConfigurer.configure(
+          http,
+          reactiveAuthenticationManager,
+          entryPoint,
+          accessDeniedHandler,
+          securityProperties,
+          keycloakClient,
+          keycloakConfig.getClientId(),
+          sessionManager,
+          rateLimiter,
+          loggingFilter,
+          authLoggingFilter,
+          clientRegistrationRepo,
+          authorizedClientService,
+          backChannelFilter);
+    }
+
+    /**
+     * include/exclude 패턴을 {@link ServerWebExchangeMatcher}로 변환합니다.
+     */
+    private ServerWebExchangeMatcher buildSecurityMatcher(KeycloakMatcherProperties properties) {
+      List<String> includes = properties.getInclude();
+      List<String> excludes = properties.getExclude();
+
+      ServerWebExchangeMatcher includeMatcher = toOrMatcher(includes);
+
+      if (excludes == null || excludes.isEmpty()) {
+        return includeMatcher;
+      }
+
+      ServerWebExchangeMatcher excludeMatcher = toOrMatcher(excludes);
+      return exchange -> includeMatcher.matches(exchange)
+          .flatMap(includeResult -> {
+            if (!includeResult.isMatch()) {
+              return ServerWebExchangeMatcher.MatchResult.notMatch();
+            }
+            return excludeMatcher.matches(exchange)
+                .flatMap(excludeResult ->
+                    excludeResult.isMatch()
+                        ? ServerWebExchangeMatcher.MatchResult.notMatch()
+                        : ServerWebExchangeMatcher.MatchResult.match());
+          });
+    }
+
+    private ServerWebExchangeMatcher toOrMatcher(List<String> patterns) {
+      if (patterns == null || patterns.isEmpty()) {
+        return exchange -> ServerWebExchangeMatchers.anyExchange().matches(exchange);
+      }
+      if (patterns.size() == 1) {
+        return new PathPatternParserServerWebExchangeMatcher(patterns.get(0));
+      }
+      List<ServerWebExchangeMatcher> matchers = new ArrayList<>();
+      for (String pattern : patterns) {
+        matchers.add(new PathPatternParserServerWebExchangeMatcher(pattern));
+      }
+      return ServerWebExchangeMatchers.matchers(matchers.toArray(new ServerWebExchangeMatcher[0]));
+    }
+  }
+}

--- a/keycloak-spring-security-webflux-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/keycloak-spring-security-webflux-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.ids.keycloak.security.config.KeycloakWebFluxAutoConfiguration

--- a/keycloak-spring-security-webflux-starter/src/test/java/com/ids/keycloak/security/config/KeycloakWebFluxFilterChainConditionsTest.java
+++ b/keycloak-spring-security-webflux-starter/src/test/java/com/ids/keycloak/security/config/KeycloakWebFluxFilterChainConditionsTest.java
@@ -1,0 +1,99 @@
+package com.ids.keycloak.security.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ids.keycloak.security.filter.ReactiveAuthLoggingFilter;
+import com.ids.keycloak.security.filter.ReactiveBackChannelLogoutEndpointFilter;
+import com.ids.keycloak.security.filter.ReactiveLoggingFilter;
+import com.ids.keycloak.security.web.reactive.KeycloakServerAccessDeniedHandler;
+import com.ids.keycloak.security.web.reactive.KeycloakServerAuthenticationEntryPoint;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+/**
+ * {@code keycloakSecurityWebFilterChain} Bean의 조건/순서 어노테이션이
+ * Fail-Open 방지 설계를 유지하는지 검증합니다.
+ *
+ * <p>(CVSS 8.1, CWE-1188/863) 회귀 방지 — WebFlux 버전의 조건을 고정합니다.</p>
+ */
+class KeycloakWebFluxFilterChainConditionsTest {
+
+  /**
+   * keycloakSecurityWebFilterChain 메서드를 리플렉션으로 조회합니다.
+   */
+  private Method filterChainMethod() throws NoSuchMethodException {
+    return KeycloakWebFluxAutoConfiguration.KeycloakWebSecurityConfiguration.class
+        .getDeclaredMethod(
+            "keycloakSecurityWebFilterChain",
+            ServerHttpSecurity.class,
+            ReactiveAuthenticationManager.class,
+            KeycloakServerAuthenticationEntryPoint.class,
+            KeycloakServerAccessDeniedHandler.class,
+            KeycloakSecurityProperties.class,
+            com.sd.KeycloakClient.factory.KeycloakClient.class,
+            KeycloakWebFluxAutoConfiguration.KeycloakInfrastructureConfiguration.KeycloakConfig.class,
+            com.ids.keycloak.security.session.ReactiveSessionManager.class,
+            ObjectProvider.class,  // RateLimiter
+            ObjectProvider.class,  // ReactiveLoggingFilter
+            ObjectProvider.class,  // ReactiveAuthLoggingFilter
+            ObjectProvider.class,  // ReactiveClientRegistrationRepository
+            ObjectProvider.class,  // ReactiveOAuth2AuthorizedClientService
+            ObjectProvider.class   // ReactiveBackChannelLogoutEndpointFilter
+        );
+  }
+
+  @Test
+  @DisplayName("(b) Bean 이름 기반 @ConditionalOnMissingBean — 사용자 SecurityWebFilterChain 공존")
+  void conditionalOnMissingBeanByName() throws Exception {
+    ConditionalOnMissingBean annotation =
+        filterChainMethod().getAnnotation(ConditionalOnMissingBean.class);
+
+    assertThat(annotation).isNotNull();
+    assertThat(annotation.name()).containsExactly("keycloakSecurityWebFilterChain");
+    // 타입 기반 조건이면 Fail-Open 재발 → 반드시 비어있어야 함
+    assertThat(annotation.value()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("(a)(c) @ConditionalOnProperty — 기본 등록(matchIfMissing), auto-filter-chain=false 일 때만 미등록")
+  void conditionalOnProperty() throws Exception {
+    ConditionalOnProperty annotation =
+        filterChainMethod().getAnnotation(ConditionalOnProperty.class);
+
+    assertThat(annotation).isNotNull();
+    assertThat(annotation.prefix()).isEqualTo("keycloak.security");
+    assertThat(annotation.name()).containsExactly("auto-filter-chain");
+    assertThat(annotation.havingValue()).isEqualTo("true");
+    assertThat(annotation.matchIfMissing()).isTrue();
+  }
+
+  @Test
+  @DisplayName("@Order(LOWEST_PRECEDENCE) — catch-all 체인이 맨 뒤")
+  void orderIsLowestPrecedence() throws Exception {
+    Order annotation = filterChainMethod().getAnnotation(Order.class);
+
+    assertThat(annotation).isNotNull();
+    assertThat(annotation.value()).isEqualTo(Ordered.LOWEST_PRECEDENCE);
+  }
+
+  @Test
+  @DisplayName("@Bean 이름이 'keycloakSecurityWebFilterChain'으로 고정")
+  void beanNameMatches() throws Exception {
+    Bean annotation = filterChainMethod().getAnnotation(Bean.class);
+
+    assertThat(annotation).isNotNull();
+    assertThat(annotation.value()).containsExactly("keycloakSecurityWebFilterChain");
+  }
+}

--- a/keycloak-spring-security-webflux/build.gradle
+++ b/keycloak-spring-security-webflux/build.gradle
@@ -20,6 +20,37 @@ dependencies {
 
     // ErrorHandler에서 JSON 응답을 생성하기 위해 사용
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    // Bean Validation (DTO @NotBlank/@Valid 지원)
+    compileOnly 'jakarta.validation:jakarta.validation-api'
+
+    // OAuth2 Client (OIDC 로그인/로그아웃 성공 핸들러, ReactiveClientRegistrationRepository 등)
+    // spring-boot-starter-webflux가 전이하지 않으므로 명시 추가. 사용자가 OIDC 로그인을 쓸 때만 런타임 제공.
+    compileOnly 'org.springframework.security:spring-security-oauth2-client'
+
+    // MDC ↔ Reactor Context 자동 브릿지 (io.micrometer:context-propagation)
+    // reactor-core가 context-propagation API를 transitively 포함하지만,
+    // 실제 SPI 구현은 별도 라이브러리가 필요하므로 implementation으로 추가.
+    // Spring Boot 3.2+ BOM에 micrometer-context-propagation 버전이 관리됨.
+    implementation 'io.micrometer:context-propagation'
+
+    // Spring Session Reactive (ReactiveFindByIndexNameSessionRepository 인터페이스)
+    // 사용자가 Redis Reactive 등 Spring Session 구현체를 사용할 때만 Back-Channel 로그아웃이 활성화됨.
+    // compileOnly: 컴파일 시에만 필요하며 런타임 의존성은 사용자 프로젝트가 제공.
+    // servlet starter가 session 의존성을 compileOnly로 둔 선례와 동일.
+    compileOnly 'org.springframework.session:spring-session-core'
+
+    // Test: Reactive 스트림 검증 (StepVerifier) + WebTestClient
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
+    testImplementation 'org.springframework:spring-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    // Back-Channel 로그아웃 테스트: spring-session-core (compileOnly → test에서도 필요)
+    testImplementation 'org.springframework.session:spring-session-core'
+    // OIDC 로그인 성공 핸들러 테스트
+    testImplementation 'org.springframework.security:spring-security-oauth2-client'
+    // DTO @NotBlank 테스트용 Hibernate Validator (spring-boot-starter-validation 전이)
+    testImplementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 signing {

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/BackChannelLogoutAuthentication.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/BackChannelLogoutAuthentication.java
@@ -1,0 +1,34 @@
+package com.ids.keycloak.security.authentication;
+
+import java.util.Collections;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+/**
+ * Back-Channel Logout 요청에서 logout_token을 전달하기 위한 Authentication 객체입니다.
+ *
+ * <p>{@link ReactiveOidcBackChannelLogoutHandler}에 logout_token JWT 문자열을
+ * 전달하기 위한 내부 전용 Authentication 래퍼입니다.</p>
+ */
+public class BackChannelLogoutAuthentication extends AbstractAuthenticationToken {
+
+  private final String logoutTokenJwt;
+
+  /**
+   * @param logoutTokenJwt Keycloak이 전달한 logout_token JWT 문자열
+   */
+  public BackChannelLogoutAuthentication(String logoutTokenJwt) {
+    super(Collections.emptyList());
+    this.logoutTokenJwt = logoutTokenJwt;
+    setAuthenticated(false);
+  }
+
+  @Override
+  public Object getCredentials() {
+    return logoutTokenJwt;
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return "back-channel-logout";
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakReactiveAuthenticationManager.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakReactiveAuthenticationManager.java
@@ -1,0 +1,248 @@
+package com.ids.keycloak.security.authentication;
+
+import com.ids.keycloak.security.exception.AuthenticationFailedException;
+import com.ids.keycloak.security.exception.ConfigurationException;
+import com.ids.keycloak.security.exception.IntrospectionFailedException;
+import com.ids.keycloak.security.exception.UserInfoFetchException;
+import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.ids.keycloak.security.util.JwtUtil;
+import com.ids.keycloak.security.util.KeycloakAuthorityExtractor;
+import com.sd.KeycloakClient.dto.auth.KeycloakIntrospectResponse;
+import com.sd.KeycloakClient.dto.user.KeycloakUserInfo;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import reactor.core.publisher.Mono;
+
+/**
+ * Keycloak OIDC 인증을 처리하는 {@link ReactiveAuthenticationManager} 구현체입니다.
+ *
+ * <p>servlet 모듈의 {@code KeycloakAuthenticationProvider}를 Reactive Mono 체이닝으로 포팅합니다.
+ * 토큰 유효성 검증은 Keycloak Introspect API(온라인 검증)에 완전히 위임하며,
+ * 블로킹 호출 없이 {@code authAsync()}/{@code userAsync()} API만 사용합니다.</p>
+ */
+@Slf4j
+public class KeycloakReactiveAuthenticationManager implements ReactiveAuthenticationManager {
+
+  private final KeycloakClient keycloakClient;
+  private final String clientId;
+
+  public KeycloakReactiveAuthenticationManager(KeycloakClient keycloakClient, String clientId) {
+    this.keycloakClient = keycloakClient;
+    this.clientId = clientId;
+  }
+
+  /**
+   * 토큰을 검증하고 인증 객체를 생성합니다.
+   *
+   * <p>처리 흐름:
+   * <ol>
+   *   <li>idToken으로 Keycloak Introspect 온라인 검증</li>
+   *   <li>accessToken으로 UserInfo 조회</li>
+   *   <li>JwtUtil로 idToken 클레임 파싱, OidcIdToken 생성</li>
+   *   <li>KeycloakAuthorityExtractor로 권한 추출</li>
+   *   <li>KeycloakPrincipal / KeycloakAuthentication(authenticated=true) 생성</li>
+   * </ol>
+   * </p>
+   *
+   * @param authentication 인증 요청 객체 ({@link KeycloakAuthentication})
+   * @return 인증된 {@link Authentication}을 담은 {@link Mono}
+   */
+  @Override
+  public Mono<Authentication> authenticate(Authentication authentication) {
+    log.debug("[ReactiveAuthManager] 인증 요청 시작: {}", authentication.getName());
+
+    KeycloakAuthentication authRequest = (KeycloakAuthentication) authentication;
+    String idTokenValue = authRequest.getIdToken();
+    String accessTokenValue = authRequest.getAccessToken();
+
+    return verifyTokenOnline(idTokenValue)
+        .then(Mono.defer(() -> fetchUserInfo(accessTokenValue)
+            .map(oidcUserInfo -> createAuthenticatedToken(idTokenValue, accessTokenValue, oidcUserInfo))
+            .switchIfEmpty(Mono.fromCallable(
+                () -> createAuthenticatedToken(idTokenValue, accessTokenValue, null)))))
+        .cast(Authentication.class)
+        .onErrorResume(
+            e -> !(e instanceof AuthenticationException)
+                && !(e instanceof com.ids.keycloak.security.exception.KeycloakSecurityException),
+            e -> {
+              log.error("[ReactiveAuthManager] 예상치 못한 오류 발생: {}", e.getMessage(), e);
+              return Mono.error(
+                  new AuthenticationFailedException("인증 처리 중 오류가 발생했습니다: " + e.getMessage(), e));
+            });
+  }
+
+  /**
+   * 검증된 토큰으로 인증 객체를 생성합니다.
+   * UserInfo 조회 후 직접 호출합니다.
+   *
+   * @param idTokenValue     ID Token
+   * @param accessTokenValue Access Token
+   * @param oidcUserInfo     UserInfo (null 가능)
+   * @return 인증된 {@link Authentication} 객체
+   */
+  public Authentication createAuthenticatedToken(
+      String idTokenValue, String accessTokenValue, OidcUserInfo oidcUserInfo) {
+    Map<String, Object> idTokenClaims = JwtUtil.parseClaimsWithoutValidation(idTokenValue);
+    String subject = JwtUtil.parseSubjectWithoutValidation(idTokenValue);
+
+    OidcIdToken oidcIdToken = createOidcIdToken(idTokenValue, idTokenClaims);
+    KeycloakPrincipal principal = createPrincipal(oidcIdToken, oidcUserInfo, subject);
+
+    log.debug("[ReactiveAuthManager] 최종 인증 객체 생성 완료: {}", principal.getName());
+    return new KeycloakAuthentication(principal, idTokenValue, accessTokenValue, true);
+  }
+
+  /**
+   * Keycloak Introspect API를 통해 토큰을 온라인 검증합니다.
+   *
+   * <p>servlet의 동기 switch(status) 분기를 flatMap/map/onErrorResume으로 변환합니다.</p>
+   */
+  private Mono<Void> verifyTokenOnline(String token) {
+    log.debug("[ReactiveAuthManager] Keycloak 온라인 검증 시도 (ID Token).");
+
+    return keycloakClient.authAsync().authenticationByIntrospect(token)
+        .flatMap(response -> {
+          int status = response.getStatus();
+
+          if (status == 200) {
+            KeycloakIntrospectResponse introspectResponse =
+                response.getBody().orElse(null);
+            if (introspectResponse == null) {
+              log.warn("[ReactiveAuthManager] 온라인 검증 실패: 응답 본문이 없습니다.");
+              return Mono.error(
+                  new IntrospectionFailedException("온라인 검증 실패: 응답 본문이 없습니다."));
+            }
+            if (!introspectResponse.getActive()) {
+              log.warn("[ReactiveAuthManager] 온라인 검증 실패: 토큰이 비활성 상태입니다 (active=false).");
+              return Mono.error(
+                  new IntrospectionFailedException("온라인 검증 실패: 토큰이 유효하지 않습니다."));
+            }
+            log.debug("[ReactiveAuthManager] 온라인 검증 성공.");
+            return Mono.<Void>empty();
+          } else if (status == 401) {
+            log.warn("[ReactiveAuthManager] 온라인 검증 실패 (401 Unauthorized).");
+            return Mono.error(
+                new IntrospectionFailedException("온라인 검증 실패: 토큰이 유효하지 않습니다."));
+          } else if (status == 500) {
+            log.error("[ReactiveAuthManager] Keycloak 서버 오류 발생.");
+            return Mono.<Void>error(new ConfigurationException("Keycloak 서버에 오류가 발생했습니다."));
+          } else {
+            log.error("[ReactiveAuthManager] 온라인 검증 중 예상치 못한 응답. 상태 코드: {}", status);
+            return Mono.<Void>error(
+                new AuthenticationFailedException("온라인 검증 실패. 상태 코드: " + status));
+          }
+        })
+        .onErrorResume(
+            e -> !(e instanceof AuthenticationException)
+                && !(e instanceof com.ids.keycloak.security.exception.KeycloakSecurityException),
+            e -> {
+              log.error("[ReactiveAuthManager] Keycloak 서버와 통신 중 오류 발생: {}", e.getMessage());
+              return Mono.error(
+                  new ConfigurationException(
+                      "Keycloak 서버와 통신할 수 없습니다: " + e.getMessage()));
+            });
+  }
+
+  /**
+   * Keycloak UserInfo 엔드포인트를 비동기로 호출합니다.
+   *
+   * <p>UserInfo 조회 실패 시 null을 담은 Mono를 반환합니다(인증 자체를 중단하지 않음).</p>
+   */
+  private Mono<OidcUserInfo> fetchUserInfo(String accessToken) {
+    return keycloakClient.userAsync().getUserInfo(accessToken)
+        .flatMap(response -> {
+          int status = response.getStatus();
+
+          if (status == 200) {
+            KeycloakUserInfo keycloakUserInfo = response.getBody().orElse(null);
+            if (keycloakUserInfo != null) {
+              log.debug("[ReactiveAuthManager] UserInfo 조회 성공.");
+              return Mono.just(convertToOidcUserInfo(keycloakUserInfo));
+            }
+            log.warn("[ReactiveAuthManager] UserInfo 응답 본문이 비어있습니다. 빈 UserInfo로 진행합니다.");
+            return Mono.<OidcUserInfo>empty();
+          } else if (status == 401) {
+            log.warn("[ReactiveAuthManager] UserInfo 조회 실패 (401 Unauthorized).");
+            return Mono.<OidcUserInfo>error(
+                new UserInfoFetchException("UserInfo 조회 실패 (401 Unauthorized)."));
+          } else {
+            log.warn("[ReactiveAuthManager] UserInfo 조회 중 예상치 못한 응답. 상태 코드: {}", status);
+            return Mono.<OidcUserInfo>error(
+                new UserInfoFetchException("UserInfo 조회 중 예상치 못한 응답. 상태 코드: " + status));
+          }
+        })
+        .onErrorResume(
+            e -> !(e instanceof AuthenticationException)
+                && !(e instanceof com.ids.keycloak.security.exception.KeycloakSecurityException),
+            e -> {
+              log.warn("[ReactiveAuthManager] UserInfo 조회 중 오류 발생, null 반환: {}", e.getMessage());
+              return Mono.empty();
+            });
+  }
+
+  /**
+   * KeycloakUserInfo를 OidcUserInfo로 변환합니다.
+   */
+  private OidcUserInfo convertToOidcUserInfo(KeycloakUserInfo keycloakUserInfo) {
+    Map<String, Object> claims = new HashMap<>();
+
+    if (keycloakUserInfo.getSubject() != null) {
+      claims.put("sub", keycloakUserInfo.getSubject());
+    }
+    if (keycloakUserInfo.getPreferredUsername() != null) {
+      claims.put("preferred_username", keycloakUserInfo.getPreferredUsername());
+    }
+    if (keycloakUserInfo.getEmail() != null) {
+      claims.put("email", keycloakUserInfo.getEmail());
+    }
+    if (keycloakUserInfo.getName() != null) {
+      claims.put("name", keycloakUserInfo.getName());
+    }
+
+    claims.putAll(keycloakUserInfo.getOtherInfo());
+    return new OidcUserInfo(claims);
+  }
+
+  /**
+   * ID Token 문자열과 클레임에서 OidcIdToken 객체를 생성합니다.
+   */
+  private OidcIdToken createOidcIdToken(String idTokenValue, Map<String, Object> claims) {
+    Instant issuedAt = extractInstant(claims, "iat");
+    Instant expiresAt = extractInstant(claims, "exp");
+    return new OidcIdToken(idTokenValue, issuedAt, expiresAt, claims);
+  }
+
+  /**
+   * 클레임에서 Instant 값을 추출합니다.
+   */
+  private Instant extractInstant(Map<String, Object> claims, String claimName) {
+    Object value = claims.get(claimName);
+    if (value instanceof Number) {
+      return Instant.ofEpochSecond(((Number) value).longValue());
+    }
+    return null;
+  }
+
+  /**
+   * OidcIdToken과 OidcUserInfo에서 Principal 객체를 생성합니다.
+   */
+  private KeycloakPrincipal createPrincipal(
+      OidcIdToken oidcIdToken, OidcUserInfo oidcUserInfo, String subject) {
+    Map<String, Object> claims = (oidcUserInfo != null) ? oidcUserInfo.getClaims() : Map.of();
+    Collection<GrantedAuthority> authorities = KeycloakAuthorityExtractor.extract(claims, clientId);
+
+    log.debug(
+        "[ReactiveAuthManager] 사용자 '{}' Principal 생성 완료. 권한: {}", subject, authorities);
+    return new KeycloakPrincipal(subject, authorities, oidcIdToken, oidcUserInfo);
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakReactiveLogoutHandler.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakReactiveLogoutHandler.java
@@ -1,0 +1,70 @@
+package com.ids.keycloak.security.authentication;
+
+import com.ids.keycloak.security.config.KeycloakCookieProperties;
+import com.ids.keycloak.security.session.ReactiveSessionManager;
+import com.ids.keycloak.security.util.ReactiveCookieUtil;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.server.authentication.logout.ServerLogoutHandler;
+import reactor.core.publisher.Mono;
+
+/**
+ * 프론트채널 로그아웃 시 Keycloak 서버에 로그아웃을 요청하고,
+ * WebSession을 무효화하고 토큰 쿠키를 삭제하는 {@link ServerLogoutHandler} 구현체입니다.
+ *
+ * <p>servlet 모듈의 {@code KeycloakLogoutHandler}를 Reactive로 포팅합니다.
+ * WebSession 접근은 {@code exchange.getExchange().getSession()}(Mono)를 통해 비동기로 처리하며
+ * {@code .block()} 없이 체이닝합니다.</p>
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class KeycloakReactiveLogoutHandler implements ServerLogoutHandler {
+
+  private final KeycloakClient keycloakClient;
+  private final ReactiveSessionManager sessionManager;
+  private final KeycloakCookieProperties cookieProperties;
+
+  @Override
+  public Mono<Void> logout(WebFilterExchange webFilterExchange, Authentication authentication) {
+    log.debug("[LogoutHandler] 로그아웃 처리를 시작합니다.");
+
+    return webFilterExchange.getExchange().getSession()
+        .flatMap(session -> {
+          // 1. Keycloak 서버에 로그아웃 요청 (Refresh Token으로)
+          String refreshToken = sessionManager.getRefreshToken(session).orElse(null);
+          Mono<Void> keycloakLogout = Mono.empty();
+
+          if (refreshToken != null) {
+            keycloakLogout = keycloakClient.authAsync().logout(refreshToken)
+                .doOnSuccess(r -> log.debug("[LogoutHandler] Keycloak 서버 로그아웃 요청 완료."))
+                .onErrorResume(e -> {
+                  log.warn("[LogoutHandler] Keycloak 서버 로그아웃 요청 실패: {}", e.getMessage());
+                  return Mono.empty();
+                })
+                .then();
+          } else {
+            log.debug("[LogoutHandler] 세션에 Refresh Token이 없습니다.");
+          }
+
+          // 2. WebSession 무효화
+          Mono<Void> invalidate = sessionManager.invalidateSession(session);
+
+          return keycloakLogout.then(invalidate);
+        })
+        .doOnSuccess(v -> {
+          // 3. 모든 토큰 관련 쿠키 삭제
+          ReactiveCookieUtil.deleteAllTokenCookies(
+              webFilterExchange.getExchange().getResponse(), cookieProperties);
+          log.debug("[LogoutHandler] 토큰 쿠키 삭제 완료. 로그아웃 처리 완료.");
+        })
+        .onErrorResume(e -> {
+          log.warn("[LogoutHandler] 로그아웃 처리 중 오류 발생: {}", e.getMessage());
+          ReactiveCookieUtil.deleteAllTokenCookies(
+              webFilterExchange.getExchange().getResponse(), cookieProperties);
+          return Mono.empty();
+        });
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakReactiveOpaqueTokenIntrospector.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakReactiveOpaqueTokenIntrospector.java
@@ -1,0 +1,154 @@
+package com.ids.keycloak.security.authentication;
+
+import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.ids.keycloak.security.util.KeycloakAuthorityExtractor;
+import com.sd.KeycloakClient.dto.auth.KeycloakIntrospectResponse;
+import com.sd.KeycloakClient.dto.user.KeycloakUserInfo;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.server.resource.introspection.BadOpaqueTokenException;
+import org.springframework.security.oauth2.server.resource.introspection.ReactiveOpaqueTokenIntrospector;
+import reactor.core.publisher.Mono;
+
+/**
+ * Keycloak Introspect API를 통해 Bearer Token을 검증하고
+ * {@link KeycloakPrincipal}을 생성하는 {@link ReactiveOpaqueTokenIntrospector} 구현체입니다.
+ *
+ * <p>servlet 모듈의 {@code KeycloakOpaqueTokenIntrospector}를 Reactive로 포팅합니다.
+ * {@code authAsync().authenticationByIntrospect()} + {@code userAsync().getUserInfo()}를
+ * Mono 체이닝으로 처리하며 {@code .block()} 없이 동작합니다.</p>
+ */
+@Slf4j
+public class KeycloakReactiveOpaqueTokenIntrospector implements ReactiveOpaqueTokenIntrospector {
+
+  private final KeycloakClient keycloakClient;
+  private final String clientId;
+
+  public KeycloakReactiveOpaqueTokenIntrospector(KeycloakClient keycloakClient, String clientId) {
+    this.keycloakClient = keycloakClient;
+    this.clientId = clientId;
+  }
+
+  /**
+   * access_token을 Keycloak Introspect API로 검증하고 {@link KeycloakPrincipal}을 반환합니다.
+   *
+   * @param token access_token 문자열
+   * @return {@link OAuth2AuthenticatedPrincipal}을 담은 Mono (실제로는 {@link KeycloakPrincipal})
+   */
+  @Override
+  public Mono<OAuth2AuthenticatedPrincipal> introspect(String token) {
+    log.debug("[BearerToken] Reactive Introspect 검증 시작.");
+
+    return verifyTokenActive(token)
+        .then(fetchUserInfo(token))
+        .map(oidcUserInfo -> buildPrincipal(token, oidcUserInfo));
+  }
+
+  /**
+   * Keycloak Introspect API를 호출하여 토큰이 active인지 확인합니다.
+   */
+  private Mono<Void> verifyTokenActive(String token) {
+    return keycloakClient.authAsync().authenticationByIntrospect(token)
+        .flatMap(response -> {
+          int status = response.getStatus();
+
+          if (status == 200) {
+            KeycloakIntrospectResponse body = response.getBody().orElse(null);
+            if (body == null) {
+              return Mono.error(new BadOpaqueTokenException("Introspect 응답 본문이 없습니다."));
+            }
+            if (!body.getActive()) {
+              log.debug("[BearerToken] 토큰이 비활성 상태입니다 (active=false).");
+              return Mono.error(new BadOpaqueTokenException("토큰이 유효하지 않습니다."));
+            }
+            log.debug("[BearerToken] Introspect 검증 성공 (active=true).");
+            return Mono.<Void>empty();
+          }
+
+          log.warn("[BearerToken] Introspect 검증 실패. 상태 코드: {}", status);
+          return Mono.error(new BadOpaqueTokenException("토큰 검증 실패. 상태 코드: " + status));
+        })
+        .onErrorResume(
+            e -> !(e instanceof BadOpaqueTokenException),
+            e -> {
+              log.error("[BearerToken] Keycloak 서버 통신 오류: {}", e.getMessage());
+              return Mono.error(new BadOpaqueTokenException("인증 서버 통신 실패: " + e.getMessage()));
+            });
+  }
+
+  /**
+   * Keycloak UserInfo 엔드포인트를 비동기로 호출합니다.
+   * UserInfo 조회 실패 시 null을 담은 Mono를 반환합니다.
+   */
+  private Mono<OidcUserInfo> fetchUserInfo(String accessToken) {
+    return keycloakClient.userAsync().getUserInfo(accessToken)
+        .flatMap(response -> {
+          int status = response.getStatus();
+
+          if (status == 200) {
+            KeycloakUserInfo keycloakUserInfo = response.getBody().orElse(null);
+            if (keycloakUserInfo != null) {
+              log.debug("[BearerToken] UserInfo 조회 성공.");
+              return Mono.just(convertToOidcUserInfo(keycloakUserInfo));
+            }
+          }
+
+          log.warn("[BearerToken] UserInfo 조회 실패. 상태 코드: {}", status);
+          return Mono.<OidcUserInfo>justOrEmpty(null);
+        })
+        .onErrorResume(e -> {
+          log.warn("[BearerToken] UserInfo 조회 중 오류 발생: {}", e.getMessage());
+          return Mono.justOrEmpty((OidcUserInfo) null);
+        });
+  }
+
+  /**
+   * UserInfo와 token으로 {@link KeycloakPrincipal}을 생성합니다.
+   */
+  private OAuth2AuthenticatedPrincipal buildPrincipal(String token, OidcUserInfo oidcUserInfo) {
+    Map<String, Object> claims = (oidcUserInfo != null) ? oidcUserInfo.getClaims() : Map.of();
+    Collection<GrantedAuthority> authorities = KeycloakAuthorityExtractor.extract(claims, clientId);
+
+    String subject = extractSubject(claims);
+    OidcIdToken oidcIdToken = new OidcIdToken(
+        token, Instant.now(), null, Map.of("sub", subject));
+
+    KeycloakPrincipal principal = new KeycloakPrincipal(subject, authorities, oidcIdToken, oidcUserInfo);
+    log.debug("[BearerToken] Introspect 검증 성공. 사용자: {}", subject);
+    return principal;
+  }
+
+  /**
+   * KeycloakUserInfo를 OidcUserInfo로 변환합니다.
+   */
+  private OidcUserInfo convertToOidcUserInfo(KeycloakUserInfo keycloakUserInfo) {
+    Map<String, Object> claims = new HashMap<>();
+    if (keycloakUserInfo.getSubject() != null) {
+      claims.put("sub", keycloakUserInfo.getSubject());
+    }
+    if (keycloakUserInfo.getPreferredUsername() != null) {
+      claims.put("preferred_username", keycloakUserInfo.getPreferredUsername());
+    }
+    if (keycloakUserInfo.getEmail() != null) {
+      claims.put("email", keycloakUserInfo.getEmail());
+    }
+    if (keycloakUserInfo.getName() != null) {
+      claims.put("name", keycloakUserInfo.getName());
+    }
+    claims.putAll(keycloakUserInfo.getOtherInfo());
+    return new OidcUserInfo(claims);
+  }
+
+  private String extractSubject(Map<String, Object> claims) {
+    Object sub = claims.get("sub");
+    return sub != null ? sub.toString() : "unknown";
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakServerAuthenticationConverter.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakServerAuthenticationConverter.java
@@ -1,0 +1,244 @@
+package com.ids.keycloak.security.authentication;
+
+import com.ids.keycloak.security.config.KeycloakCookieProperties;
+import com.ids.keycloak.security.exception.AuthenticationFailedException;
+import com.ids.keycloak.security.exception.RefreshTokenException;
+import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.ids.keycloak.security.session.ReactiveSessionManager;
+import com.ids.keycloak.security.util.ReactiveCookieUtil;
+import com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import java.util.Collections;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebSession;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@link ServerWebExchange}에서 Keycloak 토큰을 추출하는 {@link ServerAuthenticationConverter} 구현체입니다.
+ *
+ * <p>servlet 모듈의 {@code KeycloakAuthenticationFilter} 토큰 추출 + 세션 연동 로직을 Reactive로 포팅합니다.</p>
+ *
+ * <p><b>처리 흐름:</b>
+ * <ol>
+ *   <li>쿠키 또는 WebSession에서 토큰 조회</li>
+ *   <li>ID Token 없음 → Mono.empty() (인증 스킵)</li>
+ *   <li>ID Token 있음 → 세션에서 Refresh Token 확인</li>
+ *   <li>세션 없거나 Refresh Token 없음 → 쿠키 삭제 + Mono.empty()</li>
+ *   <li>인증 요청 객체 생성 → {@link KeycloakReactiveAuthenticationManager}에 위임</li>
+ *   <li>introspect 실패(TokenExpired 등) 시 → Refresh Token으로 재발급 → 응답 쿠키 갱신 후 재인증</li>
+ * </ol>
+ * </p>
+ *
+ * <p>Bearer, Basic, CREDENTIAL_LOGIN 방식은 다른 WebFilter/컨버터가 처리하므로 여기서 처리하지 않습니다.</p>
+ */
+@Slf4j
+public class KeycloakServerAuthenticationConverter implements ServerAuthenticationConverter {
+
+  /** 쿠키에 저장되는 ID Token 이름 */
+  public static final String ID_TOKEN_COOKIE_NAME = "id_token";
+
+  /** 쿠키에 저장되는 Access Token 이름 */
+  public static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+
+  private final KeycloakReactiveAuthenticationManager authManager;
+  private final KeycloakClient keycloakClient;
+  private final ReactiveSessionManager sessionManager;
+  private final KeycloakCookieProperties cookieProperties;
+
+  public KeycloakServerAuthenticationConverter(
+      KeycloakReactiveAuthenticationManager authManager,
+      KeycloakClient keycloakClient,
+      ReactiveSessionManager sessionManager,
+      KeycloakCookieProperties cookieProperties) {
+    this.authManager = authManager;
+    this.keycloakClient = keycloakClient;
+    this.sessionManager = sessionManager;
+    this.cookieProperties = cookieProperties;
+  }
+
+  @Override
+  public Mono<Authentication> convert(ServerWebExchange exchange) {
+    return Mono.defer(() -> {
+      ServerHttpRequest request = exchange.getRequest();
+
+      String idToken = ReactiveCookieUtil.getCookieValue(request, ID_TOKEN_COOKIE_NAME).orElse(null);
+      String accessToken = ReactiveCookieUtil.getCookieValue(request, ACCESS_TOKEN_COOKIE_NAME).orElse(null);
+
+      if (idToken == null || idToken.isBlank()) {
+        log.debug("[Converter] ID Token 쿠키 없음 — 인증 스킵.");
+        return Mono.empty();
+      }
+
+      // WebSession을 비동기로 가져온 뒤, Refresh Token 확인
+      return exchange.getSession()
+          .flatMap(session -> handleWithSession(exchange, session, idToken, accessToken));
+    });
+  }
+
+  /**
+   * WebSession을 확보한 뒤 Refresh Token 기반 인증 처리를 수행합니다.
+   */
+  private Mono<Authentication> handleWithSession(
+      ServerWebExchange exchange,
+      WebSession session,
+      String idToken,
+      String accessToken) {
+
+    Optional<String> refreshTokenOpt = sessionManager.getRefreshToken(session);
+
+    if (refreshTokenOpt.isEmpty()) {
+      log.debug("[Converter] WebSession에 Refresh Token 없음 — 쿠키 삭제 후 인증 스킵.");
+      ReactiveCookieUtil.deleteAllTokenCookies(exchange.getResponse(), cookieProperties);
+      return Mono.empty();
+    }
+
+    String refreshToken = refreshTokenOpt.get();
+    log.debug("[Converter] WebSession에서 Refresh Token 로드 성공. 인증 요청 생성.");
+
+    KeycloakPrincipal tempPrincipal = buildTempPrincipal(idToken);
+    KeycloakAuthentication authRequest = new KeycloakAuthentication(
+        tempPrincipal, idToken, accessToken, false);
+
+    // authManager.authenticate() 내부에서 introspect 실패 시 예외 발생
+    // 예외 발생 → refreshAndAuthenticate로 폴백
+    return authManager.authenticate(authRequest)
+        .onErrorResume(
+            e -> isTokenExpiredOrInvalid(e),
+            e -> {
+              log.warn("[Converter] Introspect 실패, Refresh Token으로 재발급 시도. 원인: {}", e.getMessage());
+              return refreshAndAuthenticate(exchange, session, refreshToken);
+            })
+        .cast(Authentication.class);
+  }
+
+  /**
+   * Refresh Token으로 새 토큰을 발급받고 응답 쿠키를 갱신한 뒤 인증 객체를 반환합니다.
+   */
+  private Mono<Authentication> refreshAndAuthenticate(
+      ServerWebExchange exchange,
+      WebSession session,
+      String refreshToken) {
+
+    log.debug("[Converter] Keycloak에 토큰 재발급 요청...");
+
+    return keycloakClient.authAsync().reissueToken(refreshToken)
+        .flatMap(response -> {
+          int status = response.getStatus();
+
+          if (status == 200) {
+            KeycloakTokenInfo newTokens = response.getBody()
+                .orElseThrow(() -> new RefreshTokenException("토큰 재발급 실패: 응답 본문이 없습니다."));
+
+            log.debug("[Converter] 토큰 재발급 성공. 세션 및 쿠키 업데이트.");
+
+            // 응답 쿠키 갱신
+            int expireTime = newTokens.getExpireTime();
+            ReactiveCookieUtil.addTokenCookies(
+                exchange.getResponse(),
+                newTokens.getAccessToken(), expireTime,
+                newTokens.getIdToken(), expireTime,
+                cookieProperties);
+
+            // H-N1: 새 Refresh Token 세션 저장 후 session.save()를 체인에 포함해 반드시 구독
+            Mono<Void> saveSession = Mono.empty();
+            if (newTokens.getRefreshToken() != null) {
+              sessionManager.saveRefreshToken(session, newTokens.getRefreshToken());
+              saveSession = session.save();
+              log.debug("[Converter] 새 Refresh Token 세션 저장 예약.");
+            }
+
+            // session.save() 완료 후 UserInfo 조회 → 인증 객체 반환
+            return saveSession
+                .then(keycloakClient.userAsync().getUserInfo(newTokens.getAccessToken()))
+                .flatMap(userInfoResponse -> {
+                  org.springframework.security.oauth2.core.oidc.OidcUserInfo oidcUserInfo = null;
+                  if (userInfoResponse.getStatus() == 200) {
+                    com.sd.KeycloakClient.dto.user.KeycloakUserInfo keycloakUserInfo =
+                        userInfoResponse.getBody().orElse(null);
+                    if (keycloakUserInfo != null) {
+                      oidcUserInfo = toOidcUserInfo(keycloakUserInfo);
+                    }
+                  }
+                  Authentication auth = authManager.createAuthenticatedToken(
+                      newTokens.getIdToken(), newTokens.getAccessToken(), oidcUserInfo);
+                  return Mono.just(auth);
+                })
+                .onErrorResume(e -> {
+                  log.warn("[Converter] 재발급 후 UserInfo 조회 실패, 빈 권한으로 진행: {}", e.getMessage());
+                  Authentication auth = authManager.createAuthenticatedToken(
+                      newTokens.getIdToken(), newTokens.getAccessToken(), null);
+                  return Mono.just(auth);
+                });
+
+          } else if (status == 401) {
+            log.warn("[Converter] Refresh Token 만료 또는 유효하지 않음 (401).");
+            ReactiveCookieUtil.deleteAllTokenCookies(exchange.getResponse(), cookieProperties);
+            return sessionManager.invalidateSession(session)
+                .then(Mono.error(new RefreshTokenException("Refresh Token이 만료되었습니다.")));
+          } else {
+            log.error("[Converter] 토큰 재발급 중 예상치 못한 응답. 상태 코드: {}", status);
+            return Mono.<Authentication>error(
+                new AuthenticationFailedException("토큰 재발급 실패. 상태 코드: " + status));
+          }
+        })
+        .onErrorResume(
+            e -> !(e instanceof org.springframework.security.core.AuthenticationException)
+                && !(e instanceof com.ids.keycloak.security.exception.KeycloakSecurityException),
+            e -> {
+              log.error("[Converter] 토큰 재발급 중 통신 오류: {}", e.getMessage());
+              return Mono.error(new AuthenticationFailedException("Keycloak 통신 실패: " + e.getMessage()));
+            });
+  }
+
+  /**
+   * ID Token에서 subject를 파싱하여 임시 Principal을 생성합니다.
+   * 실제 권한/UserInfo는 {@link KeycloakReactiveAuthenticationManager}에서 채워집니다.
+   */
+  private KeycloakPrincipal buildTempPrincipal(String idToken) {
+    String subject = com.ids.keycloak.security.util.JwtUtil.parseSubjectWithoutValidation(idToken);
+    if (subject == null || subject.isBlank()) {
+      subject = "unknown";
+    }
+    return new KeycloakPrincipal(subject, Collections.emptyList(), null, null);
+  }
+
+  /**
+   * 예외가 토큰 만료/유효하지 않음으로 인한 introspect 실패인지 판단합니다.
+   * RefreshToken 재시도 대상 예외: IntrospectionFailed, TokenExpired, NullPointer, UserInfoFetch
+   */
+  private boolean isTokenExpiredOrInvalid(Throwable e) {
+    return e instanceof com.ids.keycloak.security.exception.IntrospectionFailedException
+        || e instanceof com.ids.keycloak.security.exception.TokenExpiredException
+        || e instanceof com.ids.keycloak.security.exception.UserInfoFetchException
+        || e instanceof NullPointerException;
+  }
+
+  /**
+   * KeycloakUserInfo를 OidcUserInfo로 변환합니다 (M-1 재발급 후 권한 채우기용).
+   */
+  private org.springframework.security.oauth2.core.oidc.OidcUserInfo toOidcUserInfo(
+      com.sd.KeycloakClient.dto.user.KeycloakUserInfo src) {
+    java.util.Map<String, Object> claims = new java.util.HashMap<>();
+    if (src.getSubject() != null) {
+      claims.put("sub", src.getSubject());
+    }
+    if (src.getPreferredUsername() != null) {
+      claims.put("preferred_username", src.getPreferredUsername());
+    }
+    if (src.getEmail() != null) {
+      claims.put("email", src.getEmail());
+    }
+    if (src.getName() != null) {
+      claims.put("name", src.getName());
+    }
+    if (src.getOtherInfo() != null) {
+      claims.putAll(src.getOtherInfo());
+    }
+    return new org.springframework.security.oauth2.core.oidc.OidcUserInfo(claims);
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/OidcReactiveLoginSuccessHandler.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/OidcReactiveLoginSuccessHandler.java
@@ -1,0 +1,201 @@
+package com.ids.keycloak.security.authentication;
+
+import com.ids.keycloak.security.config.KeycloakCookieProperties;
+import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.ids.keycloak.security.session.ReactiveSessionManager;
+import com.ids.keycloak.security.util.ReactiveCookieUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.server.authentication.RedirectServerAuthenticationSuccessHandler;
+import org.springframework.security.web.server.authentication.ServerAuthenticationSuccessHandler;
+import reactor.core.publisher.Mono;
+
+/**
+ * OIDC 로그인 성공 후 Access/ID Token을 쿠키에 저장하고 Refresh Token/sid를 세션에 저장하는
+ * Reactive 성공 핸들러입니다.
+ *
+ * <p>servlet 모듈의 {@code OidcLoginSuccessHandler}를 Reactive(WebFlux)로 포팅합니다.
+ * 저장 내용은 servlet과 완전히 동일합니다:
+ * <ul>
+ *   <li>Access Token → {@code access_token} 쿠키 (만료 시각 기반 maxAge)</li>
+ *   <li>ID Token → {@code id_token} 쿠키 (만료 시각 기반 maxAge)</li>
+ *   <li>Refresh Token → WebSession {@code KEYCLOAK_REFRESH_TOKEN}</li>
+ *   <li>Keycloak SID (sid 클레임) → WebSession {@code KEYCLOAK_SESSION_ID}</li>
+ *   <li>Principal Name → WebSession {@code SPRING_SECURITY_CONTEXT} (FindByIndexNameSessionRepository 호환)</li>
+ * </ul>
+ * </p>
+ *
+ * <p>처리 흐름:
+ * <ol>
+ *   <li>{@link OAuth2AuthenticationToken} 타입 확인 → 아니면 기본 리다이렉트만 수행</li>
+ *   <li>Principal이 {@link OidcUser}인지 확인 → 아니면 기본 리다이렉트</li>
+ *   <li>{@link ReactiveOAuth2AuthorizedClientService}에서 {@link OAuth2AuthorizedClient} 조회</li>
+ *   <li>Access Token 쿠키, ID Token 쿠키 발급</li>
+ *   <li>Refresh Token / sid / principalName 세션 저장</li>
+ *   <li>SecurityContext를 {@link KeycloakPrincipal} 기반으로 교체</li>
+ *   <li>defaultSuccessUrl로 리다이렉트</li>
+ * </ol>
+ * </p>
+ */
+@Slf4j
+public class OidcReactiveLoginSuccessHandler implements ServerAuthenticationSuccessHandler {
+
+  private final ReactiveOAuth2AuthorizedClientService authorizedClientService;
+  private final ReactiveSessionManager sessionManager;
+  private final KeycloakCookieProperties cookieProperties;
+  private final RedirectServerAuthenticationSuccessHandler redirectHandler;
+
+  public OidcReactiveLoginSuccessHandler(
+      ReactiveOAuth2AuthorizedClientService authorizedClientService,
+      ReactiveSessionManager sessionManager,
+      KeycloakCookieProperties cookieProperties,
+      String defaultSuccessUrl) {
+    this.authorizedClientService = authorizedClientService;
+    this.sessionManager = sessionManager;
+    this.cookieProperties = cookieProperties;
+    this.redirectHandler = new RedirectServerAuthenticationSuccessHandler(defaultSuccessUrl);
+  }
+
+  @Override
+  public Mono<Void> onAuthenticationSuccess(
+      WebFilterExchange webFilterExchange, Authentication authentication) {
+
+    if (!(authentication instanceof OAuth2AuthenticationToken oauthToken)) {
+      log.warn("[OidcSuccessHandler] OAuth2AuthenticationToken 타입이 아닙니다. type={}",
+          authentication.getClass().getName());
+      return redirectHandler.onAuthenticationSuccess(webFilterExchange, authentication);
+    }
+
+    if (!(oauthToken.getPrincipal() instanceof OidcUser oidcUser)) {
+      log.warn("[OidcSuccessHandler] OidcUser 타입이 아닙니다.");
+      return redirectHandler.onAuthenticationSuccess(webFilterExchange, authentication);
+    }
+
+    log.debug("[OidcSuccessHandler] OIDC 로그인 성공. principal={}", authentication.getName());
+
+    // 1. AuthorizedClient에서 Access Token / Refresh Token 조회
+    return authorizedClientService
+        .loadAuthorizedClient(
+            oauthToken.getAuthorizedClientRegistrationId(),
+            authentication.getName())
+        .flatMap(authorizedClient ->
+            issueTokenCookiesAndSaveSession(
+                webFilterExchange, authentication, oidcUser, authorizedClient))
+        .switchIfEmpty(
+            Mono.defer(() -> {
+              log.warn("[OidcSuccessHandler] AuthorizedClient를 찾을 수 없음. 쿠키 없이 진행합니다.");
+              return issueIdTokenCookieOnly(webFilterExchange, authentication, oidcUser);
+            }));
+  }
+
+  /**
+   * AuthorizedClient가 존재할 때: Access Token 쿠키 + ID Token 쿠키 + 세션 저장 + 리다이렉트.
+   */
+  private Mono<Void> issueTokenCookiesAndSaveSession(
+      WebFilterExchange webFilterExchange,
+      Authentication authentication,
+      OidcUser oidcUser,
+      OAuth2AuthorizedClient authorizedClient) {
+
+    var exchange = webFilterExchange.getExchange();
+
+    if (authorizedClient.getAccessToken() != null) {
+      String accessTokenValue = authorizedClient.getAccessToken().getTokenValue();
+      int accessMaxAge = ReactiveCookieUtil.calculateRestMaxAge(
+          authorizedClient.getAccessToken().getExpiresAt());
+      exchange.getResponse().addCookie(
+          ReactiveCookieUtil.createCookie(
+              ReactiveCookieUtil.ACCESS_TOKEN_NAME, accessTokenValue, accessMaxAge, cookieProperties));
+      log.debug("[OidcSuccessHandler] access_token 쿠키 발급 완료.");
+    } else {
+      log.warn("[OidcSuccessHandler] AccessToken이 null입니다.");
+    }
+
+    // ID Token 쿠키
+    String idTokenValue = oidcUser.getIdToken().getTokenValue();
+    int idMaxAge = ReactiveCookieUtil.calculateRestMaxAge(oidcUser.getIdToken().getExpiresAt());
+    exchange.getResponse().addCookie(
+        ReactiveCookieUtil.createCookie(
+            ReactiveCookieUtil.ID_TOKEN_NAME, idTokenValue, idMaxAge, cookieProperties));
+    log.debug("[OidcSuccessHandler] id_token 쿠키 발급 완료.");
+
+    // KeycloakPrincipal 생성
+    KeycloakPrincipal keycloakPrincipal = toKeycloakPrincipal(oidcUser);
+    OAuth2AuthenticationToken newToken = new OAuth2AuthenticationToken(
+        keycloakPrincipal,
+        keycloakPrincipal.getAuthorities(),
+        ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId());
+
+    // 세션에 Refresh Token / sid / principalName 저장
+    return exchange.getSession()
+        .flatMap(session -> {
+          // Refresh Token 저장
+          if (authorizedClient.getRefreshToken() != null) {
+            sessionManager.saveRefreshToken(session, authorizedClient.getRefreshToken().getTokenValue());
+            log.debug("[OidcSuccessHandler] Refresh Token 세션 저장 완료.");
+          }
+
+          // Principal Name 저장 (FindByIndexNameSessionRepository 호환 — Back-Channel 로그아웃 인덱스)
+          sessionManager.savePrincipalName(session, keycloakPrincipal.getName());
+
+          // Keycloak Session ID (sid 클레임) 저장
+          String keycloakSid = oidcUser.getIdToken().getClaimAsString("sid");
+          if (keycloakSid != null) {
+            sessionManager.saveKeycloakSessionId(session, keycloakSid);
+            log.debug("[OidcSuccessHandler] Keycloak SID 세션 저장 완료: {}", keycloakSid);
+          }
+
+          return session.save();
+        })
+        .then(redirectHandler.onAuthenticationSuccess(webFilterExchange, newToken));
+  }
+
+  /**
+   * AuthorizedClient가 없을 때: ID Token 쿠키만 발급 후 리다이렉트.
+   */
+  private Mono<Void> issueIdTokenCookieOnly(
+      WebFilterExchange webFilterExchange,
+      Authentication authentication,
+      OidcUser oidcUser) {
+
+    var exchange = webFilterExchange.getExchange();
+    String idTokenValue = oidcUser.getIdToken().getTokenValue();
+    int idMaxAge = ReactiveCookieUtil.calculateRestMaxAge(oidcUser.getIdToken().getExpiresAt());
+    exchange.getResponse().addCookie(
+        ReactiveCookieUtil.createCookie(
+            ReactiveCookieUtil.ID_TOKEN_NAME, idTokenValue, idMaxAge, cookieProperties));
+
+    KeycloakPrincipal keycloakPrincipal = toKeycloakPrincipal(oidcUser);
+    OAuth2AuthenticationToken newToken = new OAuth2AuthenticationToken(
+        keycloakPrincipal,
+        keycloakPrincipal.getAuthorities(),
+        ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId());
+
+    return exchange.getSession()
+        .flatMap(session -> {
+          sessionManager.savePrincipalName(session, keycloakPrincipal.getName());
+          String keycloakSid = oidcUser.getIdToken().getClaimAsString("sid");
+          if (keycloakSid != null) {
+            sessionManager.saveKeycloakSessionId(session, keycloakSid);
+          }
+          return session.save();
+        })
+        .then(redirectHandler.onAuthenticationSuccess(webFilterExchange, newToken));
+  }
+
+  /**
+   * OidcUser → KeycloakPrincipal 변환 (servlet OidcLoginSuccessHandler#createKeycloakPrincipal과 동일).
+   */
+  private KeycloakPrincipal toKeycloakPrincipal(OidcUser oidcUser) {
+    return new KeycloakPrincipal(
+        oidcUser.getName(),
+        oidcUser.getAuthorities(),
+        oidcUser.getIdToken(),
+        oidcUser.getUserInfo());
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/ReactiveOidcBackChannelLogoutHandler.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/ReactiveOidcBackChannelLogoutHandler.java
@@ -1,0 +1,189 @@
+package com.ids.keycloak.security.authentication;
+
+import com.ids.keycloak.security.model.KeycloakLogoutToken;
+import com.ids.keycloak.security.session.ReactiveSessionManager;
+import com.ids.keycloak.security.util.JwtUtil;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.server.authentication.logout.ServerLogoutHandler;
+import org.springframework.session.ReactiveFindByIndexNameSessionRepository;
+import org.springframework.session.ReactiveSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * OIDC Back-Channel Logout 요청을 처리하는 Reactive {@link ServerLogoutHandler} 구현체입니다.
+ *
+ * <p>servlet 모듈의 {@code OidcBackChannelSessionLogoutHandler}를 Reactive로 포팅합니다.
+ * Keycloak이 {@code /logout/connect/back-channel/keycloak} 엔드포인트로 POST 요청을 보낼 때
+ * {@code logout_token} JWT를 파싱하여 sub/sid에 해당하는 세션을 {@link ReactiveFindByIndexNameSessionRepository}로 무효화합니다.</p>
+ *
+ * <p><b>처리 흐름:</b>
+ * <ol>
+ *   <li>요청 폼 파라미터에서 {@code logout_token} 추출</li>
+ *   <li>JWT 파싱 → {@link KeycloakLogoutToken} 생성 및 유효성 검증</li>
+ *   <li>sid 있음 → 해당 Keycloak SID 속성을 가진 세션만 삭제</li>
+ *   <li>sid 없음, sub 있음 → 해당 사용자의 모든 세션 삭제</li>
+ *   <li>성공: 200 OK, 실패: 400 Bad Request 응답</li>
+ * </ol>
+ * </p>
+ *
+ * <p><b>의존성 조건:</b> {@code ReactiveFindByIndexNameSessionRepository}는 Spring Session Reactive
+ * (spring-session-core)에 포함됩니다. 사용자가 Redis Reactive 등을 사용할 때만 활성화됩니다.
+ * {@code @ConditionalOnBean(ReactiveFindByIndexNameSessionRepository.class)}로 조건부 등록하세요.</p>
+ *
+ * @see ReactiveBackChannelLogoutEndpointFilter
+ */
+@Slf4j
+public class ReactiveOidcBackChannelLogoutHandler implements ServerLogoutHandler {
+
+  /** 세션에 저장된 Keycloak Session ID 속성 키 (ReactiveSessionManager와 동일) */
+  public static final String KEYCLOAK_SESSION_ID_ATTR = ReactiveSessionManager.KEYCLOAK_SESSION_ID_ATTR;
+
+  private final ReactiveFindByIndexNameSessionRepository<? extends Session> findByIndexNameRepo;
+  private final ReactiveSessionRepository<? extends Session> reactiveRepo;
+
+  /**
+   * @param sessionRepository {@link ReactiveFindByIndexNameSessionRepository}이자
+   *                          {@link ReactiveSessionRepository}이기도 한 구현체
+   *                          (예: Spring Session Redis Reactive)
+   */
+  @SuppressWarnings("unchecked")
+  public ReactiveOidcBackChannelLogoutHandler(
+      ReactiveFindByIndexNameSessionRepository<? extends Session> sessionRepository) {
+    this.findByIndexNameRepo = sessionRepository;
+    // 실제 구현체(예: ReactiveRedisIndexedSessionRepository)는 ReactiveSessionRepository도 구현한다.
+    // 캐스팅 실패 시 ClassCastException이 발생하며, 이는 설정 오류를 의미한다.
+    this.reactiveRepo = (ReactiveSessionRepository<? extends Session>) sessionRepository;
+  }
+
+  /**
+   * Back-Channel logout_token을 파싱하여 해당 세션을 무효화합니다.
+   *
+   * <p>이 핸들러는 {@link ReactiveBackChannelLogoutEndpointFilter}에 의해 호출됩니다.
+   * Authentication principal에 logout_token JWT 문자열이 담겨있습니다.</p>
+   */
+  @Override
+  public Mono<Void> logout(WebFilterExchange webFilterExchange, Authentication authentication) {
+    if (authentication == null) {
+      log.debug("[BackChannelLogoutHandler] Authentication이 null — 처리 스킵");
+      return respondBadRequest(webFilterExchange.getExchange(), "Authentication is null");
+    }
+
+    String logoutTokenJwt = extractLogoutTokenJwt(authentication);
+    if (logoutTokenJwt == null || logoutTokenJwt.isBlank()) {
+      log.warn("[BackChannelLogoutHandler] logout_token을 추출할 수 없음");
+      return respondBadRequest(webFilterExchange.getExchange(), "Missing logout_token");
+    }
+
+    Map<String, Object> claims = JwtUtil.parseClaimsWithoutValidation(logoutTokenJwt);
+    if (claims.isEmpty()) {
+      log.warn("[BackChannelLogoutHandler] logout_token JWT 파싱 실패");
+      return respondBadRequest(webFilterExchange.getExchange(), "Invalid logout_token JWT");
+    }
+
+    KeycloakLogoutToken logoutToken = new KeycloakLogoutToken(claims);
+    if (!logoutToken.isLogoutToken()) {
+      log.warn("[BackChannelLogoutHandler] 유효한 Back-Channel Logout 이벤트가 없음");
+      return respondBadRequest(webFilterExchange.getExchange(), "Not a valid logout token");
+    }
+
+    String subject = logoutToken.getSubject();
+    String keycloakSessionId = logoutToken.getSessionId();
+
+    log.debug("[BackChannelLogoutHandler] Logout Token - sub={}, sid={}", subject, keycloakSessionId);
+
+    if (subject == null && keycloakSessionId == null) {
+      log.warn("[BackChannelLogoutHandler] sub와 sid 모두 없음 — 처리 스킵");
+      return respondBadRequest(webFilterExchange.getExchange(), "logout_token has neither sub nor sid");
+    }
+
+    Mono<Void> revokeAction;
+    if (keycloakSessionId != null && subject != null) {
+      revokeAction = revokeSessionByKeycloakSid(subject, keycloakSessionId);
+    } else if (subject != null) {
+      revokeAction = revokeAllUserSessions(subject);
+    } else {
+      // sid만 있고 sub가 없는 경우는 spec상 드물지만 fallback
+      log.warn("[BackChannelLogoutHandler] sub 없이 sid만 존재 — subject 없이 처리 불가");
+      return respondBadRequest(webFilterExchange.getExchange(), "logout_token missing sub");
+    }
+
+    return revokeAction
+        .then(respondOk(webFilterExchange.getExchange()))
+        .onErrorResume(e -> {
+          log.error("[BackChannelLogoutHandler] 세션 무효화 중 오류: {}", e.getMessage(), e);
+          return respondBadRequest(webFilterExchange.getExchange(), "Session revocation failed");
+        });
+  }
+
+  /**
+   * Authentication 객체에서 logout_token JWT 문자열을 추출합니다.
+   * principal 또는 credentials에서 String을 탐색합니다.
+   */
+  private String extractLogoutTokenJwt(Authentication authentication) {
+    if (authentication.getCredentials() instanceof String jwt) {
+      return jwt;
+    }
+    if (authentication.getPrincipal() instanceof String jwt) {
+      return jwt;
+    }
+    if (authentication.getDetails() instanceof String jwt) {
+      return jwt;
+    }
+    return null;
+  }
+
+  /**
+   * 특정 Keycloak SID(sid)에 해당하는 세션만 삭제합니다.
+   * subject 기준으로 세션 목록을 조회한 뒤 KEYCLOAK_SESSION_ID_ATTR 속성을 비교합니다.
+   */
+  private Mono<Void> revokeSessionByKeycloakSid(String subject, String keycloakSessionId) {
+    return findByIndexNameRepo
+        .findByPrincipalName(subject)
+        .flatMapMany(sessions -> Flux.fromIterable(sessions.entrySet()))
+        .filter(entry -> keycloakSessionId.equals(entry.getValue().getAttribute(KEYCLOAK_SESSION_ID_ATTR)))
+        .flatMap(entry -> {
+          log.debug("[BackChannelLogoutHandler] 세션 삭제 - Spring Session ID: {}, Keycloak SID: {}",
+              entry.getKey(), keycloakSessionId);
+          return reactiveRepo.deleteById(entry.getKey())
+              .doOnSuccess(v -> log.info(
+                  "[BackChannelLogoutHandler] Keycloak SID '{}' 세션 폐기 완료", keycloakSessionId));
+        })
+        .then();
+  }
+
+  /**
+   * 주어진 subject에 해당하는 모든 세션을 삭제합니다.
+   */
+  private Mono<Void> revokeAllUserSessions(String subject) {
+    return findByIndexNameRepo
+        .findByPrincipalName(subject)
+        .flatMapMany(sessions -> Flux.fromIterable(sessions.entrySet()))
+        .flatMap(entry -> {
+          log.debug("[BackChannelLogoutHandler] 세션 삭제 - Session ID: {}", entry.getKey());
+          return reactiveRepo.deleteById(entry.getKey());
+        })
+        .then()
+        .doOnSuccess(v -> log.info("[BackChannelLogoutHandler] subject '{}' 모든 세션 폐기 완료", subject));
+  }
+
+  private Mono<Void> respondOk(ServerWebExchange exchange) {
+    exchange.getResponse().setStatusCode(org.springframework.http.HttpStatus.OK);
+    return exchange.getResponse().setComplete();
+  }
+
+  private Mono<Void> respondBadRequest(ServerWebExchange exchange, String reason) {
+    exchange.getResponse().setStatusCode(org.springframework.http.HttpStatus.BAD_REQUEST);
+    exchange.getResponse().getHeaders().setContentType(MediaType.TEXT_PLAIN);
+    byte[] bytes = reason.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    org.springframework.core.io.buffer.DataBuffer buffer =
+        exchange.getResponse().bufferFactory().wrap(bytes);
+    return exchange.getResponse().writeWith(Mono.just(buffer));
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxConstants.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxConstants.java
@@ -1,0 +1,13 @@
+package com.ids.keycloak.security.config;
+
+/**
+ * Keycloak WebFlux Security 관련 상수를 정의합니다.
+ */
+public final class KeycloakWebFluxConstants {
+
+  private KeycloakWebFluxConstants() {
+  }
+
+  /** 프론트채널 로그아웃 URL */
+  public static final String LOGOUT_URL = "/logout";
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxSecurityConfigurer.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxSecurityConfigurer.java
@@ -1,0 +1,327 @@
+package com.ids.keycloak.security.config;
+
+import com.ids.keycloak.security.authentication.KeycloakReactiveAuthenticationManager;
+import com.ids.keycloak.security.authentication.KeycloakReactiveLogoutHandler;
+import com.ids.keycloak.security.authentication.KeycloakReactiveOpaqueTokenIntrospector;
+import com.ids.keycloak.security.authentication.KeycloakServerAuthenticationConverter;
+import com.ids.keycloak.security.authentication.OidcReactiveLoginSuccessHandler;
+import com.ids.keycloak.security.filter.ReactiveAuthLoggingFilter;
+import com.ids.keycloak.security.filter.ReactiveBackChannelLogoutEndpointFilter;
+import com.ids.keycloak.security.filter.ReactiveBasicAuthenticationFilter;
+import com.ids.keycloak.security.filter.ReactiveLoggingFilter;
+import com.ids.keycloak.security.filter.ReactiveRateLimitFilter;
+import com.ids.keycloak.security.manager.KeycloakReactiveAuthorizationManager;
+import com.ids.keycloak.security.ratelimit.RateLimiter;
+import com.ids.keycloak.security.session.ReactiveSessionManager;
+import com.ids.keycloak.security.util.ReactiveCookieUtil;
+import com.ids.keycloak.security.web.reactive.KeycloakServerAccessDeniedHandler;
+import com.ids.keycloak.security.web.reactive.KeycloakServerAuthenticationEntryPoint;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.oidc.web.server.logout.OidcClientInitiatedServerLogoutSuccessHandler;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.authentication.AuthenticationWebFilter;
+import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+import org.springframework.security.web.server.util.matcher.AndServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.NegatedServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.OrServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
+
+/**
+ * Keycloak 인증에 필요한 설정을 {@link ServerHttpSecurity}에 조립하는 헬퍼 클래스입니다.
+ *
+ * <p>servlet 모듈의 {@code KeycloakHttpConfigurer}에 대응하는 WebFlux 구현체입니다.
+ * OIDC 로그인, 세션 연동, 로깅, 인가, Bearer Token, Basic Auth, Rate Limiting, CSRF,
+ * Front-Channel/Back-Channel 로그아웃을 조건부로 설정합니다.</p>
+ */
+@Slf4j
+public final class KeycloakWebFluxSecurityConfigurer {
+
+  private KeycloakWebFluxSecurityConfigurer() {
+  }
+
+  /**
+   * 전체 Keycloak 보안 설정이 적용된 {@link SecurityWebFilterChain}을 빌드합니다.
+   *
+   * @param http                      {@link ServerHttpSecurity} 인스턴스
+   * @param authenticationManager     {@link KeycloakReactiveAuthenticationManager}
+   * @param entryPoint                인증 실패 핸들러
+   * @param accessDeniedHandler       인가 실패 핸들러
+   * @param securityProperties        Keycloak 보안 설정
+   * @param keycloakClient            Keycloak 클라이언트
+   * @param clientId                  OAuth2 클라이언트 ID
+   * @param sessionManager            Reactive 세션 매니저
+   * @param rateLimiter               Rate Limiter (null 가능, null이면 Rate Limit 비활성)
+   * @param loggingFilter             로깅 WebFilter (null 가능)
+   * @param authLoggingFilter         인증 로깅 WebFilter (null 가능)
+   * @param clientRegistrationRepo    ReactiveClientRegistrationRepository (OIDC 로그인/로그아웃용)
+   * @param authorizedClientService   ReactiveOAuth2AuthorizedClientService (토큰 조회용)
+   * @param backChannelFilter         BackChannel 로그아웃 필터 (null 가능 — Spring Session 없으면 null)
+   * @return 구성된 {@link SecurityWebFilterChain}
+   */
+  public static SecurityWebFilterChain configure(
+      ServerHttpSecurity http,
+      ReactiveAuthenticationManager authenticationManager,
+      KeycloakServerAuthenticationEntryPoint entryPoint,
+      KeycloakServerAccessDeniedHandler accessDeniedHandler,
+      KeycloakSecurityProperties securityProperties,
+      KeycloakClient keycloakClient,
+      String clientId,
+      ReactiveSessionManager sessionManager,
+      RateLimiter rateLimiter,
+      ReactiveLoggingFilter loggingFilter,
+      ReactiveAuthLoggingFilter authLoggingFilter,
+      ReactiveClientRegistrationRepository clientRegistrationRepo,
+      ReactiveOAuth2AuthorizedClientService authorizedClientService,
+      ReactiveBackChannelLogoutEndpointFilter backChannelFilter) throws Exception {
+
+    // 1. SecurityContext를 세션에 저장하지 않음 — 매 요청마다 필터가 인증 처리
+    http.securityContextRepository(NoOpServerSecurityContextRepository.getInstance());
+
+    // 2. 예외 처리기 등록
+    http.exceptionHandling(spec -> spec
+        .authenticationEntryPoint(entryPoint)
+        .accessDeniedHandler(accessDeniedHandler)
+    );
+
+    // 3. 로깅 필터 등록
+    if (loggingFilter != null) {
+      http.addFilterAt(loggingFilter, SecurityWebFiltersOrder.FIRST);
+      log.debug("[Configurer] ReactiveLoggingFilter 등록 완료.");
+    }
+    if (authLoggingFilter != null) {
+      http.addFilterAfter(authLoggingFilter, SecurityWebFiltersOrder.AUTHENTICATION);
+      log.debug("[Configurer] ReactiveAuthLoggingFilter 등록 완료.");
+    }
+
+    // 4. Back-Channel 로그아웃 필터 명시 등록 (H-2: 전역 WebFilter 빈 대신 체인 내 명시 등록)
+    if (backChannelFilter != null) {
+      http.addFilterAt(backChannelFilter, SecurityWebFiltersOrder.FIRST);
+      log.info("[Configurer] ReactiveBackChannelLogoutEndpointFilter 등록 완료.");
+    }
+
+    // 5. Rate Limit 필터 등록 (조건부)
+    KeycloakRateLimitProperties rateLimitProps = securityProperties.getRateLimit();
+    if (rateLimitProps.isEnabled() && rateLimiter != null) {
+      List<String> rateLimitPaths = new ArrayList<>();
+      if (securityProperties.getBearerToken().isEnabled()) {
+        String prefix = securityProperties.getBearerToken().getTokenEndpoint().getPrefix();
+        rateLimitPaths.add(prefix + "/token");
+      }
+      ReactiveRateLimitFilter rateLimitFilter = new ReactiveRateLimitFilter(
+          rateLimiter, rateLimitProps, rateLimitPaths);
+      http.addFilterBefore(rateLimitFilter, SecurityWebFiltersOrder.HTTP_BASIC);
+      log.info("[Configurer] Rate Limit 필터 등록 완료 (대상 경로: {}, Basic 포함: {})",
+          rateLimitPaths, rateLimitProps.isIncludeBasicAuth());
+    }
+
+    // 6. Basic Auth 필터 등록 (조건부)
+    if (securityProperties.getBasicAuth().isEnabled()) {
+      ReactiveBasicAuthenticationFilter basicAuthFilter =
+          new ReactiveBasicAuthenticationFilter(keycloakClient, clientId);
+      http.addFilterAt(basicAuthFilter, SecurityWebFiltersOrder.HTTP_BASIC);
+      log.info("[Configurer] Basic Auth 필터 등록 완료.");
+    }
+
+    // 7. OIDC 쿠키 인증 필터 (AuthenticationWebFilter) 등록
+    if (!(authenticationManager instanceof KeycloakReactiveAuthenticationManager)) {
+      throw new IllegalStateException(
+          "authenticationManager must be KeycloakReactiveAuthenticationManager but was: "
+              + authenticationManager.getClass().getName());
+    }
+    KeycloakServerAuthenticationConverter converter = new KeycloakServerAuthenticationConverter(
+        (KeycloakReactiveAuthenticationManager) authenticationManager,
+        keycloakClient,
+        sessionManager,
+        securityProperties.getCookie());
+
+    AuthenticationWebFilter authFilter = new AuthenticationWebFilter(authenticationManager);
+    authFilter.setServerAuthenticationConverter(converter);
+    http.addFilterAt(authFilter, SecurityWebFiltersOrder.AUTHENTICATION);
+    log.debug("[Configurer] AuthenticationWebFilter (OIDC Cookie) 등록 완료.");
+
+    // 8. CSRF 설정
+    configureCsrf(http, securityProperties);
+
+    // 9. Bearer Token Resource Server 설정 (조건부)
+    if (securityProperties.getBearerToken().isEnabled()) {
+      KeycloakReactiveOpaqueTokenIntrospector introspector =
+          new KeycloakReactiveOpaqueTokenIntrospector(keycloakClient, clientId);
+      http.oauth2ResourceServer(rs -> rs
+          .opaqueToken(opaque -> opaque.introspector(introspector))
+      );
+      log.info("[Configurer] Bearer Token Resource Server (Introspect) 등록 완료.");
+    }
+
+    // 10. OIDC 로그인 (C-1) — Spring Security oauth2Login + 성공 핸들러
+    if (clientRegistrationRepo != null && authorizedClientService != null) {
+      String defaultSuccessUrl = securityProperties.getAuthentication().getDefaultSuccessUrl();
+      OidcReactiveLoginSuccessHandler oidcSuccessHandler = new OidcReactiveLoginSuccessHandler(
+          authorizedClientService,
+          sessionManager,
+          securityProperties.getCookie(),
+          defaultSuccessUrl != null ? defaultSuccessUrl : "/");
+
+      http.oauth2Login(login -> login
+          .authenticationSuccessHandler(oidcSuccessHandler)
+      );
+      log.info("[Configurer] OIDC oauth2Login 등록 완료 (defaultSuccessUrl={}).", defaultSuccessUrl);
+    } else {
+      log.debug("[Configurer] ReactiveClientRegistrationRepository 또는 "
+          + "ReactiveOAuth2AuthorizedClientService가 없어 oauth2Login을 건너뜁니다.");
+    }
+
+    // 11. 로그아웃 설정
+    // 11-1. Front-Channel 로그아웃 핸들러
+    KeycloakReactiveLogoutHandler logoutHandler = new KeycloakReactiveLogoutHandler(
+        keycloakClient, sessionManager, securityProperties.getCookie());
+
+    // 11-2. RP-Initiated 로그아웃 (C-3) — OidcClientInitiatedServerLogoutSuccessHandler
+    if (clientRegistrationRepo != null) {
+      OidcClientInitiatedServerLogoutSuccessHandler oidcLogoutHandler =
+          new OidcClientInitiatedServerLogoutSuccessHandler(clientRegistrationRepo);
+      oidcLogoutHandler.setPostLogoutRedirectUri("{baseUrl}");
+
+      http.logout(logout -> logout
+          .logoutUrl(KeycloakWebFluxConstants.LOGOUT_URL)
+          .logoutHandler(logoutHandler)
+          .logoutSuccessHandler(oidcLogoutHandler)
+      );
+      log.info("[Configurer] RP-Initiated 로그아웃(OidcClientInitiatedServerLogoutSuccessHandler) 등록 완료.");
+    } else {
+      http.logout(logout -> logout
+          .logoutUrl(KeycloakWebFluxConstants.LOGOUT_URL)
+          .logoutHandler(logoutHandler)
+      );
+      log.debug("[Configurer] 기본 로그아웃 핸들러 등록 완료.");
+    }
+
+    // 12. 인가 설정
+    configureAuthorization(http, securityProperties, keycloakClient);
+
+    return http.build();
+  }
+
+  /**
+   * CSRF 설정을 적용합니다.
+   *
+   * <p>API 서버 기본값은 disabled. CSRF 활성화 시 면제 경로를 {@code requireCsrfProtectionMatcher}에
+   * <b>부정 매처(NegatedServerWebExchangeMatcher)</b>로 지정합니다.</p>
+   *
+   * <p><b>면제 대상:</b>
+   * <ul>
+   *   <li>Front-Channel 로그아웃 경로 ({@code /logout})</li>
+   *   <li>Back-Channel 로그아웃 경로 — POST+exact 경로 한정 (M-2 보강)</li>
+   *   <li>Bearer Token 엔드포인트 경로</li>
+   *   <li>사용자 지정 ignorePaths</li>
+   *   <li>Basic Auth 활성화 시 {@code Authorization: Basic} 헤더 보유 요청</li>
+   * </ul>
+   * </p>
+   */
+  private static void configureCsrf(
+      ServerHttpSecurity http, KeycloakSecurityProperties securityProperties) {
+
+    KeycloakCsrfProperties csrfProperties = securityProperties.getCsrf();
+
+    if (!csrfProperties.isEnabled()) {
+      http.csrf(ServerHttpSecurity.CsrfSpec::disable);
+      log.info("[Configurer] CSRF 비활성화.");
+      return;
+    }
+
+    List<String> ignorePaths = new ArrayList<>();
+    ignorePaths.add(KeycloakWebFluxConstants.LOGOUT_URL);
+
+    if (securityProperties.getBearerToken().isEnabled()) {
+      String prefix = securityProperties.getBearerToken().getTokenEndpoint().getPrefix();
+      ignorePaths.add(prefix + "/token");
+      ignorePaths.add(prefix + "/refresh");
+      ignorePaths.add(prefix + "/logout");
+    }
+
+    ignorePaths.addAll(csrfProperties.getIgnorePaths());
+    log.info("[Configurer] CSRF 활성화 (면제 경로: {})", ignorePaths);
+
+    List<ServerWebExchangeMatcher> exemptMatchers = new ArrayList<>();
+    for (String path : ignorePaths) {
+      exemptMatchers.add(new PathPatternParserServerWebExchangeMatcher(path));
+    }
+
+    // M-2: Back-Channel 로그아웃은 POST + exact 경로로 한정
+    exemptMatchers.add(new PathPatternParserServerWebExchangeMatcher(
+        ReactiveBackChannelLogoutEndpointFilter.BACK_CHANNEL_LOGOUT_PATH, HttpMethod.POST));
+
+    if (securityProperties.getBasicAuth().isEnabled()) {
+      ServerWebExchangeMatcher basicAuthMatcher =
+          exchange -> {
+            String auth = exchange.getRequest().getHeaders().getFirst("Authorization");
+            if (auth != null && auth.startsWith("Basic ")) {
+              return ServerWebExchangeMatcher.MatchResult.match();
+            }
+            return ServerWebExchangeMatcher.MatchResult.notMatch();
+          };
+      exemptMatchers.add(basicAuthMatcher);
+    }
+
+    ServerWebExchangeMatcher exemptMatcher = new OrServerWebExchangeMatcher(exemptMatchers);
+    ServerWebExchangeMatcher csrfMatcher = new NegatedServerWebExchangeMatcher(exemptMatcher);
+
+    http.csrf(csrf -> csrf.requireCsrfProtectionMatcher(csrfMatcher));
+  }
+
+  /**
+   * 인가 설정을 적용합니다.
+   */
+  private static void configureAuthorization(
+      ServerHttpSecurity http,
+      KeycloakSecurityProperties securityProperties,
+      KeycloakClient keycloakClient) {
+
+    KeycloakAuthorizationProperties authorizationProps = securityProperties.getAuthorization();
+    List<String> permitAllPaths = securityProperties.getAuthentication().getPermitAllPaths();
+
+    List<String> allPermitPaths = new ArrayList<>(permitAllPaths);
+    if (securityProperties.getBearerToken().isEnabled()) {
+      String prefix = securityProperties.getBearerToken().getTokenEndpoint().getPrefix();
+      allPermitPaths.add(prefix + "/token");
+      allPermitPaths.add(prefix + "/refresh");
+      allPermitPaths.add(prefix + "/logout");
+    }
+    allPermitPaths.add(KeycloakWebFluxConstants.LOGOUT_URL);
+
+    if (authorizationProps.isEnabled()) {
+      KeycloakReactiveAuthorizationManager authorizationManager =
+          new KeycloakReactiveAuthorizationManager(keycloakClient);
+
+      http.authorizeExchange(authorize -> {
+        if (!allPermitPaths.isEmpty()) {
+          String[] paths = allPermitPaths.toArray(new String[0]);
+          authorize.pathMatchers(paths).permitAll();
+          log.info("[Configurer] 인증 제외 경로 설정: {}", allPermitPaths);
+        }
+        authorize.anyExchange().access(authorizationManager);
+        log.info("[Configurer] Keycloak Authorization Manager 적용 완료.");
+      });
+    } else {
+      http.authorizeExchange(authorize -> {
+        if (!allPermitPaths.isEmpty()) {
+          String[] paths = allPermitPaths.toArray(new String[0]);
+          authorize.pathMatchers(paths).permitAll();
+          log.info("[Configurer] 인증 제외 경로 설정: {}", allPermitPaths);
+        }
+        authorize.anyExchange().authenticated();
+      });
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/controller/KeycloakReactiveTokenController.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/controller/KeycloakReactiveTokenController.java
@@ -1,0 +1,218 @@
+package com.ids.keycloak.security.controller;
+
+import com.ids.keycloak.security.dto.ReactiveLogoutRequest;
+import com.ids.keycloak.security.dto.ReactiveRefreshRequest;
+import com.ids.keycloak.security.dto.ReactiveTokenRequest;
+import com.ids.keycloak.security.ratelimit.AuthenticationEventLogger;
+import com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import jakarta.validation.Valid;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.support.WebExchangeBindException;
+import reactor.core.publisher.Mono;
+
+/**
+ * Bearer Token 발급/갱신/로그아웃 REST 컨트롤러의 Reactive 버전입니다.
+ *
+ * <p>servlet 모듈의 {@code KeycloakTokenController}를 Reactive(Mono 반환)로 포팅합니다.
+ * RestTemplate 대신 {@code authAsync()}를 사용하여 Non-blocking으로 동작합니다.
+ * {@code .block()} 호출 없이 완전히 Reactive 체이닝으로 처리합니다.</p>
+ *
+ * <p><b>보안:</b> 토큰 발급/갱신 응답에 {@code Cache-Control: no-store}를 설정합니다.</p>
+ */
+@RestController
+@Slf4j
+public class KeycloakReactiveTokenController {
+
+  private final KeycloakClient keycloakClient;
+  private final String prefix;
+
+  public KeycloakReactiveTokenController(KeycloakClient keycloakClient, String prefix) {
+    this.keycloakClient = keycloakClient;
+    this.prefix = prefix;
+  }
+
+  /**
+   * 토큰 발급: username/password로 Keycloak에 토큰을 요청합니다.
+   * Resource Owner Password Credentials Grant.
+   */
+  @PostMapping("${keycloak.security.bearer-token.token-endpoint.prefix:/auth}/token")
+  public Mono<ResponseEntity<Object>> issueToken(
+      @RequestBody @Valid ReactiveTokenRequest request,
+      ServerHttpRequest httpRequest) {
+
+    String username = request.username();
+    String clientIp = getClientIp(httpRequest);
+
+    log.debug("[TokenAPI] 토큰 발급 요청: username={}", username);
+
+    return keycloakClient.authAsync().basicAuth(username, request.password())
+        .map(response -> {
+          int status = response.getStatus();
+
+          if (status == 200) {
+            KeycloakTokenInfo tokenInfo = response.getBody().orElse(null);
+            if (tokenInfo == null) {
+              AuthenticationEventLogger.logFailure(
+                  AuthenticationEventLogger.METHOD_TOKEN_API, clientIp, username, "empty_response");
+              return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                  .<Object>body(errorBody("server_error", "Empty response from authentication server"));
+            }
+            AuthenticationEventLogger.logSuccess(
+                AuthenticationEventLogger.METHOD_TOKEN_API, clientIp, username);
+            log.debug("[TokenAPI] 토큰 발급 성공.");
+            return (ResponseEntity<Object>) ResponseEntity.ok()
+                .cacheControl(CacheControl.noStore())
+                .<Object>body(buildTokenResponse(tokenInfo));
+          }
+
+          if (status == 401) {
+            AuthenticationEventLogger.logFailure(
+                AuthenticationEventLogger.METHOD_TOKEN_API, clientIp, username, "invalid_credentials");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .<Object>body(errorBody("invalid_grant", "Invalid user credentials"));
+          }
+
+          AuthenticationEventLogger.logFailure(
+              AuthenticationEventLogger.METHOD_TOKEN_API, clientIp, username, "status_" + status);
+          log.warn("[TokenAPI] 토큰 발급 실패. 상태 코드: {}", status);
+          return ResponseEntity.status(status)
+              .<Object>body(errorBody("server_error", "Authentication server error"));
+        })
+        .onErrorResume(e -> {
+          log.error("[TokenAPI] Keycloak 통신 오류: {}", e.getMessage());
+          return Mono.<ResponseEntity<Object>>just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+              .<Object>body(errorBody("server_error", "Failed to communicate with authentication server")));
+        });
+  }
+
+  /**
+   * 토큰 갱신: refreshToken으로 새 access_token을 발급받습니다.
+   * grant_type=refresh_token
+   */
+  @PostMapping("${keycloak.security.bearer-token.token-endpoint.prefix:/auth}/refresh")
+  public Mono<ResponseEntity<Object>> refreshToken(
+      @RequestBody @Valid ReactiveRefreshRequest request) {
+
+    log.debug("[TokenAPI] 토큰 갱신 요청.");
+
+    return keycloakClient.authAsync().reissueToken(request.refreshToken())
+        .map(response -> {
+          int status = response.getStatus();
+
+          if (status == 200) {
+            KeycloakTokenInfo tokenInfo = response.getBody().orElse(null);
+            if (tokenInfo == null) {
+              return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                  .<Object>body(errorBody("server_error", "Empty response from authentication server"));
+            }
+            log.debug("[TokenAPI] 토큰 갱신 성공.");
+            return (ResponseEntity<Object>) ResponseEntity.ok()
+                .cacheControl(CacheControl.noStore())
+                .<Object>body(buildTokenResponse(tokenInfo));
+          }
+
+          if (status == 401) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .<Object>body(errorBody("invalid_grant", "Refresh token is expired or invalid"));
+          }
+
+          log.warn("[TokenAPI] 토큰 갱신 실패. 상태 코드: {}", status);
+          return ResponseEntity.status(status)
+              .<Object>body(errorBody("server_error", "Authentication server error"));
+        })
+        .onErrorResume(e -> {
+          log.error("[TokenAPI] Keycloak 통신 오류: {}", e.getMessage());
+          return Mono.<ResponseEntity<Object>>just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+              .<Object>body(errorBody("server_error", "Failed to communicate with authentication server")));
+        });
+  }
+
+  /**
+   * 로그아웃: refreshToken을 Keycloak에서 폐기합니다.
+   */
+  @PostMapping("${keycloak.security.bearer-token.token-endpoint.prefix:/auth}/logout")
+  public Mono<ResponseEntity<Object>> logout(
+      @RequestBody @Valid ReactiveLogoutRequest request) {
+
+    log.debug("[TokenAPI] 로그아웃 요청.");
+
+    return keycloakClient.authAsync().logout(request.refreshToken())
+        .map(response -> {
+          int status = response.getStatus();
+
+          if (status == 200 || status == 204) {
+            log.debug("[TokenAPI] 로그아웃 성공.");
+            return ResponseEntity.<Object>noContent().build();
+          }
+
+          if (status == 400 || status == 401) {
+            return ResponseEntity.status(status)
+                .<Object>body(errorBody("invalid_grant", "Token is not active"));
+          }
+
+          log.warn("[TokenAPI] 로그아웃 실패. 상태 코드: {}", status);
+          return ResponseEntity.status(status)
+              .<Object>body(errorBody("server_error", "Failed to logout"));
+        })
+        .onErrorResume(e -> {
+          log.error("[TokenAPI] Keycloak 통신 오류: {}", e.getMessage());
+          return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+              .<Object>body(errorBody("server_error", "Failed to communicate with authentication server")));
+        });
+  }
+
+  /**
+   * KeycloakTokenInfo를 Map 응답으로 변환합니다.
+   */
+  private Map<String, Object> buildTokenResponse(KeycloakTokenInfo tokenInfo) {
+    return Map.of(
+        "access_token", tokenInfo.getAccessToken() != null ? tokenInfo.getAccessToken() : "",
+        "refresh_token", tokenInfo.getRefreshToken() != null ? tokenInfo.getRefreshToken() : "",
+        "id_token", tokenInfo.getIdToken() != null ? tokenInfo.getIdToken() : "",
+        "token_type", "Bearer",
+        "expires_in", tokenInfo.getExpireTime()
+    );
+  }
+
+  /**
+   * M-N1: @Valid @NotBlank 위반 시 OAuth2 표준 에러 포맷({@code error/error_description}) + 400 응답.
+   *
+   * <p>Spring 기본 {@code timestamp/status/error/path} 포맷 대신 정상 경로 에러와 동일한
+   * {@code {"error":"invalid_request","error_description":"..."}} 포맷을 반환합니다.</p>
+   */
+  @ExceptionHandler(WebExchangeBindException.class)
+  public ResponseEntity<Map<String, String>> handleValidationException(
+      WebExchangeBindException ex) {
+    String description = ex.getBindingResult().getFieldErrors().stream()
+        .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+        .collect(Collectors.joining(", "));
+    log.debug("[TokenAPI] 요청 파라미터 검증 실패: {}", description);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(errorBody("invalid_request", description));
+  }
+
+  private Map<String, String> errorBody(String error, String description) {
+    return Map.of("error", error, "error_description", description);
+  }
+
+  private String getClientIp(ServerHttpRequest request) {
+    String xff = request.getHeaders().getFirst("X-Forwarded-For");
+    if (xff != null && !xff.isBlank()) {
+      return xff.split(",")[0].trim();
+    }
+    return request.getRemoteAddress() != null
+        ? request.getRemoteAddress().getAddress().getHostAddress()
+        : "unknown";
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/dto/ReactiveLogoutRequest.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/dto/ReactiveLogoutRequest.java
@@ -1,0 +1,14 @@
+package com.ids.keycloak.security.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Bearer Token 로그아웃 요청 DTO.
+ *
+ * <p>servlet 모듈의 {@code LogoutRequest}와 동일한 계약이나,
+ * 모듈 분리 원칙에 따라 webflux 모듈에 별도 정의합니다.</p>
+ */
+public record ReactiveLogoutRequest(
+    @NotBlank(message = "refreshToken은 필수입니다.") String refreshToken
+) {
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/dto/ReactiveRefreshRequest.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/dto/ReactiveRefreshRequest.java
@@ -1,0 +1,14 @@
+package com.ids.keycloak.security.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Bearer Token 갱신 요청 DTO.
+ *
+ * <p>servlet 모듈의 {@code RefreshRequest}와 동일한 계약이나,
+ * 모듈 분리 원칙에 따라 webflux 모듈에 별도 정의합니다.</p>
+ */
+public record ReactiveRefreshRequest(
+    @NotBlank(message = "refreshToken은 필수입니다.") String refreshToken
+) {
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/dto/ReactiveTokenRequest.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/dto/ReactiveTokenRequest.java
@@ -1,0 +1,15 @@
+package com.ids.keycloak.security.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Bearer Token 발급 요청 DTO (Resource Owner Password Credentials).
+ *
+ * <p>servlet 모듈의 {@code TokenRequest}와 동일한 계약이나,
+ * 모듈 분리 원칙에 따라 webflux 모듈에 별도 정의합니다.</p>
+ */
+public record ReactiveTokenRequest(
+    @NotBlank(message = "username은 필수입니다.") String username,
+    @NotBlank(message = "password는 필수입니다.") String password
+) {
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/filter/ReactiveAuthLoggingFilter.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/filter/ReactiveAuthLoggingFilter.java
@@ -1,0 +1,137 @@
+package com.ids.keycloak.security.filter;
+
+import com.ids.keycloak.security.config.KeycloakLoggingProperties;
+import com.ids.keycloak.security.config.KeycloakSecurityProperties;
+import com.ids.keycloak.security.logging.LoggingContextKeys;
+import com.ids.keycloak.security.logging.ReactiveLoggingContextAccessor;
+import com.ids.keycloak.security.model.KeycloakPrincipal;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
+
+/**
+ * 인증 완료 후 사용자 정보를 Reactor Context(MDC 브릿지 포함)에 추가하는 WebFilter입니다.
+ *
+ * <p>servlet 모듈의 {@code MdcAuthenticationFilter}를 Reactive로 포팅합니다.
+ * SecurityContext를 ReactiveSecurityContextHolder에서 비동기로 조회하여
+ * userId, username, sessionId를 Reactor Context에 추가합니다.</p>
+ *
+ * <p><b>구현 패턴:</b> chain.filter(exchange) 완료 후 contextWrite 하는 방식은
+ * 이미 downstream 에서 SecurityContext가 소비된 이후라 userId를 적재할 수 없습니다.
+ * 대신 chain.filter(exchange)를 구독하기 전에 {@code ReactiveSecurityContextHolder.getContext()}를
+ * 실제 구독하여 Reactor Context에 userId/username/sessionId를 주입합니다.</p>
+ *
+ * <p>MDC 정리는 {@link ReactiveLoggingFilter}에서 doFinally 시점에 수행됩니다.</p>
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ReactiveAuthLoggingFilter implements WebFilter, Ordered {
+
+  private final KeycloakSecurityProperties securityProperties;
+
+  @Override
+  public int getOrder() {
+    // ReactiveLoggingFilter(HIGHEST_PRECEDENCE+10) 이후, 인증 필터 이후에 위치
+    return Ordered.HIGHEST_PRECEDENCE + 200;
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    KeycloakLoggingProperties loggingProps = securityProperties.getLogging();
+
+    // ReactiveSecurityContextHolder에서 인증 정보를 실제 구독하여 Reactor Context에 적재한 뒤
+    // chain.filter(exchange)를 실행합니다.
+    return ReactiveSecurityContextHolder.getContext()
+        .map(SecurityContext::getAuthentication)
+        .filter(auth -> auth != null && auth.isAuthenticated()
+            && !(auth instanceof AnonymousAuthenticationToken))
+        .map(auth -> buildAuthContextFromAuth(auth, loggingProps))
+        .defaultIfEmpty(Context.empty())
+        .flatMap(authCtx ->
+            chain.filter(exchange)
+                .contextWrite(ctx -> mergeContext(ctx, authCtx)));
+  }
+
+  /**
+   * Authentication에서 로깅 컨텍스트(userId, username, sessionId)를 Reactor Context로 추출합니다.
+   */
+  private Context buildAuthContextFromAuth(
+      Authentication auth, KeycloakLoggingProperties loggingProps) {
+
+    Object principal = auth.getPrincipal();
+    Map<String, Object> attributes = extractAttributes(principal, auth);
+
+    Context ctx = Context.empty();
+
+    if (attributes == null) {
+      // 속성을 파싱할 수 없는 경우 — auth.getName()으로 username만 적재
+      if (loggingProps.isIncludeUsername()) {
+        ctx = ReactiveLoggingContextAccessor.putValue(
+            ctx, LoggingContextKeys.USERNAME, auth.getName());
+      }
+      return ctx;
+    }
+
+    if (loggingProps.isIncludeUserId()) {
+      Object sub = attributes.get("sub");
+      if (sub != null) {
+        ctx = ReactiveLoggingContextAccessor.putValue(
+            ctx, LoggingContextKeys.USER_ID, sub.toString());
+      }
+    }
+    if (loggingProps.isIncludeUsername()) {
+      Object username = attributes.get("preferred_username");
+      if (username != null) {
+        ctx = ReactiveLoggingContextAccessor.putValue(
+            ctx, LoggingContextKeys.USERNAME, username.toString());
+      }
+    }
+    if (loggingProps.isIncludeSessionId()) {
+      Object sid = attributes.get("sid");
+      if (sid != null) {
+        ctx = ReactiveLoggingContextAccessor.putValue(
+            ctx, LoggingContextKeys.SESSION_ID, sid.toString());
+      }
+    }
+    return ctx;
+  }
+
+  /**
+   * 기존 Reactor Context에 인증 컨텍스트를 병합합니다.
+   */
+  private Context mergeContext(Context existing, Context authCtx) {
+    if (authCtx.isEmpty()) {
+      return existing;
+    }
+    // authCtx의 KEYCLOAK_LOGGING_CONTEXT 맵을 existing에 병합
+    Object loggingMap = authCtx.getOrDefault(ReactiveLoggingContextAccessor.CONTEXT_KEY, null);
+    if (loggingMap == null) {
+      return existing;
+    }
+    return existing.put(ReactiveLoggingContextAccessor.CONTEXT_KEY, loggingMap);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> extractAttributes(Object principal, Authentication auth) {
+    if (principal instanceof KeycloakPrincipal keycloakPrincipal) {
+      return keycloakPrincipal.getAttributes();
+    } else if (principal instanceof OidcUser oidcUser) {
+      return oidcUser.getAttributes();
+    } else if (principal instanceof Jwt jwt) {
+      return (Map<String, Object>) jwt.getClaims();
+    }
+    return null;
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/filter/ReactiveBackChannelLogoutEndpointFilter.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/filter/ReactiveBackChannelLogoutEndpointFilter.java
@@ -1,0 +1,111 @@
+package com.ids.keycloak.security.filter;
+
+import com.ids.keycloak.security.authentication.BackChannelLogoutAuthentication;
+import com.ids.keycloak.security.authentication.ReactiveOidcBackChannelLogoutHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Back-Channel 로그아웃 엔드포인트({@code /logout/connect/back-channel/keycloak})를 처리하는 WebFilter입니다.
+ *
+ * <p>Keycloak이 POST 요청으로 {@code logout_token} 폼 파라미터를 전송하면,
+ * 이 필터가 가로채어 {@link ReactiveOidcBackChannelLogoutHandler}로 위임합니다.</p>
+ *
+ * <p>이 필터가 처리하면 체인을 중단하고 직접 응답합니다(200/400).
+ * 경로가 다르면 다음 필터로 투명하게 통과합니다.</p>
+ *
+ * <p><b>등록 조건:</b> {@code @ConditionalOnBean(ReactiveFindByIndexNameSessionRepository.class)}로
+ * Spring Session Reactive가 활성화된 경우에만 등록됩니다.</p>
+ */
+@Slf4j
+public class ReactiveBackChannelLogoutEndpointFilter implements WebFilter, Ordered {
+
+  /** Keycloak Back-Channel 로그아웃 엔드포인트 경로 */
+  public static final String BACK_CHANNEL_LOGOUT_PATH = "/logout/connect/back-channel/keycloak";
+
+  private final ServerWebExchangeMatcher matcher;
+  private final ReactiveOidcBackChannelLogoutHandler logoutHandler;
+
+  public ReactiveBackChannelLogoutEndpointFilter(
+      ReactiveOidcBackChannelLogoutHandler logoutHandler) {
+    this.logoutHandler = logoutHandler;
+    this.matcher = ServerWebExchangeMatchers
+        .pathMatchers(HttpMethod.POST, BACK_CHANNEL_LOGOUT_PATH);
+  }
+
+  /**
+   * Security 필터 체인 전에 실행되어 Back-Channel 요청을 우선 처리합니다.
+   */
+  @Override
+  public int getOrder() {
+    return Ordered.HIGHEST_PRECEDENCE + 5;
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    return matcher.matches(exchange)
+        .flatMap(result -> {
+          if (!result.isMatch()) {
+            return chain.filter(exchange);
+          }
+          log.debug("[BackChannelEndpoint] Back-Channel 로그아웃 요청 수신: {}",
+              exchange.getRequest().getPath().value());
+          return handleBackChannelLogout(exchange);
+        });
+  }
+
+  /**
+   * 폼 파라미터에서 logout_token을 추출하여 LogoutHandler로 위임합니다.
+   */
+  private Mono<Void> handleBackChannelLogout(ServerWebExchange exchange) {
+    return exchange.getFormData()
+        .flatMap(formData -> {
+          String logoutTokenJwt = extractLogoutToken(formData);
+          if (logoutTokenJwt == null || logoutTokenJwt.isBlank()) {
+            log.warn("[BackChannelEndpoint] logout_token 파라미터 없음");
+            return respondBadRequest(exchange, "Missing logout_token parameter");
+          }
+
+          log.debug("[BackChannelEndpoint] logout_token 수신, 세션 무효화 시작");
+
+          // Authentication 객체에 logout_token JWT를 담아 전달
+          BackChannelLogoutAuthentication authentication =
+              new BackChannelLogoutAuthentication(logoutTokenJwt);
+
+          org.springframework.security.web.server.WebFilterExchange webFilterExchange =
+              new org.springframework.security.web.server.WebFilterExchange(
+                  exchange,
+                  webExchange -> Mono.empty() // chain — 사용하지 않음
+              );
+
+          return logoutHandler.logout(webFilterExchange, authentication);
+        })
+        .onErrorResume(e -> {
+          log.error("[BackChannelEndpoint] Back-Channel 로그아웃 처리 중 오류: {}", e.getMessage(), e);
+          return respondBadRequest(exchange, "Internal error: " + e.getMessage());
+        });
+  }
+
+  private String extractLogoutToken(MultiValueMap<String, String> formData) {
+    return formData.getFirst("logout_token");
+  }
+
+  private Mono<Void> respondBadRequest(ServerWebExchange exchange, String reason) {
+    exchange.getResponse().setStatusCode(HttpStatus.BAD_REQUEST);
+    exchange.getResponse().getHeaders().setContentType(MediaType.TEXT_PLAIN);
+    byte[] bytes = reason.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    org.springframework.core.io.buffer.DataBuffer buffer =
+        exchange.getResponse().bufferFactory().wrap(bytes);
+    return exchange.getResponse().writeWith(Mono.just(buffer));
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/filter/ReactiveBasicAuthenticationFilter.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/filter/ReactiveBasicAuthenticationFilter.java
@@ -1,0 +1,247 @@
+package com.ids.keycloak.security.filter;
+
+import com.ids.keycloak.security.authentication.BasicAuthenticationToken;
+import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.ids.keycloak.security.ratelimit.AuthenticationEventLogger;
+import com.ids.keycloak.security.util.JwtUtil;
+import com.ids.keycloak.security.util.KeycloakAuthorityExtractor;
+import com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo;
+import com.sd.KeycloakClient.dto.user.KeycloakUserInfo;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * {@code Authorization: Basic} 헤더를 파싱하여 Keycloak Direct Access Grants 인증을 시도하는 WebFilter입니다.
+ *
+ * <p>servlet 모듈의 {@code BasicAuthenticationFilter}를 Reactive WebFilter로 포팅합니다.
+ * Basic 헤더가 없으면 다음 필터로 위임하고,
+ * Basic 헤더가 있으면 {@code authAsync().basicAuth(username, password)}를 Non-blocking으로 호출합니다.</p>
+ *
+ * <p>Basic Auth는 Stateless로 동작합니다. 매 요청마다 인증하며 세션을 생성하지 않습니다.</p>
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ReactiveBasicAuthenticationFilter implements WebFilter, Ordered {
+
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+  private static final String BASIC_PREFIX = "Basic ";
+  private static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+
+  private final KeycloakClient keycloakClient;
+  private final String clientId;
+
+  @Override
+  public int getOrder() {
+    // 인증 필터 이전에 위치 (SecurityWebFiltersOrder.AUTHENTICATION 앞)
+    return Ordered.HIGHEST_PRECEDENCE + 100;
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    String authHeader = exchange.getRequest().getHeaders().getFirst(AUTHORIZATION_HEADER);
+
+    // Basic 헤더가 없으면 다음 필터로 위임 (OIDC 쿠키 흐름)
+    if (authHeader == null || !authHeader.startsWith(BASIC_PREFIX)) {
+      return chain.filter(exchange);
+    }
+
+    log.debug("[BasicAuthFilter] Authorization: Basic 헤더 감지. 인증 시도.");
+
+    String clientIp = getClientIp(exchange);
+    String[] credentials = decodeBasicAuth(authHeader);
+
+    if (credentials == null) {
+      log.warn("[BasicAuthFilter] Base64 디코딩 실패 또는 잘못된 형식.");
+      return chain.filter(exchange);
+    }
+
+    String username = credentials[0];
+    String password = credentials[1];
+
+    return keycloakClient.authAsync().basicAuth(username, password)
+        .flatMap(response -> {
+          int status = response.getStatus();
+
+          if (status == 200) {
+            KeycloakTokenInfo tokenInfo = response.getBody().orElse(null);
+            if (tokenInfo == null) {
+              log.warn("[BasicAuthFilter] Basic Auth 성공하였으나 응답 본문이 없습니다.");
+              AuthenticationEventLogger.logFailure(
+                  AuthenticationEventLogger.METHOD_BASIC, clientIp, username, "empty_response");
+              return chain.filter(exchange);
+            }
+
+            // userAsync().getUserInfo(accessToken)으로 상세 권한까지 조회하여 Principal 구성
+            return buildAuthenticationWithUserInfo(username, tokenInfo)
+                .flatMap(auth -> {
+                  log.debug("[BasicAuthFilter] Basic Auth 인증 성공: {}", username);
+                  AuthenticationEventLogger.logSuccess(
+                      AuthenticationEventLogger.METHOD_BASIC, clientIp, username);
+
+                  SecurityContext securityContext = new SecurityContextImpl(auth);
+                  return chain.filter(exchange)
+                      .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(
+                          Mono.just(securityContext)));
+                });
+          }
+
+          if (status == 401) {
+            log.warn("[BasicAuthFilter] Basic Auth 인증 실패 (401): username={}", username);
+            AuthenticationEventLogger.logFailure(
+                AuthenticationEventLogger.METHOD_BASIC, clientIp, username, "invalid_credentials");
+            return chain.filter(exchange);
+          }
+
+          log.warn("[BasicAuthFilter] Basic Auth 예상치 못한 응답: {}", status);
+          AuthenticationEventLogger.logFailure(
+              AuthenticationEventLogger.METHOD_BASIC, clientIp, username, "status_" + status);
+          return chain.filter(exchange);
+        })
+        .onErrorResume(e -> {
+          log.warn("[BasicAuthFilter] Basic Auth 인증 중 오류: {}", e.getMessage());
+          AuthenticationEventLogger.logFailure(
+              AuthenticationEventLogger.METHOD_BASIC, clientIp, username, e.getMessage());
+          return chain.filter(exchange);
+        });
+  }
+
+  /**
+   * Basic Auth 헤더를 Base64 디코딩하여 [username, password] 배열을 반환합니다.
+   * 실패 시 null을 반환합니다.
+   */
+  private String[] decodeBasicAuth(String authHeader) {
+    try {
+      String base64Credentials = authHeader.substring(BASIC_PREFIX.length()).trim();
+      String credentials = new String(
+          Base64.getDecoder().decode(base64Credentials), StandardCharsets.UTF_8);
+      int colonIndex = credentials.indexOf(':');
+      if (colonIndex < 0) {
+        return null;
+      }
+      return new String[]{
+          credentials.substring(0, colonIndex),
+          credentials.substring(colonIndex + 1)
+      };
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Keycloak 토큰 정보로 인증된 {@link Authentication} 객체를 Reactive하게 생성합니다.
+   *
+   * <p>처리 흐름:
+   * <ol>
+   *   <li>ID Token 클레임 파싱으로 subject 추출</li>
+   *   <li>{@code userAsync().getUserInfo(accessToken)}으로 UserInfo 조회 (상세 권한 포함)</li>
+   *   <li>UserInfo 조회 성공 시 UserInfo 클레임 기반 권한 추출, 실패 시 ID Token 클레임 폴백</li>
+   *   <li>{@link KeycloakPrincipal} 생성 후 {@link BasicAuthenticationToken} 반환</li>
+   * </ol>
+   * </p>
+   *
+   * @param username  사용자명 (subject 파싱 실패 시 폴백)
+   * @param tokenInfo Keycloak 토큰 응답
+   * @return 인증된 {@link Authentication}을 담은 {@link Mono}
+   */
+  private Mono<Authentication> buildAuthenticationWithUserInfo(
+      String username, KeycloakTokenInfo tokenInfo) {
+
+    String idToken = tokenInfo.getIdToken();
+    String accessToken = tokenInfo.getAccessToken();
+
+    String subject = JwtUtil.parseSubjectWithoutValidation(idToken);
+    if (subject == null || subject.isBlank()) {
+      subject = username;
+    }
+    final String finalSubject = subject;
+
+    Map<String, Object> idTokenClaims = JwtUtil.parseClaimsWithoutValidation(idToken);
+
+    return keycloakClient.userAsync().getUserInfo(accessToken)
+        .flatMap(userInfoResponse -> {
+          int status = userInfoResponse.getStatus();
+          if (status == 200) {
+            KeycloakUserInfo keycloakUserInfo = userInfoResponse.getBody().orElse(null);
+            if (keycloakUserInfo != null) {
+              log.debug("[BasicAuthFilter] UserInfo 조회 성공: subject={}", finalSubject);
+              OidcUserInfo oidcUserInfo = convertToOidcUserInfo(keycloakUserInfo);
+              // UserInfo 클레임 기반 권한 추출 (상세 권한 포함)
+              Map<String, Object> userInfoClaims = oidcUserInfo.getClaims();
+              // resource_access 등의 권한 클레임은 ID Token에 있으므로 병합
+              Map<String, Object> mergedClaims = new HashMap<>(idTokenClaims);
+              mergedClaims.putAll(userInfoClaims);
+              Collection<GrantedAuthority> authorities =
+                  KeycloakAuthorityExtractor.extract(mergedClaims, clientId);
+              KeycloakPrincipal principal =
+                  new KeycloakPrincipal(finalSubject, authorities, null, oidcUserInfo);
+              return Mono.<Authentication>just(
+                  new BasicAuthenticationToken(principal, idToken, accessToken));
+            }
+          }
+          log.warn("[BasicAuthFilter] UserInfo 조회 실패 (status={}), ID Token 클레임으로 폴백", status);
+          return Mono.just(buildAuthenticationFromIdToken(finalSubject, idToken, accessToken, idTokenClaims));
+        })
+        .onErrorResume(e -> {
+          log.warn("[BasicAuthFilter] UserInfo 조회 중 오류, ID Token 클레임으로 폴백: {}", e.getMessage());
+          return Mono.just(buildAuthenticationFromIdToken(finalSubject, idToken, accessToken, idTokenClaims));
+        });
+  }
+
+  /**
+   * UserInfo 조회 실패 시 ID Token 클레임만으로 인증 객체를 생성하는 폴백 메서드입니다.
+   */
+  private Authentication buildAuthenticationFromIdToken(
+      String subject, String idToken, String accessToken, Map<String, Object> claims) {
+    Collection<GrantedAuthority> authorities = KeycloakAuthorityExtractor.extract(claims, clientId);
+    KeycloakPrincipal principal = new KeycloakPrincipal(subject, authorities, null, null);
+    return new BasicAuthenticationToken(principal, idToken, accessToken);
+  }
+
+  /**
+   * KeycloakUserInfo를 OidcUserInfo로 변환합니다.
+   */
+  private OidcUserInfo convertToOidcUserInfo(KeycloakUserInfo keycloakUserInfo) {
+    Map<String, Object> claims = new HashMap<>();
+    if (keycloakUserInfo.getSubject() != null) {
+      claims.put("sub", keycloakUserInfo.getSubject());
+    }
+    if (keycloakUserInfo.getPreferredUsername() != null) {
+      claims.put("preferred_username", keycloakUserInfo.getPreferredUsername());
+    }
+    if (keycloakUserInfo.getEmail() != null) {
+      claims.put("email", keycloakUserInfo.getEmail());
+    }
+    if (keycloakUserInfo.getName() != null) {
+      claims.put("name", keycloakUserInfo.getName());
+    }
+    claims.putAll(keycloakUserInfo.getOtherInfo());
+    return new OidcUserInfo(claims);
+  }
+
+  private String getClientIp(ServerWebExchange exchange) {
+    String xff = exchange.getRequest().getHeaders().getFirst(X_FORWARDED_FOR_HEADER);
+    if (xff != null && !xff.isBlank()) {
+      return xff.split(",")[0].trim();
+    }
+    return exchange.getRequest().getRemoteAddress() != null
+        ? exchange.getRequest().getRemoteAddress().getAddress().getHostAddress()
+        : "unknown";
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/filter/ReactiveLoggingFilter.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/filter/ReactiveLoggingFilter.java
@@ -1,0 +1,206 @@
+package com.ids.keycloak.security.filter;
+
+import com.ids.keycloak.security.config.KeycloakLoggingProperties;
+import com.ids.keycloak.security.config.KeycloakSecurityProperties;
+import com.ids.keycloak.security.logging.LoggingContextKeys;
+import com.ids.keycloak.security.logging.LoggingValueSanitizer;
+import com.ids.keycloak.security.logging.ReactiveLoggingContextAccessor;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
+
+/**
+ * WebFlux 환경에서 요청 메타데이터를 Reactor Context에 적재하는 로깅 필터입니다.
+ *
+ * <p>servlet 모듈의 {@code MdcRequestFilter}를 Reactive로 포팅합니다.
+ * Reactor에서는 ThreadLocal MDC를 직접 사용할 수 없으므로, 로깅 컨텍스트를
+ * <b>Reactor Context</b>에 저장하고 응답 헤더(X-Request-Id)로 traceId를 회신합니다.</p>
+ *
+ * <p><b>MDC 브릿지 전략 (최소 구현):</b>
+ * Reactor Context → MDC 자동 브릿지는 {@code Hooks.onEachOperator} 또는
+ * {@code CoreSubscriber} 데코레이터로 구현할 수 있으나 복잡도가 높습니다.
+ * 현재는 다음만 보장합니다:
+ * <ul>
+ *   <li>traceId를 Reactor Context에 저장하고 응답 헤더로 회신</li>
+ *   <li>응답 메트릭(status, durationMs) 토글 지원</li>
+ *   <li>exclude-patterns 경로 제외</li>
+ * </ul>
+ * TODO: {@code reactor-tools} or MDC propagation 라이브러리 도입 시 전체 MDC 브릿지 구현 권장.
+ * </p>
+ *
+ * @see ReactiveLoggingContextAccessor
+ * @see ReactiveAuthLoggingFilter
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ReactiveLoggingFilter implements WebFilter, Ordered {
+
+  private static final String X_REQUEST_ID_HEADER = "X-Request-Id";
+  private static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+  private static final String USER_AGENT_HEADER = "User-Agent";
+  private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
+  private final KeycloakSecurityProperties securityProperties;
+  private final LoggingValueSanitizer sanitizer;
+
+  @Override
+  public int getOrder() {
+    return Ordered.HIGHEST_PRECEDENCE + 10;
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    if (isExcluded(exchange.getRequest())) {
+      return chain.filter(exchange);
+    }
+
+    KeycloakLoggingProperties loggingProps = securityProperties.getLogging();
+    long startTime = System.currentTimeMillis();
+
+    // Reactor Context에 로깅 값을 적재
+    Context loggingContext = buildLoggingContext(exchange, loggingProps);
+
+    // traceId 응답 헤더 회신
+    if (loggingProps.isIncludeTraceId() && loggingProps.isReturnTraceIdHeader()) {
+      String traceId = ReactiveLoggingContextAccessor
+          .getLoggingContext(loggingContext)
+          .getOrDefault(LoggingContextKeys.TRACE_ID, "");
+      if (!traceId.isBlank()) {
+        exchange.getResponse().getHeaders().add(X_REQUEST_ID_HEADER, traceId);
+      }
+    }
+
+    return chain.filter(exchange)
+        .doFinally(signal -> {
+          // 응답 메트릭 토글 — 기본 off
+          if (loggingProps.isIncludeResponseMetrics()) {
+            int status = exchange.getResponse().getStatusCode() != null
+                ? exchange.getResponse().getStatusCode().value()
+                : 0;
+            long duration = System.currentTimeMillis() - startTime;
+            log.info("[LoggingFilter] request completed — status={}, durationMs={}", status, duration);
+          }
+        })
+        .contextWrite(ctx -> ctx.putAll(loggingContext));
+  }
+
+  /**
+   * 요청 메타데이터를 Reactor Context 형태로 빌드합니다.
+   */
+  private Context buildLoggingContext(
+      ServerWebExchange exchange, KeycloakLoggingProperties loggingProps) {
+
+    ServerHttpRequest request = exchange.getRequest();
+    Context context = Context.empty();
+
+    // traceId
+    if (loggingProps.isIncludeTraceId()) {
+      String traceId = request.getHeaders().getFirst(X_REQUEST_ID_HEADER);
+      if (traceId == null || traceId.isBlank()) {
+        traceId = UUID.randomUUID().toString();
+      }
+      context = ReactiveLoggingContextAccessor.putValue(context, LoggingContextKeys.TRACE_ID, traceId);
+    }
+
+    // HTTP Method
+    if (loggingProps.isIncludeHttpMethod()) {
+      context = ReactiveLoggingContextAccessor.putValue(
+          context, LoggingContextKeys.HTTP_METHOD, request.getMethod().name());
+    }
+
+    // Request URI
+    if (loggingProps.isIncludeRequestUri()) {
+      context = ReactiveLoggingContextAccessor.putValue(
+          context, LoggingContextKeys.REQUEST_URI, request.getPath().value());
+    }
+
+    // Client IP
+    if (loggingProps.isIncludeClientIp()) {
+      context = ReactiveLoggingContextAccessor.putValue(
+          context, LoggingContextKeys.CLIENT_IP, getClientIp(request));
+    }
+
+    // Query String: URL 디코딩 → 길이 제한 → 마스킹
+    if (loggingProps.isIncludeQueryString()) {
+      String rawQuery = request.getURI().getRawQuery();
+      if (rawQuery != null) {
+        String sanitized = sanitizer.sanitize(
+            LoggingContextKeys.QUERY_STRING,
+            truncate(decode(rawQuery), loggingProps.getMaxQueryLength()));
+        context = ReactiveLoggingContextAccessor.putValue(
+            context, LoggingContextKeys.QUERY_STRING, sanitized);
+      }
+    }
+
+    // User-Agent: 길이 제한 → 마스킹
+    if (loggingProps.isIncludeUserAgent()) {
+      String userAgent = request.getHeaders().getFirst(USER_AGENT_HEADER);
+      if (userAgent != null) {
+        String sanitized = sanitizer.sanitize(
+            LoggingContextKeys.USER_AGENT,
+            truncate(userAgent, loggingProps.getMaxUserAgentLength()));
+        context = ReactiveLoggingContextAccessor.putValue(
+            context, LoggingContextKeys.USER_AGENT, sanitized);
+      }
+    }
+
+    return context;
+  }
+
+  /**
+   * exclude-patterns에 해당하는 경로인지 확인합니다.
+   */
+  private boolean isExcluded(ServerHttpRequest request) {
+    List<String> excludePatterns = securityProperties.getLogging().getExcludePatterns();
+    if (excludePatterns == null || excludePatterns.isEmpty()) {
+      return false;
+    }
+    String path = request.getPath().value();
+    for (String pattern : excludePatterns) {
+      if (PATH_MATCHER.match(pattern, path)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private String getClientIp(ServerHttpRequest request) {
+    String xff = request.getHeaders().getFirst(X_FORWARDED_FOR_HEADER);
+    if (xff != null && !xff.isBlank()) {
+      return xff.split(",")[0].trim();
+    }
+    String remoteAddress = request.getRemoteAddress() != null
+        ? request.getRemoteAddress().getAddress().getHostAddress()
+        : "unknown";
+    return remoteAddress;
+  }
+
+  private String decode(String raw) {
+    if (raw == null || raw.isEmpty()) {
+      return raw;
+    }
+    try {
+      return URLDecoder.decode(raw, StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException e) {
+      return raw;
+    }
+  }
+
+  private String truncate(String value, int maxLength) {
+    if (value == null || value.length() <= maxLength) {
+      return value;
+    }
+    return value.substring(0, maxLength) + "...[truncated]";
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/filter/ReactiveRateLimitFilter.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/filter/ReactiveRateLimitFilter.java
@@ -1,0 +1,231 @@
+package com.ids.keycloak.security.filter;
+
+import com.ids.keycloak.security.config.KeycloakRateLimitProperties;
+import com.ids.keycloak.security.config.RateLimitKeyStrategy;
+import com.ids.keycloak.security.ratelimit.AuthenticationEventLogger;
+import com.ids.keycloak.security.ratelimit.RateLimiter;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * 인증 시도에 대한 Rate Limiting을 수행하는 WebFilter입니다.
+ *
+ * <p>servlet 모듈의 {@code RateLimitFilter}를 Reactive WebFilter로 포팅합니다.
+ * core의 {@link RateLimiter} 인터페이스를 재사용하며,
+ * 토큰 발급 API와 Basic Auth 요청에 대해 브루트포스 공격을 방지합니다.</p>
+ *
+ * <p><b>동작 방식:</b>
+ * <ol>
+ *   <li>요청 전: 차단 여부 확인 (카운트 증가 없음)</li>
+ *   <li>차단 중이면 즉시 429 Too Many Requests 반환</li>
+ *   <li>차단 아니면 다음 필터로 위임</li>
+ *   <li>응답 후: 401/403이면 실패 기록 (post-filter)</li>
+ * </ol>
+ * </p>
+ *
+ * <p>Reactive에서는 응답 상태를 post-filter에서 확인하기 어렵습니다.
+ * 따라서 doFinally로 응답 완료 시점에 상태를 확인하여 실패를 기록합니다.</p>
+ */
+@Slf4j
+public class ReactiveRateLimitFilter implements WebFilter, Ordered {
+
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+  private static final String BASIC_PREFIX = "Basic ";
+  private static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+  private static final byte[] RATE_LIMIT_ERROR_BODY =
+      "{\"error\":\"rate_limit_exceeded\",\"error_description\":\"Too many authentication attempts. Please try again later.\"}"
+          .getBytes(StandardCharsets.UTF_8);
+
+  private final RateLimiter rateLimiter;
+  private final KeycloakRateLimitProperties properties;
+  private final List<String> rateLimitPaths;
+
+  public ReactiveRateLimitFilter(
+      RateLimiter rateLimiter,
+      KeycloakRateLimitProperties properties,
+      List<String> rateLimitPaths) {
+    this.rateLimiter = rateLimiter;
+    this.properties = properties;
+    this.rateLimitPaths = rateLimitPaths;
+  }
+
+  @Override
+  public int getOrder() {
+    // BasicAuth 필터보다 앞에 위치 (차단된 요청은 인증 시도 자체를 하지 않음)
+    return Ordered.HIGHEST_PRECEDENCE + 50;
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    if (!shouldApply(exchange)) {
+      return chain.filter(exchange);
+    }
+
+    String clientIp = getClientIp(exchange);
+    String username = extractUsername(exchange);
+    String authMethod = detectAuthMethod(exchange);
+    RateLimitKeyStrategy strategy = properties.getKeyStrategy();
+
+    // 1단계: 차단 여부만 확인 (카운트 증가 없음)
+    if (isBlocked(strategy, clientIp, username)) {
+      String key = buildPrimaryKey(strategy, clientIp, username);
+      long retryAfter = rateLimiter.getRetryAfterSeconds(key);
+
+      AuthenticationEventLogger.logRateLimited(authMethod, clientIp, username);
+      return writeRateLimitResponse(exchange.getResponse(), retryAfter);
+    }
+
+    // 2단계: 다음 필터 실행 후 응답 상태에 따라 실패 기록
+    return chain.filter(exchange)
+        .doFinally(signal -> {
+          if (exchange.getResponse().getStatusCode() != null) {
+            int status = exchange.getResponse().getStatusCode().value();
+            if (status == 401 || status == 403) {
+              recordFailure(strategy, clientIp, username);
+            }
+          }
+        });
+  }
+
+  /**
+   * Rate Limit을 적용해야 하는 요청인지 확인합니다.
+   */
+  private boolean shouldApply(ServerWebExchange exchange) {
+    String requestPath = exchange.getRequest().getPath().value();
+
+    // Token API 경로 체크
+    for (String path : rateLimitPaths) {
+      if (requestPath.equals(path)) {
+        return true;
+      }
+    }
+
+    // Basic Auth 포함 설정 시, Basic 헤더가 있는 요청도 대상
+    if (properties.isIncludeBasicAuth()) {
+      String authHeader = exchange.getRequest().getHeaders().getFirst(AUTHORIZATION_HEADER);
+      if (authHeader != null && authHeader.startsWith(BASIC_PREFIX)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * 429 Too Many Requests 응답을 작성합니다.
+   */
+  private Mono<Void> writeRateLimitResponse(ServerHttpResponse response, long retryAfter) {
+    response.setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
+    response.getHeaders().add("Retry-After", String.valueOf(retryAfter));
+    response.getHeaders().add("Content-Type", MediaType.APPLICATION_JSON_VALUE);
+    DataBuffer buffer = response.bufferFactory().wrap(RATE_LIMIT_ERROR_BODY);
+    return response.writeWith(Mono.just(buffer));
+  }
+
+  /**
+   * Rate Limit 키 전략에 따라 차단 여부를 판단합니다.
+   */
+  private boolean isBlocked(RateLimitKeyStrategy strategy, String clientIp, String username) {
+    return switch (strategy) {
+      case IP -> rateLimiter.isBlocked("ip:" + clientIp);
+      case USERNAME -> {
+        if (username != null) {
+          yield rateLimiter.isBlocked("user:" + username);
+        }
+        yield rateLimiter.isBlocked("ip:" + clientIp);
+      }
+      case IP_AND_USERNAME -> {
+        if (rateLimiter.isBlocked("ip:" + clientIp)) {
+          yield true;
+        }
+        if (username != null) {
+          yield rateLimiter.isBlocked("user:" + username);
+        }
+        yield false;
+      }
+    };
+  }
+
+  /**
+   * Rate Limit 키 전략에 따라 인증 실패를 기록합니다.
+   */
+  private void recordFailure(RateLimitKeyStrategy strategy, String clientIp, String username) {
+    switch (strategy) {
+      case IP -> rateLimiter.recordFailure("ip:" + clientIp);
+      case USERNAME -> {
+        if (username != null) {
+          rateLimiter.recordFailure("user:" + username);
+        } else {
+          rateLimiter.recordFailure("ip:" + clientIp);
+        }
+      }
+      case IP_AND_USERNAME -> {
+        rateLimiter.recordFailure("ip:" + clientIp);
+        if (username != null) {
+          rateLimiter.recordFailure("user:" + username);
+        }
+      }
+    }
+  }
+
+  /**
+   * Retry-After 계산을 위한 기본 키를 반환합니다.
+   */
+  private String buildPrimaryKey(RateLimitKeyStrategy strategy, String clientIp, String username) {
+    return switch (strategy) {
+      case USERNAME -> username != null ? "user:" + username : "ip:" + clientIp;
+      default -> "ip:" + clientIp;
+    };
+  }
+
+  /**
+   * Basic Auth 헤더에서 username을 추출합니다.
+   */
+  private String extractUsername(ServerWebExchange exchange) {
+    String authHeader = exchange.getRequest().getHeaders().getFirst(AUTHORIZATION_HEADER);
+    if (authHeader != null && authHeader.startsWith(BASIC_PREFIX)) {
+      try {
+        String base64Credentials = authHeader.substring(BASIC_PREFIX.length()).trim();
+        String credentials = new String(
+            Base64.getDecoder().decode(base64Credentials), StandardCharsets.UTF_8);
+        int colonIndex = credentials.indexOf(':');
+        if (colonIndex > 0) {
+          return credentials.substring(0, colonIndex);
+        }
+      } catch (IllegalArgumentException e) {
+        // Base64 디코딩 실패 시 무시
+      }
+    }
+    return null;
+  }
+
+  private String detectAuthMethod(ServerWebExchange exchange) {
+    String authHeader = exchange.getRequest().getHeaders().getFirst(AUTHORIZATION_HEADER);
+    if (authHeader != null && authHeader.startsWith(BASIC_PREFIX)) {
+      return "BASIC";
+    }
+    return "TOKEN_API";
+  }
+
+  private String getClientIp(ServerWebExchange exchange) {
+    String xff = exchange.getRequest().getHeaders().getFirst(X_FORWARDED_FOR_HEADER);
+    if (xff != null && !xff.isBlank()) {
+      return xff.split(",")[0].trim();
+    }
+    return exchange.getRequest().getRemoteAddress() != null
+        ? exchange.getRequest().getRemoteAddress().getAddress().getHostAddress()
+        : "unknown";
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/logging/MdcContextPropagationAccessor.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/logging/MdcContextPropagationAccessor.java
@@ -1,0 +1,143 @@
+package com.ids.keycloak.security.logging;
+
+import io.micrometer.context.ThreadLocalAccessor;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.MDC;
+
+/**
+ * Reactor Context에 저장된 로깅 컨텍스트(KEYCLOAK_LOGGING_CONTEXT)를
+ * MDC(Mapped Diagnostic Context)로 자동 전파하는 {@link ThreadLocalAccessor} 구현체입니다.
+ *
+ * <p>Micrometer Context Propagation SPI({@code io.micrometer:context-propagation})를 통해
+ * {@link reactor.core.publisher.Hooks#enableAutomaticContextPropagation()} 활성화 시
+ * Reactor 연산자 전환 시점마다 이 Accessor가 자동으로 호출되어 MDC를 설정/복원합니다.</p>
+ *
+ * <p><b>작동 원리:</b>
+ * <ol>
+ *   <li>{@link ReactiveLoggingFilter}가 요청마다 Reactor Context에
+ *       {@code KEYCLOAK_LOGGING_CONTEXT} 키로 {@code Map<String,String>}을 적재</li>
+ *   <li>Hooks 활성화 시 {@link ThreadLocalAccessor#restore(Object)} 가 스레드 전환 시마다 호출됨</li>
+ *   <li>해당 스레드의 MDC에 loggingContext 맵이 설정되어 Logback/Log4j 패턴에서 참조 가능</li>
+ *   <li>연산자 종료 시 {@link ThreadLocalAccessor#reset()} 으로 MDC가 정리됨</li>
+ * </ol>
+ * </p>
+ *
+ * <p><b>전역 Hooks 부작용 처리:</b>
+ * {@code Hooks.enableAutomaticContextPropagation()}은 JVM 전역에 영향을 미칩니다.
+ * 라이브러리에서 전역 훅을 설정하는 것은 사용자 코드에 부작용을 줄 수 있습니다.
+ * 이를 최소화하기 위해:
+ * <ul>
+ *   <li>AutoConfiguration의 {@code @PostConstruct}에서 1회만 설정합니다</li>
+ *   <li>멱등성 보장: 이미 활성화되어 있어도 중복 호출은 무해합니다</li>
+ *   <li>opt-out: {@code keycloak.security.logging.mdc-propagation-enabled=false}로 비활성화 가능</li>
+ *   <li>이 Accessor는 {@code KEYCLOAK_LOGGING_CONTEXT} 키에만 동작하므로 다른 컨텍스트에 영향 없음</li>
+ * </ul>
+ * </p>
+ *
+ * @see ReactiveLoggingContextAccessor
+ * @see reactor.core.publisher.Hooks#enableAutomaticContextPropagation()
+ */
+public class MdcContextPropagationAccessor implements ThreadLocalAccessor<Map<String, String>> {
+
+  /**
+   * Reactor Context 키 — {@link ReactiveLoggingContextAccessor#CONTEXT_KEY}와 동일.
+   */
+  public static final String KEY = ReactiveLoggingContextAccessor.CONTEXT_KEY;
+
+  /**
+   * 이 Accessor가 관리하는 MDC 키 목록.
+   * core 모듈의 {@link LoggingContextKeys} 상수들을 열거합니다.
+   * core 모듈 수정 없이 webflux 모듈에서만 관리하기 위해 여기서 정의합니다.
+   */
+  private static final List<String> LOGGING_KEYS = Arrays.asList(
+      LoggingContextKeys.TRACE_ID,
+      LoggingContextKeys.HTTP_METHOD,
+      LoggingContextKeys.REQUEST_URI,
+      LoggingContextKeys.QUERY_STRING,
+      LoggingContextKeys.CLIENT_IP,
+      LoggingContextKeys.USER_AGENT,
+      LoggingContextKeys.STATUS,
+      LoggingContextKeys.DURATION_MS,
+      LoggingContextKeys.USER_ID,
+      LoggingContextKeys.USERNAME,
+      LoggingContextKeys.SESSION_ID
+  );
+
+  /**
+   * ThreadLocalAccessor SPI가 이 accessor를 식별하는 키를 반환합니다.
+   *
+   * @return {@code KEYCLOAK_LOGGING_CONTEXT}
+   */
+  @Override
+  public Object key() {
+    return KEY;
+  }
+
+  /**
+   * 현재 MDC에서 로깅 컨텍스트 맵의 키에 해당하는 항목을 스냅샷으로 캡처합니다.
+   *
+   * <p>이 메서드는 구독자가 다른 스레드로 이동할 때 Reactor가 호출합니다.
+   * MDC에서 로깅 관련 키만 수집하여 반환합니다.</p>
+   *
+   * @return 현재 MDC의 로깅 컨텍스트 스냅샷 (없으면 빈 맵)
+   */
+  @Override
+  public Map<String, String> getValue() {
+    Map<String, String> mdcCopy = MDC.getCopyOfContextMap();
+    if (mdcCopy == null) {
+      return new HashMap<>();
+    }
+    // 라이브러리 로깅 컨텍스트 키에 해당하는 항목만 반환
+    Map<String, String> result = new HashMap<>();
+    for (String key : LOGGING_KEYS) {
+      String value = mdcCopy.get(key);
+      if (value != null) {
+        result.put(key, value);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Reactor Context에서 가져온 로깅 컨텍스트를 현재 스레드의 MDC에 설정합니다.
+   *
+   * <p>스레드 전환 후 구독자가 실행되기 직전 Reactor가 호출합니다.</p>
+   *
+   * @param value Reactor Context에서 전달된 로깅 컨텍스트 맵
+   */
+  @Override
+  public void restore(Map<String, String> value) {
+    if (value == null || value.isEmpty()) {
+      return;
+    }
+    value.forEach(MDC::put);
+  }
+
+  /**
+   * 주어진 값으로 현재 스레드의 MDC를 설정합니다.
+   *
+   * <p>Context Propagation SPI의 {@code setValue(T)} 추상 메서드 구현입니다.
+   * Reactor가 스냅샷에서 값을 복원할 때 {@link #restore(Map)}와 유사하게 호출됩니다.</p>
+   *
+   * @param value 설정할 로깅 컨텍스트 맵
+   */
+  @Override
+  public void setValue(Map<String, String> value) {
+    restore(value);
+  }
+
+  /**
+   * 현재 스레드의 MDC에서 로깅 컨텍스트 키들을 제거합니다.
+   *
+   * <p>연산자 종료 후 Reactor가 호출하여 MDC 누수를 방지합니다.</p>
+   */
+  @Override
+  public void reset() {
+    for (String key : LOGGING_KEYS) {
+      MDC.remove(key);
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/logging/ReactiveLoggingContextAccessor.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/logging/ReactiveLoggingContextAccessor.java
@@ -1,0 +1,92 @@
+package com.ids.keycloak.security.logging;
+
+import java.util.Map;
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+
+/**
+ * WebFlux(Reactive) 환경에서 로깅 컨텍스트를 Reactor Context에 저장/조회하는 구현체입니다.
+ *
+ * <p>Reactor는 스레드-로컬 MDC를 직접 사용할 수 없으므로, {@link Context}를 1차 저장소로 사용합니다.
+ * 로그 출력 직전에 contextView에서 값을 읽어 MDC를 일시적으로 복원하는 패턴을 지원합니다.
+ * ({@link #bridgeToMdc(ContextView)} 참고)</p>
+ *
+ * <p>이 클래스는 {@link LoggingContextAccessor} 인터페이스를 구현하나,
+ * put/get/remove/clear 는 직접 MDC를 사용하지 않고 Reactor Context에서만 동작합니다.
+ * WebFlux 필터에서 직접 사용하기보다는 {@code contextWrite}와 함께 사용합니다.</p>
+ */
+public class ReactiveLoggingContextAccessor implements LoggingContextAccessor {
+
+  /**
+   * Reactor Context 키로 사용되는 로깅 컨텍스트 맵의 키입니다.
+   */
+  public static final String CONTEXT_KEY = "KEYCLOAK_LOGGING_CONTEXT";
+
+  /**
+   * ContextView에서 로깅 컨텍스트 맵을 추출합니다.
+   */
+  @SuppressWarnings("unchecked")
+  public static Map<String, String> getLoggingContext(ContextView contextView) {
+    return contextView.getOrDefault(CONTEXT_KEY, new java.util.HashMap<>());
+  }
+
+  /**
+   * 기존 Context에 로깅 컨텍스트 값을 추가한 새 Context를 반환합니다.
+   */
+  public static Context putValue(Context context, String key, String value) {
+    Map<String, String> existing = context.getOrDefault(CONTEXT_KEY, new java.util.HashMap<>());
+    Map<String, String> updated = new java.util.HashMap<>(existing);
+    updated.put(key, value);
+    return context.put(CONTEXT_KEY, updated);
+  }
+
+  /**
+   * Reactor ContextView의 로깅 컨텍스트를 MDC로 브릿지합니다.
+   *
+   * <p>단일 연산자 단위에서 직전에 호출하면, Reactor 스레드에 관계없이
+   * 해당 스코프에서만 MDC 값이 설정됩니다.</p>
+   *
+   * @param contextView 현재 Reactor ContextView
+   */
+  public static void bridgeToMdc(ContextView contextView) {
+    Map<String, String> loggingCtx = getLoggingContext(contextView);
+    loggingCtx.forEach(org.slf4j.MDC::put);
+  }
+
+  /**
+   * MDC에서 로깅 컨텍스트 키들을 제거합니다.
+   *
+   * @param contextView 현재 Reactor ContextView
+   */
+  public static void clearMdc(ContextView contextView) {
+    Map<String, String> loggingCtx = getLoggingContext(contextView);
+    loggingCtx.keySet().forEach(org.slf4j.MDC::remove);
+  }
+
+  // ===== LoggingContextAccessor 구현 (ThreadLocal MDC 직접 사용 — 폴백용) =====
+  // Reactor 파이프라인 안에서는 contextWrite 패턴을 우선합니다.
+
+  @Override
+  public void put(String key, String value) {
+    if (key != null && value != null) {
+      org.slf4j.MDC.put(key, value);
+    }
+  }
+
+  @Override
+  public String get(String key) {
+    return key != null ? org.slf4j.MDC.get(key) : null;
+  }
+
+  @Override
+  public void remove(String key) {
+    if (key != null) {
+      org.slf4j.MDC.remove(key);
+    }
+  }
+
+  @Override
+  public void clear() {
+    org.slf4j.MDC.clear();
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/manager/KeycloakReactiveAuthorizationManager.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/manager/KeycloakReactiveAuthorizationManager.java
@@ -1,0 +1,104 @@
+package com.ids.keycloak.security.manager;
+
+import com.ids.keycloak.security.authentication.AccessTokenHolder;
+import com.sd.KeycloakClient.dto.auth.KeycloakAuthorizationResult;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.ReactiveAuthorizationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
+import org.springframework.security.web.server.authorization.AuthorizationContext;
+import reactor.core.publisher.Mono;
+
+/**
+ * Keycloak Authorization Services를 사용하여 HTTP 요청에 대한 인가를 수행하는
+ * {@link ReactiveAuthorizationManager} 구현체입니다.
+ *
+ * <p>servlet 모듈의 {@code KeycloakAuthorizationManager}를 Reactive로 포팅합니다.
+ * {@code authAsync().authorization(accessToken, endpoint, method)}를 Mono로 호출하며
+ * {@code .block()} 없이 비동기 체이닝으로 결과를 처리합니다.</p>
+ *
+ * <p>지원 인증 타입:
+ * <ul>
+ *   <li>{@link AccessTokenHolder} — KeycloakAuthentication, BasicAuthenticationToken</li>
+ *   <li>{@link BearerTokenAuthentication} — Spring Security OAuth2 Resource Server</li>
+ * </ul>
+ * </p>
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class KeycloakReactiveAuthorizationManager
+    implements ReactiveAuthorizationManager<AuthorizationContext> {
+
+  private final KeycloakClient keycloakClient;
+
+  /**
+   * 현재 인증된 사용자가 요청한 HTTP 리소스에 접근할 수 있는지 Keycloak에 인가 요청을 보냅니다.
+   *
+   * @param authentication 인증 정보 Mono
+   * @param context        인가 컨텍스트 (HTTP 메서드, 엔드포인트 포함)
+   * @return {@link AuthorizationDecision}을 담은 Mono
+   */
+  @Override
+  public Mono<AuthorizationDecision> check(
+      Mono<Authentication> authentication,
+      AuthorizationContext context) {
+
+    ServerHttpRequest request = context.getExchange().getRequest();
+    String method = request.getMethod().name();
+    String endpoint = request.getPath().value();
+
+    log.debug("[ReactiveAuthorization] 인가 요청 수신: {} {}", method, endpoint);
+
+    return authentication
+        .filter(auth -> auth != null && auth.isAuthenticated())
+        .flatMap(auth -> reactor.core.publisher.Mono.justOrEmpty(extractAccessToken(auth)))
+        .flatMap(accessToken -> {
+          log.debug("[ReactiveAuthorization] Keycloak에 인가 요청...");
+          return keycloakClient.authAsync().authorization(accessToken, endpoint, method)
+              .map(response -> {
+                KeycloakAuthorizationResult result = response.getBody().orElse(null);
+                if (result == null) {
+                  log.warn("[ReactiveAuthorization] Keycloak 인가 응답 본문 없음. 거부 처리: {} {}",
+                      method, endpoint);
+                  return new AuthorizationDecision(false);
+                }
+                boolean granted = result.isGranted();
+                log.debug("[ReactiveAuthorization] Keycloak 인가 결과: {} - {} {}",
+                    granted ? "허용" : "거부", method, endpoint);
+                return new AuthorizationDecision(granted);
+              })
+              .onErrorResume(e -> {
+                log.warn("[ReactiveAuthorization] Keycloak 인가 요청 실패 (통신 오류). 거부 처리: {} {} - {}",
+                    method, endpoint, e.getMessage());
+                return Mono.just(new AuthorizationDecision(false));
+              });
+        })
+        .defaultIfEmpty(new AuthorizationDecision(false))
+        .doOnNext(decision -> {
+          if (!decision.isGranted()) {
+            log.warn("[ReactiveAuthorization] 미인증 또는 지원하지 않는 인증 타입 — 거부: {} {}",
+                method, endpoint);
+          }
+        });
+  }
+
+  /**
+   * 인증 객체에서 Access Token을 추출합니다.
+   */
+  private String extractAccessToken(Authentication auth) {
+    if (auth instanceof AccessTokenHolder holder) {
+      log.debug("[ReactiveAuthorization] AccessTokenHolder 인증 타입: {}",
+          auth.getClass().getSimpleName());
+      return holder.getAccessToken();
+    } else if (auth instanceof BearerTokenAuthentication bearer) {
+      log.debug("[ReactiveAuthorization] BearerTokenAuthentication 인증 타입");
+      return bearer.getToken().getTokenValue();
+    }
+    log.warn("[ReactiveAuthorization] 지원하지 않는 인증 타입: {}", auth.getClass().getSimpleName());
+    return null;
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/ratelimit/AuthenticationEventLogger.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/ratelimit/AuthenticationEventLogger.java
@@ -1,0 +1,41 @@
+package com.ids.keycloak.security.ratelimit;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 인증 이벤트를 표준 포맷으로 로깅하는 유틸리티 클래스입니다.
+ *
+ * <p>servlet 모듈의 {@code AuthenticationEventLogger}와 동일한 상수/메서드를 제공합니다.
+ * WebFlux 모듈에서 재정의하여 core 의존성 없이 독립적으로 사용합니다.</p>
+ */
+@Slf4j
+public final class AuthenticationEventLogger {
+
+  public static final String METHOD_OIDC_COOKIE = "OIDC_COOKIE";
+  public static final String METHOD_BASIC = "BASIC";
+  public static final String METHOD_TOKEN_API = "TOKEN_API";
+  public static final String METHOD_BEARER = "BEARER";
+
+  private AuthenticationEventLogger() {
+  }
+
+  public static void logSuccess(String method, String clientIp, String username) {
+    log.info("[AuthEvent] SUCCESS method={} clientIp={} username={}", method, clientIp, username);
+  }
+
+  public static void logFailure(String method, String clientIp, String username, String reason) {
+    log.warn("[AuthEvent] FAILURE method={} clientIp={} username={} reason={}", method, clientIp, username, reason);
+  }
+
+  public static void logSkipped(String method, String clientIp, String reason) {
+    log.debug("[AuthEvent] SKIPPED method={} clientIp={} reason={}", method, clientIp, reason);
+  }
+
+  public static void logNoSession(String method, String clientIp) {
+    log.debug("[AuthEvent] NO_SESSION method={} clientIp={}", method, clientIp);
+  }
+
+  public static void logRateLimited(String method, String clientIp, String username) {
+    log.warn("[AuthEvent] RATE_LIMITED method={} clientIp={} username={}", method, clientIp, username);
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/ratelimit/InMemoryRateLimiter.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/ratelimit/InMemoryRateLimiter.java
@@ -1,0 +1,171 @@
+package com.ids.keycloak.security.ratelimit;
+
+import jakarta.annotation.PreDestroy;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link ConcurrentHashMap} 기반 인메모리 Rate Limiter 구현체입니다.
+ *
+ * <p>servlet 모듈의 {@code InMemoryRateLimiter}와 동일한 구현입니다.
+ * Sliding Window Counter 알고리즘을 사용하여 인증 실패를 제한합니다.
+ * 윈도우 시간 내에 {@code maxRequests}를 초과하면 {@code blockDurationSeconds} 동안 차단합니다.</p>
+ *
+ * <p>주기적으로 만료된 엔트리를 정리하여 메모리 누수를 방지합니다.</p>
+ */
+@Slf4j
+public class InMemoryRateLimiter implements RateLimiter {
+
+  private final int maxRequests;
+  private final long windowSeconds;
+  private final long blockDurationSeconds;
+
+  private final Map<String, SlidingWindowCounter> counters = new ConcurrentHashMap<>();
+  private final ScheduledExecutorService cleanupExecutor;
+
+  public InMemoryRateLimiter(int maxRequests, long windowSeconds, long blockDurationSeconds) {
+    this.maxRequests = maxRequests;
+    this.windowSeconds = windowSeconds;
+    this.blockDurationSeconds = blockDurationSeconds > 0 ? blockDurationSeconds : windowSeconds;
+
+    this.cleanupExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+      Thread thread = new Thread(r, "reactive-rate-limit-cleanup");
+      thread.setDaemon(true);
+      return thread;
+    });
+    this.cleanupExecutor.scheduleAtFixedRate(this::cleanup, 5, 5, TimeUnit.MINUTES);
+  }
+
+  @Override
+  public boolean isBlocked(String key) {
+    Instant now = Instant.now();
+    SlidingWindowCounter counter = counters.get(key);
+    if (counter == null) {
+      return false;
+    }
+    return counter.isBlocked(now);
+  }
+
+  @Override
+  public void recordFailure(String key) {
+    Instant now = Instant.now();
+    SlidingWindowCounter counter = counters.compute(key, (k, existing) -> {
+      if (existing == null) {
+        return new SlidingWindowCounter(now);
+      }
+      return existing;
+    });
+    counter.recordFailure(now);
+  }
+
+  @Override
+  public long getRetryAfterSeconds(String key) {
+    SlidingWindowCounter counter = counters.get(key);
+    if (counter == null) {
+      return 0;
+    }
+    return counter.getRetryAfterSeconds(Instant.now());
+  }
+
+  private void cleanup() {
+    Instant now = Instant.now();
+    int before = counters.size();
+    counters.entrySet().removeIf(entry -> entry.getValue().isExpired(now));
+    int removed = before - counters.size();
+    if (removed > 0) {
+      log.debug("[RateLimiter] 만료된 엔트리 {}개 정리 (현재: {}개)", removed, counters.size());
+    }
+  }
+
+  @PreDestroy
+  public void shutdown() {
+    cleanupExecutor.shutdown();
+    try {
+      if (!cleanupExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+        cleanupExecutor.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      cleanupExecutor.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Sliding Window Counter.
+   */
+  private class SlidingWindowCounter {
+
+    private volatile long windowStart;
+    private final AtomicInteger count;
+    private volatile long blockedUntil;
+
+    SlidingWindowCounter(Instant now) {
+      this.windowStart = now.getEpochSecond();
+      this.count = new AtomicInteger(0);
+      this.blockedUntil = 0;
+    }
+
+    synchronized boolean isBlocked(Instant now) {
+      long nowEpoch = now.getEpochSecond();
+      if (blockedUntil > 0 && nowEpoch < blockedUntil) {
+        return true;
+      }
+      if (blockedUntil > 0 && nowEpoch >= blockedUntil) {
+        resetWindow(nowEpoch);
+        return false;
+      }
+      if (nowEpoch - windowStart >= windowSeconds) {
+        resetWindow(nowEpoch);
+        return false;
+      }
+      return false;
+    }
+
+    synchronized void recordFailure(Instant now) {
+      long nowEpoch = now.getEpochSecond();
+      if (blockedUntil > 0 && nowEpoch < blockedUntil) {
+        return;
+      }
+      if (blockedUntil > 0 && nowEpoch >= blockedUntil) {
+        resetWindow(nowEpoch);
+      }
+      if (nowEpoch - windowStart >= windowSeconds) {
+        resetWindow(nowEpoch);
+      }
+      int currentCount = count.incrementAndGet();
+      if (currentCount > maxRequests) {
+        blockedUntil = nowEpoch + blockDurationSeconds;
+        log.debug("[RateLimiter] 차단 시작: 윈도우 내 실패 {}회 초과 (최대: {}), 차단 해제: {}초 후",
+            currentCount, maxRequests, blockDurationSeconds);
+      }
+    }
+
+    long getRetryAfterSeconds(Instant now) {
+      long nowEpoch = now.getEpochSecond();
+      if (blockedUntil > 0 && nowEpoch < blockedUntil) {
+        return blockedUntil - nowEpoch;
+      }
+      return 0;
+    }
+
+    boolean isExpired(Instant now) {
+      long nowEpoch = now.getEpochSecond();
+      if (blockedUntil > 0) {
+        return nowEpoch >= blockedUntil + windowSeconds;
+      }
+      return nowEpoch - windowStart >= windowSeconds * 2;
+    }
+
+    private void resetWindow(long nowEpoch) {
+      windowStart = nowEpoch;
+      count.set(0);
+      blockedUntil = 0;
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/ratelimit/RateLimiter.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/ratelimit/RateLimiter.java
@@ -1,0 +1,38 @@
+package com.ids.keycloak.security.ratelimit;
+
+/**
+ * Rate Limiting 판단을 수행하는 인터페이스입니다.
+ *
+ * <p>servlet 모듈의 {@code RateLimiter}와 동일한 계약(contract)을 WebFlux 모듈에서 재정의합니다.
+ * 기본 구현체로 {@link InMemoryRateLimiter}가 제공되며,
+ * 분산 환경에서는 Redis 기반 등 커스텀 구현체를 빈으로 등록하여 교체할 수 있습니다.</p>
+ *
+ * <p>브루트포스 방지 목적이므로 인증 실패 시에만 카운트합니다.</p>
+ */
+public interface RateLimiter {
+
+  /**
+   * 해당 키가 현재 차단 상태인지 확인합니다.
+   * 카운트를 증가시키지 않고 차단 여부만 판단합니다.
+   *
+   * @param key rate limit 키 (IP, username, 또는 복합)
+   * @return 차단 중이면 true, 허용이면 false
+   */
+  boolean isBlocked(String key);
+
+  /**
+   * 인증 실패를 기록합니다. 실패 카운트를 증가시키고,
+   * 임계치 초과 시 차단 상태로 전환합니다.
+   *
+   * @param key rate limit 키 (IP, username, 또는 복합)
+   */
+  void recordFailure(String key);
+
+  /**
+   * 차단 해제까지 남은 시간(초)을 반환합니다.
+   *
+   * @param key rate limit 키
+   * @return 남은 차단 시간(초), 차단 중이 아니면 0
+   */
+  long getRetryAfterSeconds(String key);
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/session/ReactiveSessionManager.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/session/ReactiveSessionManager.java
@@ -1,0 +1,132 @@
+package com.ids.keycloak.security.session;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.web.server.WebSession;
+import reactor.core.publisher.Mono;
+
+/**
+ * WebFlux {@link WebSession} 기반 Keycloak 세션 데이터 관리자입니다.
+ *
+ * <p>servlet 모듈의 {@code KeycloakSessionManager}를 Reactive로 포팅합니다.
+ * WebSession은 Non-blocking 방식으로 접근하며, 데이터 자체는 동기적으로 읽고 씁니다.</p>
+ *
+ * <p>저장 데이터:
+ * <ul>
+ *   <li>Refresh Token — 토큰 갱신에 사용</li>
+ *   <li>Keycloak Session ID(sid) — Back-Channel 로그아웃에 사용</li>
+ * </ul>
+ * </p>
+ */
+@Slf4j
+public class ReactiveSessionManager {
+
+  /** 세션에 Refresh Token을 저장하는 키 */
+  public static final String REFRESH_TOKEN_ATTR = "KEYCLOAK_REFRESH_TOKEN";
+
+  /** 세션에 Keycloak Session ID를 저장하는 키 */
+  public static final String KEYCLOAK_SESSION_ID_ATTR = "KEYCLOAK_SESSION_ID";
+
+  /**
+   * WebSession에서 Refresh Token을 조회합니다.
+   *
+   * @param session WebSession
+   * @return Refresh Token (Optional)
+   */
+  public Optional<String> getRefreshToken(WebSession session) {
+    if (session == null) {
+      return Optional.empty();
+    }
+    String refreshToken = session.getAttribute(REFRESH_TOKEN_ATTR);
+    return Optional.ofNullable(refreshToken);
+  }
+
+  /**
+   * WebSession에 Refresh Token을 저장합니다.
+   *
+   * @param session      WebSession
+   * @param refreshToken 저장할 Refresh Token
+   */
+  public void saveRefreshToken(WebSession session, String refreshToken) {
+    if (session == null || refreshToken == null) {
+      log.warn("[ReactiveSessionManager] session 또는 refreshToken이 null입니다.");
+      return;
+    }
+    session.getAttributes().put(REFRESH_TOKEN_ATTR, refreshToken);
+    log.debug("[ReactiveSessionManager] Refresh Token 저장 완료.");
+  }
+
+  /**
+   * WebSession에서 Refresh Token을 제거합니다.
+   *
+   * @param session WebSession
+   */
+  public void removeRefreshToken(WebSession session) {
+    if (session == null) {
+      return;
+    }
+    session.getAttributes().remove(REFRESH_TOKEN_ATTR);
+    log.debug("[ReactiveSessionManager] Refresh Token 삭제 완료.");
+  }
+
+  /**
+   * WebSession에 Keycloak Session ID(sid)를 저장합니다.
+   *
+   * @param session           WebSession
+   * @param keycloakSessionId Keycloak sid 클레임 값
+   */
+  public void saveKeycloakSessionId(WebSession session, String keycloakSessionId) {
+    if (session == null || keycloakSessionId == null) {
+      return;
+    }
+    session.getAttributes().put(KEYCLOAK_SESSION_ID_ATTR, keycloakSessionId);
+    log.debug("[ReactiveSessionManager] Keycloak Session ID 저장: {}", keycloakSessionId);
+  }
+
+  /**
+   * WebSession에서 Keycloak Session ID를 조회합니다.
+   *
+   * @param session WebSession
+   * @return Keycloak Session ID (Optional)
+   */
+  public Optional<String> getKeycloakSessionId(WebSession session) {
+    if (session == null) {
+      return Optional.empty();
+    }
+    String sid = session.getAttribute(KEYCLOAK_SESSION_ID_ATTR);
+    return Optional.ofNullable(sid);
+  }
+
+  /**
+   * WebSession에 Principal Name을 저장합니다.
+   * Back-Channel 로그아웃 시 세션 검색에 사용됩니다.
+   *
+   * @param session       WebSession
+   * @param principalName 사용자 식별자
+   */
+  public void savePrincipalName(WebSession session, String principalName) {
+    if (session == null || principalName == null) {
+      return;
+    }
+    session.getAttributes().put(
+        FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, principalName);
+    log.debug("[ReactiveSessionManager] Principal Name 저장: {}", principalName);
+  }
+
+  /**
+   * WebSession을 무효화합니다.
+   *
+   * @param session WebSession
+   * @return 완료를 나타내는 Mono
+   */
+  public Mono<Void> invalidateSession(WebSession session) {
+    if (session == null) {
+      log.debug("[ReactiveSessionManager] 무효화할 세션이 없습니다.");
+      return Mono.empty();
+    }
+    String sessionId = session.getId();
+    return session.invalidate()
+        .doOnSuccess(v -> log.debug("[ReactiveSessionManager] 세션 무효화 완료. Session ID: {}", sessionId));
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/util/ReactiveCookieUtil.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/util/ReactiveCookieUtil.java
@@ -1,0 +1,135 @@
+package com.ids.keycloak.security.util;
+
+import com.ids.keycloak.security.config.KeycloakCookieProperties;
+import java.time.Instant;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.util.StringUtils;
+
+/**
+ * WebFlux 환경에서 쿠키를 조작하는 유틸리티 클래스입니다.
+ *
+ * <p>servlet 모듈의 {@code CookieUtil}을 Reactive {@link ServerHttpRequest}/{@link ServerHttpResponse}로 포팅합니다.
+ * Reactive에서는 {@link ResponseCookie}를 사용하며, servlet의 {@code Cookie}와 달리
+ * SameSite 속성을 직접 지원합니다.</p>
+ */
+@Slf4j
+public final class ReactiveCookieUtil {
+
+  public static final String ID_TOKEN_NAME = "id_token";
+  public static final String ACCESS_TOKEN_NAME = "access_token";
+
+  private ReactiveCookieUtil() {
+  }
+
+  /**
+   * 설정 기반으로 {@link ResponseCookie}를 생성합니다.
+   *
+   * @param name       쿠키 이름
+   * @param value      쿠키 값
+   * @param maxAge     쿠키 만료 시간(초), 0이면 즉시 삭제
+   * @param properties 쿠키 설정 프로퍼티
+   * @return 생성된 ResponseCookie
+   */
+  public static ResponseCookie createCookie(
+      String name, String value, int maxAge, KeycloakCookieProperties properties) {
+
+    ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value != null ? value : "")
+        .httpOnly(properties.isHttpOnly())
+        .secure(properties.isSecure())
+        .path(properties.getPath())
+        .maxAge(maxAge);
+
+    if (StringUtils.hasText(properties.getDomain())) {
+      builder.domain(properties.getDomain());
+    }
+    if (StringUtils.hasText(properties.getSameSite())) {
+      builder.sameSite(properties.getSameSite());
+    }
+
+    if (log.isTraceEnabled()) {
+      log.trace("쿠키 생성: name={}, path={}, maxAge={}, secure={}, httpOnly={}",
+          name, properties.getPath(), maxAge, properties.isSecure(), properties.isHttpOnly());
+    }
+    return builder.build();
+  }
+
+  /**
+   * Access Token과 ID Token 쿠키를 응답에 추가합니다.
+   *
+   * @param response     ServerHttpResponse
+   * @param accessToken  Access Token 값
+   * @param accessMaxAge Access Token 만료 시간(초)
+   * @param idToken      ID Token 값
+   * @param idMaxAge     ID Token 만료 시간(초)
+   * @param properties   쿠키 설정
+   */
+  public static void addTokenCookies(
+      ServerHttpResponse response,
+      String accessToken, int accessMaxAge,
+      String idToken, int idMaxAge,
+      KeycloakCookieProperties properties) {
+
+    log.debug("[ReactiveCookieUtil] Access Token / ID Token 쿠키 추가.");
+    response.addCookie(createCookie(ACCESS_TOKEN_NAME, accessToken, accessMaxAge, properties));
+    response.addCookie(createCookie(ID_TOKEN_NAME, idToken, idMaxAge, properties));
+  }
+
+  /**
+   * 모든 토큰 쿠키를 삭제합니다(maxAge=0으로 덮어씀).
+   *
+   * @param response   ServerHttpResponse
+   * @param properties 쿠키 설정
+   */
+  public static void deleteAllTokenCookies(
+      ServerHttpResponse response, KeycloakCookieProperties properties) {
+
+    log.debug("[ReactiveCookieUtil] 모든 토큰 쿠키 삭제 요청.");
+    response.addCookie(createCookie(ACCESS_TOKEN_NAME, null, 0, properties));
+    response.addCookie(createCookie(ID_TOKEN_NAME, null, 0, properties));
+  }
+
+  /**
+   * 요청에서 특정 이름의 쿠키 값을 조회합니다.
+   *
+   * @param request 요청 객체
+   * @param name    쿠키 이름
+   * @return 쿠키 값 (Optional)
+   */
+  public static Optional<String> getCookieValue(ServerHttpRequest request, String name) {
+    HttpCookie cookie = request.getCookies().getFirst(name);
+    if (cookie != null && StringUtils.hasText(cookie.getValue())) {
+      return Optional.of(cookie.getValue());
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * 만료 시각(Epoch Second)을 기준으로 남은 수명을 계산합니다.
+   *
+   * @param expireTimeEpochSecond 만료 시각 (Epoch Second)
+   * @return 남은 시간 (초), 0 이상
+   */
+  public static int calculateRestMaxAge(long expireTimeEpochSecond) {
+    long now = Instant.now().getEpochSecond();
+    long diff = expireTimeEpochSecond - now;
+    return diff > 0 ? (int) diff : 0;
+  }
+
+  /**
+   * Instant 기준으로 남은 수명을 계산합니다.
+   *
+   * @param expiresAt 만료 시각 (null이면 -1 반환 — 세션 쿠키)
+   * @return 남은 시간 (초)
+   */
+  public static int calculateRestMaxAge(Instant expiresAt) {
+    if (expiresAt == null) {
+      return -1;
+    }
+    return calculateRestMaxAge(expiresAt.getEpochSecond());
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/web/reactive/KeycloakServerAuthenticationEntryPoint.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/web/reactive/KeycloakServerAuthenticationEntryPoint.java
@@ -2,11 +2,14 @@ package com.ids.keycloak.security.web.reactive;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ids.keycloak.security.config.KeycloakErrorProperties;
 import com.ids.keycloak.security.exception.ErrorCode;
 import com.ids.keycloak.security.exception.KeycloakSecurityException;
-import lombok.RequiredArgsConstructor;
+import java.net.URI;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.security.core.AuthenticationException;
@@ -15,59 +18,184 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 /**
- * Reactive 환경에서 인증(Authentication) 과정에서 실패하는 경우 호출되는 핸들러
+ * Reactive 환경에서 인증(Authentication) 실패 시 호출되는 핸들러입니다.
+ *
+ * <p>servlet 모듈의 {@code KeycloakAuthenticationEntryPoint}를 WebFlux로 포팅합니다.
+ * 요청 유형에 따라 다음 분기를 수행합니다:
+ * <ol>
+ *   <li>Bearer Token 요청 ({@code Authorization: Bearer}) → WWW-Authenticate: Bearer 헤더 + 401</li>
+ *   <li>Basic Auth 요청 ({@code Authorization: Basic}, basicAuthEnabled=true) → WWW-Authenticate: Basic realm 헤더</li>
+ *   <li>redirect-enabled=true + AJAX 요청 + ajaxReturnsJson=true → 401 JSON</li>
+ *   <li>redirect-enabled=true (비-AJAX) → 로그인/세션만료 URL로 리다이렉트</li>
+ *   <li>그 외 (API 모드) → 401 JSON</li>
+ * </ol>
+ * </p>
  */
-@RequiredArgsConstructor
+@Slf4j
 public class KeycloakServerAuthenticationEntryPoint implements ServerAuthenticationEntryPoint {
 
-    private final ObjectMapper objectMapper;
+  private static final String BEARER_PREFIX = "Bearer ";
+  private static final String BASIC_PREFIX = "Basic ";
+  private static final String AJAX_HEADER = "X-Requested-With";
+  private static final String AJAX_HEADER_VALUE = "XMLHttpRequest";
 
-    @Override
-    public Mono<Void> commence(ServerWebExchange exchange, AuthenticationException ex) {
-        return Mono.defer(() -> {
-            ServerHttpResponse response = exchange.getResponse();
-            response.getHeaders().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+  private final ObjectMapper objectMapper;
+  private final KeycloakErrorProperties errorProperties;
+  private final boolean basicAuthEnabled;
+  private final String realmName;
 
-            ErrorCode errorCode;
-            String message;
+  /**
+   * API 모드(redirect 없음) 기본 생성자.
+   */
+  public KeycloakServerAuthenticationEntryPoint(ObjectMapper objectMapper) {
+    this(objectMapper, new KeycloakErrorProperties(), false, null);
+  }
 
-            if (ex.getCause() instanceof KeycloakSecurityException) {
-                KeycloakSecurityException cause = (KeycloakSecurityException) ex.getCause();
-                errorCode = cause.getErrorCode();
-                message = errorCode.getDefaultMessage();
-            } else {
-                errorCode = ErrorCode.AUTHENTICATION_FAILED;
-                message = ex.getMessage();
-            }
+  /**
+   * 전체 분기 지원 생성자.
+   *
+   * @param objectMapper      JSON 직렬화
+   * @param errorProperties   redirect/ajaxReturnsJson/URL 설정
+   * @param basicAuthEnabled  Basic Auth 요청 분기 활성 여부
+   * @param realmName         WWW-Authenticate: Basic realm 이름
+   */
+  public KeycloakServerAuthenticationEntryPoint(
+      ObjectMapper objectMapper,
+      KeycloakErrorProperties errorProperties,
+      boolean basicAuthEnabled,
+      String realmName) {
+    this.objectMapper = objectMapper;
+    this.errorProperties = errorProperties;
+    this.basicAuthEnabled = basicAuthEnabled;
+    this.realmName = realmName;
+  }
 
-            response.setRawStatusCode(errorCode.getHttpStatus());
+  @Override
+  public Mono<Void> commence(ServerWebExchange exchange, AuthenticationException ex) {
+    return Mono.defer(() -> {
+      ServerHttpResponse response = exchange.getResponse();
+      String authHeader = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
 
-            try {
-                byte[] bytes = objectMapper.writeValueAsBytes(new ErrorResponse(errorCode.getCode(), message));
-                DataBuffer buffer = response.bufferFactory().wrap(bytes);
-                return response.writeWith(Mono.just(buffer));
-            } catch (JsonProcessingException e) {
-                // 직렬화 실패 시, 내부 서버 에러로 처리
-                response.setRawStatusCode(ErrorCode.CONFIGURATION_ERROR.getHttpStatus());
-                byte[] bytes = getFallbackErrorResponse(ErrorCode.CONFIGURATION_ERROR);
-                DataBuffer buffer = response.bufferFactory().wrap(bytes);
-                return response.writeWith(Mono.just(buffer));
-            }
-        });
-    }
+      // 1. Bearer Token 요청 → WWW-Authenticate: Bearer 위임
+      if (authHeader != null && authHeader.startsWith(BEARER_PREFIX)) {
+        log.debug("[EntryPoint] Bearer Token 요청 감지 — WWW-Authenticate: Bearer 응답");
+        response.setStatusCode(HttpStatus.UNAUTHORIZED);
+        response.getHeaders().set(HttpHeaders.WWW_AUTHENTICATE,
+            "Bearer realm=\"" + getRealmName() + "\", error=\"invalid_token\"");
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+        return writeJsonError(response, resolveErrorCode(ex), ex.getMessage());
+      }
 
-    private byte[] getFallbackErrorResponse(ErrorCode errorCode) {
-        try {
-            return objectMapper.writeValueAsBytes(new ErrorResponse(errorCode.getCode(), errorCode.getDefaultMessage()));
-        } catch (JsonProcessingException e) {
-            // ObjectMapper가 완전 실패하는 최악의 경우를 대비한 텍스트 기반 응답
-            return String.format("{\"code\":\"%s\",\"message\":\"%s\"}", errorCode.getCode(), errorCode.getDefaultMessage()).getBytes();
+      // 2. Basic Auth 요청 (basicAuthEnabled=true) → WWW-Authenticate: Basic
+      if (basicAuthEnabled && authHeader != null && authHeader.startsWith(BASIC_PREFIX)) {
+        log.debug("[EntryPoint] Basic Auth 요청 감지 — WWW-Authenticate: Basic 응답");
+        response.setStatusCode(HttpStatus.UNAUTHORIZED);
+        response.getHeaders().set(HttpHeaders.WWW_AUTHENTICATE,
+            "Basic realm=\"" + getRealmName() + "\"");
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+        return writeJsonError(response, resolveErrorCode(ex), ex.getMessage());
+      }
+
+      // 3. redirect-enabled 모드
+      if (errorProperties.isRedirectEnabled()) {
+        // AJAX 요청이고 ajaxReturnsJson=true면 JSON 응답
+        if (errorProperties.isAjaxReturnsJson() && isAjaxRequest(exchange)) {
+          log.debug("[EntryPoint] AJAX 요청 — JSON 401 응답");
+          response.setStatusCode(HttpStatus.UNAUTHORIZED);
+          response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+          return writeJsonError(response, ErrorCode.AUTHENTICATION_FAILED, ex.getMessage());
         }
-    }
 
-    /**
-     * JSON 에러 응답을 위한 내부 레코드
-     */
-    private record ErrorResponse(String code, String message) {
+        // 브라우저 리다이렉트
+        String redirectUrl = determineRedirectUrl(exchange);
+        log.debug("[EntryPoint] 인증 실패 — 리다이렉트: {}", redirectUrl);
+        response.setStatusCode(HttpStatus.FOUND);
+        response.getHeaders().setLocation(URI.create(redirectUrl));
+        return response.setComplete();
+      }
+
+      // 4. API 모드 기본: 401 JSON
+      log.debug("[EntryPoint] 인증 실패 — 401 JSON 응답");
+      response.setStatusCode(HttpStatus.UNAUTHORIZED);
+      response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+      return writeJsonError(response, resolveErrorCode(ex), ex.getMessage());
+    });
+  }
+
+  /**
+   * 세션 만료/인증 실패에 따라 리다이렉트 URL을 결정합니다.
+   */
+  private String determineRedirectUrl(ServerWebExchange exchange) {
+    // WebFlux에서는 HttpSession 직접 접근 불가, 쿠키 기반 세션 ID 확인으로 대체
+    // 세션 쿠키가 있으면 세션 만료로 간주
+    boolean hasSessionCookie = exchange.getRequest().getCookies().containsKey("SESSION");
+    if (hasSessionCookie) {
+      return errorProperties.getEffectiveSessionExpiredRedirectUrl();
     }
+    return errorProperties.getAuthenticationFailedRedirectUrl();
+  }
+
+  /**
+   * AJAX 요청 여부를 판단합니다.
+   * {@code X-Requested-With: XMLHttpRequest} 또는 {@code Accept: application/json} 기준.
+   */
+  private boolean isAjaxRequest(ServerWebExchange exchange) {
+    HttpHeaders headers = exchange.getRequest().getHeaders();
+    String xRequestedWith = headers.getFirst(AJAX_HEADER);
+    if (AJAX_HEADER_VALUE.equalsIgnoreCase(xRequestedWith)) {
+      return true;
+    }
+    MediaType accept = headers.getAccept().stream()
+        .filter(mt -> mt.includes(MediaType.APPLICATION_JSON))
+        .findFirst()
+        .orElse(null);
+    return accept != null;
+  }
+
+  /**
+   * 예외 원인에서 ErrorCode를 추출합니다.
+   */
+  private ErrorCode resolveErrorCode(AuthenticationException ex) {
+    if (ex.getCause() instanceof KeycloakSecurityException cause) {
+      return cause.getErrorCode();
+    }
+    return ErrorCode.AUTHENTICATION_FAILED;
+  }
+
+  private String getRealmName() {
+    return (realmName != null && !realmName.isBlank()) ? realmName : "keycloak";
+  }
+
+  /**
+   * JSON 에러 응답을 응답 스트림에 씁니다.
+   */
+  private Mono<Void> writeJsonError(
+      ServerHttpResponse response, ErrorCode errorCode, String fallbackMessage) {
+    String message = (fallbackMessage != null) ? fallbackMessage : errorCode.getDefaultMessage();
+    try {
+      byte[] bytes = objectMapper.writeValueAsBytes(
+          new ErrorResponse(errorCode.getCode(), message));
+      DataBuffer buffer = response.bufferFactory().wrap(bytes);
+      return response.writeWith(Mono.just(buffer));
+    } catch (JsonProcessingException e) {
+      response.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
+      byte[] bytes = getFallbackBytes(errorCode);
+      DataBuffer buffer = response.bufferFactory().wrap(bytes);
+      return response.writeWith(Mono.just(buffer));
+    }
+  }
+
+  private byte[] getFallbackBytes(ErrorCode errorCode) {
+    try {
+      return objectMapper.writeValueAsBytes(
+          new ErrorResponse(errorCode.getCode(), errorCode.getDefaultMessage()));
+    } catch (JsonProcessingException e) {
+      return String.format("{\"code\":\"%s\",\"message\":\"%s\"}",
+          errorCode.getCode(), errorCode.getDefaultMessage()).getBytes();
+    }
+  }
+
+  /** JSON 에러 응답 레코드 */
+  private record ErrorResponse(String code, String message) {
+  }
 }

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/KeycloakReactiveAuthenticationManagerTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/KeycloakReactiveAuthenticationManagerTest.java
@@ -1,0 +1,311 @@
+package com.ids.keycloak.security.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.ids.keycloak.security.exception.AuthenticationFailedException;
+import com.ids.keycloak.security.exception.ConfigurationException;
+import com.ids.keycloak.security.exception.IntrospectionFailedException;
+import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.ids.keycloak.security.util.JwtUtil;
+import com.sd.KeycloakClient.client.auth.async.KeycloakAuthAsyncClient;
+import com.sd.KeycloakClient.client.user.async.KeycloakUserAsyncClient;
+import com.sd.KeycloakClient.dto.KeycloakResponse;
+import com.sd.KeycloakClient.dto.auth.KeycloakIntrospectResponse;
+import com.sd.KeycloakClient.dto.user.KeycloakUserInfo;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * {@link KeycloakReactiveAuthenticationManager} 단위 테스트.
+ *
+ * <p>Mono 체이닝이 런타임에 실제로 동작하는지 {@link StepVerifier}로 검증합니다.
+ * {@link KeycloakClient}를 flat mock 으로 분리하여 deep stub 의 UnfinishedStubbing 문제를 방지합니다.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class KeycloakReactiveAuthenticationManagerTest {
+
+  private KeycloakReactiveAuthenticationManager manager;
+
+  /** KeycloakClient 자체는 일반 mock — authAsync/userAsync 를 직접 stub */
+  @Mock
+  private KeycloakClient keycloakClient;
+
+  @Mock
+  private KeycloakAuthAsyncClient authAsyncClient;
+
+  @Mock
+  private KeycloakUserAsyncClient userAsyncClient;
+
+  private static final String CLIENT_ID = "test-client";
+  private static final String USER_SUB = "user-sub-123";
+  private static final String ID_TOKEN_VAL = "valid.id.token";
+  private static final String ACCESS_TOKEN_VAL = "valid.access.token";
+
+  @BeforeEach
+  void setUp() {
+    // lenient: 인증 실패 테스트에서 userAsync 가 사용되지 않아도 UnnecessaryStubbingException 방지
+    lenient().when(keycloakClient.authAsync()).thenReturn(authAsyncClient);
+    lenient().when(keycloakClient.userAsync()).thenReturn(userAsyncClient);
+    manager = new KeycloakReactiveAuthenticationManager(keycloakClient, CLIENT_ID);
+  }
+
+  // ------------------------------------------------------------------
+  // Helpers
+  // ------------------------------------------------------------------
+
+  private KeycloakAuthentication buildAuthRequest(String idToken, String accessToken) {
+    OidcIdToken oidcIdToken = new OidcIdToken(
+        idToken, Instant.now(), Instant.now().plusSeconds(3600), Map.of("sub", USER_SUB));
+    KeycloakPrincipal principal =
+        new KeycloakPrincipal(USER_SUB, Collections.emptyList(), oidcIdToken, null);
+    return new KeycloakAuthentication(principal, idToken, accessToken, false);
+  }
+
+  private KeycloakResponse<KeycloakIntrospectResponse> introspectOk(boolean active) {
+    return KeycloakResponse.<KeycloakIntrospectResponse>builder()
+        .status(200)
+        .body(new KeycloakIntrospectResponse(active))
+        .build();
+  }
+
+  private KeycloakResponse<KeycloakIntrospectResponse> introspectFail(int status) {
+    return KeycloakResponse.<KeycloakIntrospectResponse>builder()
+        .status(status)
+        .build();
+  }
+
+  private KeycloakResponse<KeycloakUserInfo> userInfoOk() {
+    KeycloakUserInfo info = new KeycloakUserInfo();
+    info.setOtherInfo("preferred_username", "testuser");
+    return KeycloakResponse.<KeycloakUserInfo>builder()
+        .status(200)
+        .body(info)
+        .build();
+  }
+
+  private KeycloakResponse<KeycloakUserInfo> userInfoFail(int status) {
+    return KeycloakResponse.<KeycloakUserInfo>builder()
+        .status(status)
+        .build();
+  }
+
+  private Map<String, Object> buildClaims() {
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("sub", USER_SUB);
+    claims.put("iat", Instant.now().getEpochSecond());
+    claims.put("exp", Instant.now().plusSeconds(3600).getEpochSecond());
+    return claims;
+  }
+
+  // ==========================================================================
+  // 인증 성공
+  // ==========================================================================
+
+  @Nested
+  class 인증_성공 {
+
+    @Test
+    void introspect_200_active_true_userinfo_200_정상_인증완료() {
+      when(authAsyncClient.authenticationByIntrospect(ID_TOKEN_VAL))
+          .thenReturn(Mono.just(introspectOk(true)));
+      when(userAsyncClient.getUserInfo(ACCESS_TOKEN_VAL))
+          .thenReturn(Mono.just(userInfoOk()));
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(ID_TOKEN_VAL))
+            .thenReturn(buildClaims());
+        jwtMock.when(() -> JwtUtil.parseSubjectWithoutValidation(ID_TOKEN_VAL))
+            .thenReturn(USER_SUB);
+
+        StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, ACCESS_TOKEN_VAL)))
+            .expectNextMatches(auth -> {
+              assertThat(auth.isAuthenticated()).isTrue();
+              assertThat(auth.getPrincipal()).isInstanceOf(KeycloakPrincipal.class);
+              assertThat(((KeycloakPrincipal) auth.getPrincipal()).getName()).isEqualTo(USER_SUB);
+              assertThat(auth).isInstanceOf(KeycloakAuthentication.class);
+              return true;
+            })
+            .verifyComplete();
+      }
+    }
+  }
+
+  // ==========================================================================
+  // UserInfo fallback 동작 검증
+  // ==========================================================================
+
+  @Nested
+  class UserInfo_fallback {
+
+    /**
+     * UserInfoFetchException 은 KeycloakSecurityException → RuntimeException 상속.
+     * {@code fetchUserInfo} 의 onErrorResume 조건은 {@code !(e instanceof KeycloakSecurityException)} 도 체크하므로
+     * → onErrorResume 이 적용되지 않아 UserInfoFetchException 이 전파됨.
+     * → 최상위 onErrorResume 도 KeycloakSecurityException 은 통과시키므로 에러 전파.
+     */
+    @Test
+    void userinfo_401_UserInfoFetchException_전파() {
+      when(authAsyncClient.authenticationByIntrospect(ID_TOKEN_VAL))
+          .thenReturn(Mono.just(introspectOk(true)));
+      when(userAsyncClient.getUserInfo(ACCESS_TOKEN_VAL))
+          .thenReturn(Mono.just(userInfoFail(401)));
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(ID_TOKEN_VAL))
+            .thenReturn(buildClaims());
+        jwtMock.when(() -> JwtUtil.parseSubjectWithoutValidation(ID_TOKEN_VAL))
+            .thenReturn(USER_SUB);
+
+        StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, ACCESS_TOKEN_VAL)))
+            .expectError(com.ids.keycloak.security.exception.UserInfoFetchException.class)
+            .verify();
+      }
+    }
+
+    /**
+     * 순수 RuntimeException 통신 오류는 onErrorResume 에서 잡혀 Mono.empty() 반환.
+     * switchIfEmpty 에서 createAuthenticatedToken(null) 호출 → 인증 성공.
+     */
+    @Test
+    void userinfo_RuntimeException_오류시_null_fallback_인증_성공() {
+      when(authAsyncClient.authenticationByIntrospect(ID_TOKEN_VAL))
+          .thenReturn(Mono.just(introspectOk(true)));
+      when(userAsyncClient.getUserInfo(ACCESS_TOKEN_VAL))
+          .thenReturn(Mono.error(new RuntimeException("network error")));
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(ID_TOKEN_VAL))
+            .thenReturn(buildClaims());
+        jwtMock.when(() -> JwtUtil.parseSubjectWithoutValidation(ID_TOKEN_VAL))
+            .thenReturn(USER_SUB);
+
+        StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, ACCESS_TOKEN_VAL)))
+            .expectNextMatches(auth -> {
+              assertThat(auth.isAuthenticated()).isTrue();
+              return true;
+            })
+            .verifyComplete();
+      }
+    }
+  }
+
+  // ==========================================================================
+  // 인증 실패
+  // ==========================================================================
+
+  @Nested
+  class 인증_실패 {
+
+    @Test
+    void introspect_200_active_false_IntrospectionFailedException_발생() {
+      when(authAsyncClient.authenticationByIntrospect(ID_TOKEN_VAL))
+          .thenReturn(Mono.just(introspectOk(false)));
+
+      StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, ACCESS_TOKEN_VAL)))
+          .expectErrorMatches(e ->
+              e instanceof IntrospectionFailedException
+                  && e.getMessage().contains("유효하지 않습니다"))
+          .verify();
+    }
+
+    @Test
+    void introspect_401_IntrospectionFailedException_발생() {
+      when(authAsyncClient.authenticationByIntrospect(ID_TOKEN_VAL))
+          .thenReturn(Mono.just(introspectFail(401)));
+
+      StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, ACCESS_TOKEN_VAL)))
+          .expectErrorMatches(e -> e instanceof IntrospectionFailedException)
+          .verify();
+    }
+
+    @Test
+    void introspect_500_ConfigurationException_발생() {
+      when(authAsyncClient.authenticationByIntrospect(ID_TOKEN_VAL))
+          .thenReturn(Mono.just(introspectFail(500)));
+
+      StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, ACCESS_TOKEN_VAL)))
+          .expectErrorMatches(e ->
+              e instanceof ConfigurationException
+                  && e.getMessage().contains("Keycloak 서버"))
+          .verify();
+    }
+
+    @Test
+    void introspect_body_없음_IntrospectionFailedException_발생() {
+      // status 200 + body null
+      KeycloakResponse<KeycloakIntrospectResponse> resp =
+          KeycloakResponse.<KeycloakIntrospectResponse>builder().status(200).build();
+      when(authAsyncClient.authenticationByIntrospect(ID_TOKEN_VAL))
+          .thenReturn(Mono.just(resp));
+
+      StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, ACCESS_TOKEN_VAL)))
+          .expectErrorMatches(e -> e instanceof IntrospectionFailedException)
+          .verify();
+    }
+
+    @Test
+    void introspect_통신_오류_ConfigurationException_으로_래핑() {
+      when(authAsyncClient.authenticationByIntrospect(ID_TOKEN_VAL))
+          .thenReturn(Mono.error(new RuntimeException("Connection refused")));
+
+      StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, ACCESS_TOKEN_VAL)))
+          .expectErrorMatches(e ->
+              e instanceof ConfigurationException
+                  && e.getMessage().contains("통신"))
+          .verify();
+    }
+
+    @Test
+    void introspect_기타_상태코드_AuthenticationFailedException_발생() {
+      when(authAsyncClient.authenticationByIntrospect(ID_TOKEN_VAL))
+          .thenReturn(Mono.just(introspectFail(403)));
+
+      StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, ACCESS_TOKEN_VAL)))
+          .expectErrorMatches(e -> e instanceof AuthenticationFailedException)
+          .verify();
+    }
+  }
+
+  // ==========================================================================
+  // createAuthenticatedToken (직접 호출 — refreshAndAuthenticate 에서 사용)
+  // ==========================================================================
+
+  @Nested
+  class createAuthenticatedToken_직접_호출 {
+
+    @Test
+    void userinfo_null_전달시_인증된_Authentication_반환() {
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(anyString()))
+            .thenReturn(buildClaims());
+        jwtMock.when(() -> JwtUtil.parseSubjectWithoutValidation(anyString()))
+            .thenReturn(USER_SUB);
+
+        Authentication result =
+            manager.createAuthenticatedToken(ID_TOKEN_VAL, ACCESS_TOKEN_VAL, null);
+
+        assertThat(result.isAuthenticated()).isTrue();
+        assertThat(result.getPrincipal()).isInstanceOf(KeycloakPrincipal.class);
+        assertThat(((KeycloakPrincipal) result.getPrincipal()).getName()).isEqualTo(USER_SUB);
+      }
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/KeycloakServerAuthenticationConverterTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/KeycloakServerAuthenticationConverterTest.java
@@ -1,0 +1,231 @@
+package com.ids.keycloak.security.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ids.keycloak.security.config.KeycloakCookieProperties;
+import com.ids.keycloak.security.session.ReactiveSessionManager;
+import com.sd.KeycloakClient.client.auth.async.KeycloakAuthAsyncClient;
+import com.sd.KeycloakClient.client.user.async.KeycloakUserAsyncClient;
+import com.sd.KeycloakClient.dto.KeycloakResponse;
+import com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpCookie;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.core.Authentication;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * {@link KeycloakServerAuthenticationConverter} 단위 테스트.
+ *
+ * <p>{@code MockServerWebExchange}를 사용하여 쿠키 존재 여부에 따른 분기를 검증합니다.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class KeycloakServerAuthenticationConverterTest {
+
+  @Mock
+  private KeycloakReactiveAuthenticationManager authManager;
+
+  @Mock
+  private KeycloakClient keycloakClient;
+
+  @Mock
+  private KeycloakAuthAsyncClient authAsyncClient;
+
+  @Mock
+  private KeycloakUserAsyncClient userAsyncClient;
+
+  @Mock
+  private ReactiveSessionManager sessionManager;
+
+  private KeycloakServerAuthenticationConverter converter;
+  private KeycloakCookieProperties cookieProperties;
+
+  private static final String ID_TOKEN = "test.id.token";
+  private static final String ACCESS_TOKEN = "test.access.token";
+  private static final String REFRESH_TOKEN = "test.refresh.token";
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(keycloakClient.authAsync()).thenReturn(authAsyncClient);
+    lenient().when(keycloakClient.userAsync()).thenReturn(userAsyncClient);
+    cookieProperties = new KeycloakCookieProperties();
+    converter = new KeycloakServerAuthenticationConverter(
+        authManager, keycloakClient, sessionManager, cookieProperties);
+  }
+
+  // ==========================================================================
+  // 토큰 없음 → Mono.empty()
+  // ==========================================================================
+
+  @Nested
+  class 토큰_없음 {
+
+    @Test
+    void id_token_쿠키_없으면_empty_Mono_반환() {
+      MockServerHttpRequest request = MockServerHttpRequest.get("/api/test").build();
+      MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+      StepVerifier.create(converter.convert(exchange))
+          .verifyComplete();
+    }
+
+    @Test
+    void id_token_쿠키_있어도_세션에_refresh_token_없으면_empty_Mono_반환() {
+      MockServerHttpRequest request = MockServerHttpRequest.get("/api/test")
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ID_TOKEN_COOKIE_NAME, ID_TOKEN))
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ACCESS_TOKEN_COOKIE_NAME, ACCESS_TOKEN))
+          .build();
+      MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+      when(sessionManager.getRefreshToken(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Optional.empty());
+
+      StepVerifier.create(converter.convert(exchange))
+          .verifyComplete();
+    }
+  }
+
+  // ==========================================================================
+  // 토큰 있음 → 미인증 Authentication 생성 시도
+  // ==========================================================================
+
+  @Nested
+  class 토큰_있음 {
+
+    @Test
+    void id_token_및_refresh_token_있으면_authManager_에_위임하고_Authentication_반환() {
+      MockServerHttpRequest request = MockServerHttpRequest.get("/api/test")
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ID_TOKEN_COOKIE_NAME, ID_TOKEN))
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ACCESS_TOKEN_COOKIE_NAME, ACCESS_TOKEN))
+          .build();
+      MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+      when(sessionManager.getRefreshToken(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Optional.of(REFRESH_TOKEN));
+
+      // authManager.authenticate() 성공 반환
+      Authentication authenticated = mock(Authentication.class);
+      when(authenticated.isAuthenticated()).thenReturn(true);
+      when(authManager.authenticate(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.just(authenticated));
+
+      StepVerifier.create(converter.convert(exchange))
+          .expectNextMatches(Authentication::isAuthenticated)
+          .verifyComplete();
+    }
+
+    /**
+     * H-N1: 토큰 재발급 성공 시 session.save() Mono가 체인에 포함되어 실제 구독·실행되는지 검증.
+     *
+     * <p>수정 전 코드는 session.save() 반환 Mono를 체인에 연결하지 않아 구독이 발생하지 않았다.
+     * 수정 후 {@code saveSession.then(...)} 체인에서 save()가 반드시 구독된다.</p>
+     *
+     * <p>검증 방식: {@code session.save()} 반환 Mono가 구독돼야만 이후 {@code .then(userInfo)} 체인이
+     * 실행되므로, 파이프라인 끝까지 완료(onComplete)되고 {@code createAuthenticatedToken}이
+     * 호출됐다면 save()도 구독됐다는 것을 의미한다.</p>
+     */
+    @Test
+    void 재발급_성공시_session_save_체인_포함으로_파이프라인_완료_검증() {
+      MockServerHttpRequest request = MockServerHttpRequest.get("/api/test")
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ID_TOKEN_COOKIE_NAME, ID_TOKEN))
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ACCESS_TOKEN_COOKIE_NAME, ACCESS_TOKEN))
+          .build();
+      MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+      when(sessionManager.getRefreshToken(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Optional.of(REFRESH_TOKEN));
+
+      // authManager 실패 → refresh 재시도 대상
+      when(authManager.authenticate(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.error(
+              new com.ids.keycloak.security.exception.IntrospectionFailedException("토큰 만료")));
+
+      // reissueToken 200 성공 (새 refreshToken 포함)
+      KeycloakTokenInfo newTokens = KeycloakTokenInfo.builder()
+          .accessToken("new.access.token")
+          .idToken("new.id.token")
+          .refreshToken("new.refresh.token")
+          .expireTime(300)
+          .build();
+      KeycloakResponse<KeycloakTokenInfo> reissueResp =
+          KeycloakResponse.<KeycloakTokenInfo>builder()
+              .status(200)
+              .body(newTokens)
+              .build();
+      when(authAsyncClient.reissueToken(REFRESH_TOKEN))
+          .thenReturn(Mono.just(reissueResp));
+
+      // UserInfo 조회 실패 → onErrorResume 경로로 null oidcUserInfo 인증 객체 반환
+      when(userAsyncClient.getUserInfo(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.error(new RuntimeException("userinfo error")));
+
+      Authentication fakeAuth = mock(Authentication.class);
+      when(fakeAuth.isAuthenticated()).thenReturn(true);
+      when(authManager.createAuthenticatedToken(
+          org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.isNull()))
+          .thenReturn(fakeAuth);
+
+      // H-N1 검증:
+      // save()가 체인에 포함되지 않았다면 saveSession.then(userInfo) 자체가 cold Mono가 되어
+      // 구독되지 않고 파이프라인이 중단됨 → StepVerifier가 onComplete을 받지 못한다.
+      // 수정 후 save() 완료 → userInfo → onErrorResume → createAuthenticatedToken 순서로 실행.
+      StepVerifier.create(converter.convert(exchange))
+          .expectNextMatches(Authentication::isAuthenticated)
+          .verifyComplete();
+
+      // save() → then() 체인 이후 createAuthenticatedToken 호출 확인
+      org.mockito.Mockito.verify(authManager).createAuthenticatedToken(
+          org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.any(),
+          org.mockito.ArgumentMatchers.isNull());
+    }
+
+    @Test
+    void authManager_인증_실패시_IntrospectionFailedException_refresh_token_재발급_시도_401이면_RefreshTokenException() {
+      MockServerHttpRequest request = MockServerHttpRequest.get("/api/test")
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ID_TOKEN_COOKIE_NAME, ID_TOKEN))
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ACCESS_TOKEN_COOKIE_NAME, ACCESS_TOKEN))
+          .build();
+      MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+      when(sessionManager.getRefreshToken(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Optional.of(REFRESH_TOKEN));
+
+      // authManager 실패 — IntrospectionFailedException (refresh 재시도 대상)
+      when(authManager.authenticate(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.error(
+              new com.ids.keycloak.security.exception.IntrospectionFailedException("토큰 만료")));
+
+      // keycloakClient.authAsync().reissueToken() — 401 응답
+      KeycloakResponse<com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo> reissueResp =
+          KeycloakResponse.<com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo>builder()
+              .status(401)
+              .build();
+
+      when(authAsyncClient.reissueToken(REFRESH_TOKEN))
+          .thenReturn(Mono.just(reissueResp));
+
+      when(sessionManager.invalidateSession(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.empty());
+
+      // refresh 401 → 세션 무효화 → RefreshTokenException 에러
+      StepVerifier.create(converter.convert(exchange))
+          .expectError(com.ids.keycloak.security.exception.RefreshTokenException.class)
+          .verify();
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/OidcReactiveLoginSuccessHandlerTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/OidcReactiveLoginSuccessHandlerTest.java
@@ -1,0 +1,275 @@
+package com.ids.keycloak.security.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ids.keycloak.security.config.KeycloakCookieProperties;
+import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.ids.keycloak.security.session.ReactiveSessionManager;
+import com.ids.keycloak.security.util.ReactiveCookieUtil;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.server.WebFilterExchange;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * OidcReactiveLoginSuccessHandler 단위 테스트.
+ * - Access Token 쿠키 발급 검증
+ * - ID Token 쿠키 발급 검증
+ * - Refresh Token 세션 저장 검증
+ * - Keycloak SID 세션 저장 검증
+ * - OAuth2AuthenticationToken 이 아닌 경우 기본 리다이렉트 검증
+ */
+class OidcReactiveLoginSuccessHandlerTest {
+
+  private ReactiveOAuth2AuthorizedClientService authorizedClientService;
+  private ReactiveSessionManager sessionManager;
+  private KeycloakCookieProperties cookieProperties;
+  private OidcReactiveLoginSuccessHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    authorizedClientService = mock(ReactiveOAuth2AuthorizedClientService.class);
+    sessionManager = mock(ReactiveSessionManager.class);
+    cookieProperties = new KeycloakCookieProperties();
+    handler = new OidcReactiveLoginSuccessHandler(
+        authorizedClientService, sessionManager, cookieProperties, "/home");
+  }
+
+  // =========================================================
+  // 정상 플로우: OIDC 로그인 성공 + AuthorizedClient 존재
+  // =========================================================
+  @Nested
+  @DisplayName("정상 플로우 - AuthorizedClient 존재")
+  class 정상_플로우 {
+
+    @Test
+    @DisplayName("access_token / id_token 쿠키가 응답에 추가된다")
+    void 토큰_쿠키_발급() {
+      OidcUser oidcUser = mockOidcUser("user-sub-123", "session-sid-abc");
+      OAuth2AuthenticationToken authentication = mockOAuth2Token(oidcUser);
+      OAuth2AuthorizedClient authorizedClient = mockAuthorizedClient("access-tok", "refresh-tok");
+
+      when(authorizedClientService.loadAuthorizedClient(anyString(), anyString()))
+          .thenReturn(Mono.just(authorizedClient));
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/home").build());
+      WebFilterExchange wfe = new WebFilterExchange(exchange, chain -> Mono.empty());
+
+      StepVerifier.create(handler.onAuthenticationSuccess(wfe, authentication))
+          .verifyComplete();
+
+      // Access Token 쿠키 확인
+      boolean hasAccessToken = exchange.getResponse().getCookies().values().stream()
+          .flatMap(List::stream)
+          .anyMatch(c -> c.getName().equals(ReactiveCookieUtil.ACCESS_TOKEN_NAME)
+              && "access-tok".equals(c.getValue()));
+      assertThat(hasAccessToken).isTrue();
+
+      // ID Token 쿠키 확인
+      boolean hasIdToken = exchange.getResponse().getCookies().values().stream()
+          .flatMap(List::stream)
+          .anyMatch(c -> c.getName().equals(ReactiveCookieUtil.ID_TOKEN_NAME)
+              && "id-token-value".equals(c.getValue()));
+      assertThat(hasIdToken).isTrue();
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 세션에 저장된다")
+    void 리프레시_토큰_세션_저장() {
+      OidcUser oidcUser = mockOidcUser("user-sub-123", "session-sid-abc");
+      OAuth2AuthenticationToken authentication = mockOAuth2Token(oidcUser);
+      OAuth2AuthorizedClient authorizedClient = mockAuthorizedClient("access-tok", "refresh-tok");
+
+      when(authorizedClientService.loadAuthorizedClient(anyString(), anyString()))
+          .thenReturn(Mono.just(authorizedClient));
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/home").build());
+      WebFilterExchange wfe = new WebFilterExchange(exchange, chain -> Mono.empty());
+
+      StepVerifier.create(handler.onAuthenticationSuccess(wfe, authentication))
+          .verifyComplete();
+
+      verify(sessionManager, atLeastOnce()).saveRefreshToken(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("Keycloak SID가 세션에 저장된다")
+    void 세션_ID_저장() {
+      OidcUser oidcUser = mockOidcUser("user-sub-123", "session-sid-abc");
+      OAuth2AuthenticationToken authentication = mockOAuth2Token(oidcUser);
+      OAuth2AuthorizedClient authorizedClient = mockAuthorizedClient("access-tok", "refresh-tok");
+
+      when(authorizedClientService.loadAuthorizedClient(anyString(), anyString()))
+          .thenReturn(Mono.just(authorizedClient));
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/home").build());
+      WebFilterExchange wfe = new WebFilterExchange(exchange, chain -> Mono.empty());
+
+      StepVerifier.create(handler.onAuthenticationSuccess(wfe, authentication))
+          .verifyComplete();
+
+      verify(sessionManager, atLeastOnce()).saveKeycloakSessionId(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("Principal Name이 세션에 저장된다")
+    void 프린시팔_이름_저장() {
+      OidcUser oidcUser = mockOidcUser("user-sub-123", "session-sid-abc");
+      OAuth2AuthenticationToken authentication = mockOAuth2Token(oidcUser);
+      OAuth2AuthorizedClient authorizedClient = mockAuthorizedClient("access-tok", "refresh-tok");
+
+      when(authorizedClientService.loadAuthorizedClient(anyString(), anyString()))
+          .thenReturn(Mono.just(authorizedClient));
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/home").build());
+      WebFilterExchange wfe = new WebFilterExchange(exchange, chain -> Mono.empty());
+
+      StepVerifier.create(handler.onAuthenticationSuccess(wfe, authentication))
+          .verifyComplete();
+
+      verify(sessionManager, atLeastOnce()).savePrincipalName(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("성공 후 /home 으로 리다이렉트된다")
+    void 리다이렉트() {
+      OidcUser oidcUser = mockOidcUser("user-sub-123", "session-sid-abc");
+      OAuth2AuthenticationToken authentication = mockOAuth2Token(oidcUser);
+      OAuth2AuthorizedClient authorizedClient = mockAuthorizedClient("access-tok", "refresh-tok");
+
+      when(authorizedClientService.loadAuthorizedClient(anyString(), anyString()))
+          .thenReturn(Mono.just(authorizedClient));
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/other").build());
+      WebFilterExchange wfe = new WebFilterExchange(exchange, chain -> Mono.empty());
+
+      StepVerifier.create(handler.onAuthenticationSuccess(wfe, authentication))
+          .verifyComplete();
+
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FOUND);
+      URI location = exchange.getResponse().getHeaders().getLocation();
+      assertThat(location).isNotNull();
+      assertThat(location.getPath()).isEqualTo("/home");
+    }
+  }
+
+  // =========================================================
+  // 엣지 케이스: OAuth2AuthenticationToken이 아닌 경우
+  // =========================================================
+  @Nested
+  @DisplayName("엣지 케이스")
+  class 엣지_케이스 {
+
+    @Test
+    @DisplayName("일반 Authentication이면 쿠키 없이 기본 리다이렉트만 수행")
+    void 비_OAuth2_인증_기본_리다이렉트() {
+      var nonOAuth2 = mock(org.springframework.security.core.Authentication.class);
+      when(nonOAuth2.getName()).thenReturn("user");
+      when(nonOAuth2.isAuthenticated()).thenReturn(true);
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/home").build());
+      WebFilterExchange wfe = new WebFilterExchange(exchange, chain -> Mono.empty());
+
+      StepVerifier.create(handler.onAuthenticationSuccess(wfe, nonOAuth2))
+          .verifyComplete();
+
+      // 쿠키 없음
+      assertThat(exchange.getResponse().getCookies().isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("AuthorizedClient가 없어도 ID Token 쿠키는 발급된다")
+    void AuthorizedClient_없을_때_ID_Token만_발급() {
+      OidcUser oidcUser = mockOidcUser("user-sub-123", "sid-xyz");
+      OAuth2AuthenticationToken authentication = mockOAuth2Token(oidcUser);
+
+      when(authorizedClientService.loadAuthorizedClient(anyString(), anyString()))
+          .thenReturn(Mono.empty());
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/home").build());
+      WebFilterExchange wfe = new WebFilterExchange(exchange, chain -> Mono.empty());
+
+      StepVerifier.create(handler.onAuthenticationSuccess(wfe, authentication))
+          .verifyComplete();
+
+      boolean hasIdToken = exchange.getResponse().getCookies().values().stream()
+          .flatMap(List::stream)
+          .anyMatch(c -> c.getName().equals(ReactiveCookieUtil.ID_TOKEN_NAME));
+      assertThat(hasIdToken).isTrue();
+    }
+  }
+
+  // =========================================================
+  // 헬퍼 메서드
+  // =========================================================
+
+  private OidcUser mockOidcUser(String subject, String sid) {
+    OidcIdToken idToken = new OidcIdToken(
+        "id-token-value",
+        Instant.now(),
+        Instant.now().plusSeconds(3600),
+        Map.of("sub", subject, "sid", sid));
+    OidcUserInfo userInfo = new OidcUserInfo(Map.of(
+        "sub", subject,
+        "preferred_username", "testuser"));
+
+    OidcUser oidcUser = mock(OidcUser.class);
+    when(oidcUser.getName()).thenReturn(subject);
+    when(oidcUser.getIdToken()).thenReturn(idToken);
+    when(oidcUser.getUserInfo()).thenReturn(userInfo);
+    when(oidcUser.getAuthorities()).thenReturn(List.of());
+    when(oidcUser.getAttributes()).thenReturn(Map.of("sub", subject));
+    return oidcUser;
+  }
+
+  private OAuth2AuthenticationToken mockOAuth2Token(OidcUser oidcUser) {
+    return new OAuth2AuthenticationToken(oidcUser, List.of(), "keycloak");
+  }
+
+  private OAuth2AuthorizedClient mockAuthorizedClient(
+      String accessTokenValue, String refreshTokenValue) {
+    OAuth2AccessToken accessToken = new OAuth2AccessToken(
+        OAuth2AccessToken.TokenType.BEARER,
+        accessTokenValue,
+        Instant.now(),
+        Instant.now().plusSeconds(3600));
+    OAuth2RefreshToken refreshToken = new OAuth2RefreshToken(
+        refreshTokenValue, Instant.now());
+
+    OAuth2AuthorizedClient client = mock(OAuth2AuthorizedClient.class);
+    when(client.getAccessToken()).thenReturn(accessToken);
+    when(client.getRefreshToken()).thenReturn(refreshToken);
+    return client;
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/ReactiveOidcBackChannelLogoutHandlerTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/ReactiveOidcBackChannelLogoutHandlerTest.java
@@ -1,0 +1,226 @@
+package com.ids.keycloak.security.authentication;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ids.keycloak.security.model.KeycloakLogoutToken;
+import com.ids.keycloak.security.util.JwtUtil;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.session.ReactiveFindByIndexNameSessionRepository;
+import org.springframework.session.ReactiveSessionRepository;
+import org.springframework.session.Session;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * {@link ReactiveOidcBackChannelLogoutHandler} 단위 테스트.
+ *
+ * <p>{@link ReactiveFindByIndexNameSessionRepository}를 mock하여
+ * logout_token 파싱 → 세션 무효화 호출 여부를 StepVerifier로 검증합니다.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class ReactiveOidcBackChannelLogoutHandlerTest {
+
+  @Mock
+  private TestSessionRepository sessionRepository;
+
+  private ReactiveOidcBackChannelLogoutHandler handler;
+
+  private static final String SUBJECT = "user-sub-123";
+  private static final String KEYCLOAK_SID = "kcSid-abc";
+  private static final String LOGOUT_TOKEN_JWT = "logout.token.jwt";
+  private static final String SPRING_SESSION_ID = "spring-session-id-1";
+
+  /**
+   * 테스트용 combined 인터페이스: ReactiveFindByIndexNameSessionRepository + ReactiveSessionRepository
+   */
+  interface TestSessionRepository
+      extends ReactiveFindByIndexNameSessionRepository<Session>,
+      ReactiveSessionRepository<Session> {
+  }
+
+  @BeforeEach
+  void setUp() {
+    handler = new ReactiveOidcBackChannelLogoutHandler(sessionRepository);
+  }
+
+  private WebFilterExchange mockWebFilterExchange() {
+    MockServerHttpRequest request = MockServerHttpRequest.post("/logout/connect/back-channel/keycloak").build();
+    MockServerWebExchange exchange = MockServerWebExchange.from(request);
+    return new WebFilterExchange(exchange, chain -> Mono.empty());
+  }
+
+  private Map<String, Object> buildLogoutTokenClaims(String sub, String sid) {
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("iss", "http://keycloak/realms/test");
+    if (sub != null) {
+      claims.put("sub", sub);
+    }
+    if (sid != null) {
+      claims.put("sid", sid);
+    }
+    // 표준 back-channel logout 이벤트 클레임
+    Map<String, Object> events = new HashMap<>();
+    events.put("http://schemas.openid.net/event/backchannel-logout", new HashMap<>());
+    claims.put("events", events);
+    return claims;
+  }
+
+  private Session mockSessionWithSid(String keycloakSid) {
+    Session session = mock(Session.class);
+    lenient().when(session.getAttribute(ReactiveOidcBackChannelLogoutHandler.KEYCLOAK_SESSION_ID_ATTR))
+        .thenReturn(keycloakSid);
+    return session;
+  }
+
+  // ==========================================================================
+  // 정상 케이스
+  // ==========================================================================
+
+  @Nested
+  class 정상_케이스 {
+
+    @Test
+    void logout_token_sub_sid_모두_있으면_매칭_세션_deleteById_호출() {
+      Session session = mockSessionWithSid(KEYCLOAK_SID);
+      Map<String, Session> sessions = Map.of(SPRING_SESSION_ID, session);
+
+      when(sessionRepository.findByPrincipalName(SUBJECT))
+          .thenReturn(Mono.just(sessions));
+      when(sessionRepository.deleteById(SPRING_SESSION_ID))
+          .thenReturn(Mono.empty());
+
+      BackChannelLogoutAuthentication auth = new BackChannelLogoutAuthentication(LOGOUT_TOKEN_JWT);
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(LOGOUT_TOKEN_JWT))
+            .thenReturn(buildLogoutTokenClaims(SUBJECT, KEYCLOAK_SID));
+
+        StepVerifier.create(handler.logout(mockWebFilterExchange(), auth))
+            .verifyComplete();
+      }
+
+      verify(sessionRepository).findByPrincipalName(SUBJECT);
+      verify(sessionRepository).deleteById(SPRING_SESSION_ID);
+    }
+
+    @Test
+    void logout_token_sub만_있고_sid_없으면_모든_세션_deleteById_호출() {
+      Session session1 = mockSessionWithSid(null);
+      Session session2 = mockSessionWithSid(null);
+      Map<String, Session> sessions = Map.of("session-1", session1, "session-2", session2);
+
+      when(sessionRepository.findByPrincipalName(SUBJECT))
+          .thenReturn(Mono.just(sessions));
+      when(sessionRepository.deleteById(anyString()))
+          .thenReturn(Mono.empty());
+
+      BackChannelLogoutAuthentication auth = new BackChannelLogoutAuthentication(LOGOUT_TOKEN_JWT);
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(LOGOUT_TOKEN_JWT))
+            .thenReturn(buildLogoutTokenClaims(SUBJECT, null));
+
+        StepVerifier.create(handler.logout(mockWebFilterExchange(), auth))
+            .verifyComplete();
+      }
+
+      verify(sessionRepository).findByPrincipalName(SUBJECT);
+    }
+
+    @Test
+    void sid_있어도_매칭_세션_없으면_deleteById_미호출() {
+      // 세션은 있지만 KEYCLOAK_SID가 다름
+      Session session = mockSessionWithSid("different-sid");
+      Map<String, Session> sessions = Map.of(SPRING_SESSION_ID, session);
+
+      when(sessionRepository.findByPrincipalName(SUBJECT))
+          .thenReturn(Mono.just(sessions));
+
+      BackChannelLogoutAuthentication auth = new BackChannelLogoutAuthentication(LOGOUT_TOKEN_JWT);
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(LOGOUT_TOKEN_JWT))
+            .thenReturn(buildLogoutTokenClaims(SUBJECT, KEYCLOAK_SID));
+
+        StepVerifier.create(handler.logout(mockWebFilterExchange(), auth))
+            .verifyComplete();
+      }
+
+      verify(sessionRepository, never()).deleteById(anyString());
+    }
+  }
+
+  // ==========================================================================
+  // 오류 케이스
+  // ==========================================================================
+
+  @Nested
+  class 오류_케이스 {
+
+    @Test
+    void authentication_null이면_BadRequest_응답() {
+      StepVerifier.create(handler.logout(mockWebFilterExchange(), null))
+          .verifyComplete();
+    }
+
+    @Test
+    void credentials_null이면_BadRequest_응답() {
+      BackChannelLogoutAuthentication auth = new BackChannelLogoutAuthentication(null);
+
+      StepVerifier.create(handler.logout(mockWebFilterExchange(), auth))
+          .verifyComplete();
+    }
+
+    @Test
+    void JWT_파싱_실패시_BadRequest_응답() {
+      BackChannelLogoutAuthentication auth = new BackChannelLogoutAuthentication(LOGOUT_TOKEN_JWT);
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(LOGOUT_TOKEN_JWT))
+            .thenReturn(java.util.Collections.emptyMap());
+
+        StepVerifier.create(handler.logout(mockWebFilterExchange(), auth))
+            .verifyComplete();
+      }
+
+      verify(sessionRepository, never()).findByPrincipalName(anyString());
+    }
+
+    @Test
+    void logout_token_이벤트_없으면_BadRequest_응답() {
+      BackChannelLogoutAuthentication auth = new BackChannelLogoutAuthentication(LOGOUT_TOKEN_JWT);
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        // events 클레임 없는 토큰
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("sub", SUBJECT);
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(LOGOUT_TOKEN_JWT))
+            .thenReturn(claims);
+
+        StepVerifier.create(handler.logout(mockWebFilterExchange(), auth))
+            .verifyComplete();
+      }
+
+      verify(sessionRepository, never()).findByPrincipalName(anyString());
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/config/CsrfExemptMatcherTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/config/CsrfExemptMatcherTest.java
@@ -1,0 +1,211 @@
+package com.ids.keycloak.security.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.web.server.util.matcher.NegatedServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.OrServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
+import reactor.test.StepVerifier;
+
+/**
+ * CSRF 면제 Matcher 단위 테스트.
+ *
+ * <p>{@link KeycloakWebFluxSecurityConfigurer}의 {@code configureCsrf} 내부에서
+ * 구성되는 {@code NegatedServerWebExchangeMatcher(OrServerWebExchangeMatcher(면제경로들))} 로직을
+ * 인라인으로 재현하여 검증합니다.</p>
+ *
+ * <p>CSRF 보호 = NOT(면제 대상) 공식 검증:
+ * <ul>
+ *   <li>면제 경로 → CSRF 검사 없음(notMatch → true: 보호 안 함)</li>
+ *   <li>일반 경로 → CSRF 검사(match → true: 보호 함)</li>
+ *   <li>Basic Auth 헤더 → CSRF 면제</li>
+ * </ul>
+ * </p>
+ */
+class CsrfExemptMatcherTest {
+
+  /**
+   * KeycloakWebFluxSecurityConfigurer.configureCsrf 와 동일한 matcher 구성 로직.
+   *
+   * @param exemptPaths          CSRF 면제 경로 목록
+   * @param basicAuthExemptEnabled Basic Auth 헤더 면제 여부
+   */
+  private ServerWebExchangeMatcher buildCsrfMatcher(List<String> exemptPaths,
+      boolean basicAuthExemptEnabled) {
+    List<ServerWebExchangeMatcher> exemptMatchers = new ArrayList<>();
+    for (String path : exemptPaths) {
+      exemptMatchers.add(new PathPatternParserServerWebExchangeMatcher(path));
+    }
+    if (basicAuthExemptEnabled) {
+      ServerWebExchangeMatcher basicAuthMatcher = exchange -> {
+        String auth = exchange.getRequest().getHeaders().getFirst("Authorization");
+        if (auth != null && auth.startsWith("Basic ")) {
+          return ServerWebExchangeMatcher.MatchResult.match();
+        }
+        return ServerWebExchangeMatcher.MatchResult.notMatch();
+      };
+      exemptMatchers.add(basicAuthMatcher);
+    }
+    // CSRF 보호 = NOT(면제 대상)
+    return new NegatedServerWebExchangeMatcher(new OrServerWebExchangeMatcher(exemptMatchers));
+  }
+
+  private MockServerWebExchange exchange(String method, String path) {
+    MockServerHttpRequest request = MockServerHttpRequest
+        .method(method.equals("POST") ? HttpMethod.POST : HttpMethod.GET, path).build();
+    return MockServerWebExchange.from(request);
+  }
+
+  private MockServerWebExchange exchangeWithHeader(String method, String path, String headerName,
+      String headerValue) {
+    MockServerHttpRequest request = MockServerHttpRequest
+        .method(method.equals("POST") ? HttpMethod.POST : HttpMethod.GET, path)
+        .header(headerName, headerValue).build();
+    return MockServerWebExchange.from(request);
+  }
+
+  // ==========================================================================
+  // 면제 경로 → CSRF 검사 없음 (matcher notMatch = 보호 안 함)
+  // ==========================================================================
+
+  @Nested
+  class 면제_경로_CSRF_보호_없음 {
+
+    @Test
+    void 로그아웃_경로_CSRF_면제() {
+      List<String> exemptPaths = List.of("/logout");
+      ServerWebExchangeMatcher csrfMatcher = buildCsrfMatcher(exemptPaths, false);
+
+      StepVerifier.create(csrfMatcher.matches(exchange("POST", "/logout")))
+          .expectNextMatches(result -> !result.isMatch())
+          .verifyComplete();
+    }
+
+    @Test
+    void BackChannel_로그아웃_경로_CSRF_면제() {
+      List<String> exemptPaths = List.of("/logout/connect/back-channel/**");
+      ServerWebExchangeMatcher csrfMatcher = buildCsrfMatcher(exemptPaths, false);
+
+      StepVerifier.create(
+              csrfMatcher.matches(exchange("POST", "/logout/connect/back-channel/keycloak")))
+          .expectNextMatches(result -> !result.isMatch())
+          .verifyComplete();
+    }
+
+    @Test
+    void Bearer_Token_엔드포인트_CSRF_면제() {
+      List<String> exemptPaths = List.of("/api/token", "/api/refresh", "/api/logout");
+      ServerWebExchangeMatcher csrfMatcher = buildCsrfMatcher(exemptPaths, false);
+
+      StepVerifier.create(csrfMatcher.matches(exchange("POST", "/api/token")))
+          .expectNextMatches(result -> !result.isMatch())
+          .verifyComplete();
+
+      StepVerifier.create(csrfMatcher.matches(exchange("POST", "/api/refresh")))
+          .expectNextMatches(result -> !result.isMatch())
+          .verifyComplete();
+    }
+
+    @Test
+    void 사용자_지정_면제_경로_CSRF_면제() {
+      List<String> exemptPaths = List.of("/webhook/**");
+      ServerWebExchangeMatcher csrfMatcher = buildCsrfMatcher(exemptPaths, false);
+
+      StepVerifier.create(csrfMatcher.matches(exchange("POST", "/webhook/event")))
+          .expectNextMatches(result -> !result.isMatch())
+          .verifyComplete();
+    }
+  }
+
+  // ==========================================================================
+  // 일반 경로 → CSRF 보호 적용 (matcher match = 보호 함)
+  // ==========================================================================
+
+  @Nested
+  class 일반_경로_CSRF_보호_적용 {
+
+    @Test
+    void 일반_API_경로_CSRF_보호() {
+      List<String> exemptPaths = List.of("/logout", "/logout/connect/back-channel/**");
+      ServerWebExchangeMatcher csrfMatcher = buildCsrfMatcher(exemptPaths, false);
+
+      StepVerifier.create(csrfMatcher.matches(exchange("POST", "/api/submit")))
+          .expectNextMatches(ServerWebExchangeMatcher.MatchResult::isMatch)
+          .verifyComplete();
+    }
+
+    @Test
+    void 루트_경로_CSRF_보호() {
+      List<String> exemptPaths = List.of("/logout");
+      ServerWebExchangeMatcher csrfMatcher = buildCsrfMatcher(exemptPaths, false);
+
+      StepVerifier.create(csrfMatcher.matches(exchange("POST", "/")))
+          .expectNextMatches(ServerWebExchangeMatcher.MatchResult::isMatch)
+          .verifyComplete();
+    }
+  }
+
+  // ==========================================================================
+  // Basic Auth 헤더 면제
+  // ==========================================================================
+
+  @Nested
+  class BasicAuth_헤더_면제 {
+
+    @Test
+    void Authorization_Basic_헤더_있으면_CSRF_면제() {
+      List<String> exemptPaths = List.of("/logout");
+      ServerWebExchangeMatcher csrfMatcher = buildCsrfMatcher(exemptPaths, true);
+
+      MockServerWebExchange ex = exchangeWithHeader("POST", "/api/resource",
+          "Authorization", "Basic dXNlcjpwYXNz");
+
+      StepVerifier.create(csrfMatcher.matches(ex))
+          .expectNextMatches(result -> !result.isMatch())
+          .verifyComplete();
+    }
+
+    @Test
+    void Authorization_Bearer_헤더는_CSRF_보호_적용() {
+      List<String> exemptPaths = List.of("/logout");
+      ServerWebExchangeMatcher csrfMatcher = buildCsrfMatcher(exemptPaths, true);
+
+      MockServerWebExchange ex = exchangeWithHeader("POST", "/api/resource",
+          "Authorization", "Bearer some.token.here");
+
+      StepVerifier.create(csrfMatcher.matches(ex))
+          .expectNextMatches(ServerWebExchangeMatcher.MatchResult::isMatch)
+          .verifyComplete();
+    }
+
+    @Test
+    void Authorization_헤더_없으면_일반_경로_CSRF_보호() {
+      List<String> exemptPaths = List.of("/logout");
+      ServerWebExchangeMatcher csrfMatcher = buildCsrfMatcher(exemptPaths, true);
+
+      StepVerifier.create(csrfMatcher.matches(exchange("POST", "/api/resource")))
+          .expectNextMatches(ServerWebExchangeMatcher.MatchResult::isMatch)
+          .verifyComplete();
+    }
+
+    @Test
+    void basicAuth_비활성화시_Basic_헤더_있어도_CSRF_보호() {
+      List<String> exemptPaths = List.of("/logout");
+      // basicAuthExemptEnabled=false
+      ServerWebExchangeMatcher csrfMatcher = buildCsrfMatcher(exemptPaths, false);
+
+      MockServerWebExchange ex = exchangeWithHeader("POST", "/api/resource",
+          "Authorization", "Basic dXNlcjpwYXNz");
+
+      StepVerifier.create(csrfMatcher.matches(ex))
+          .expectNextMatches(ServerWebExchangeMatcher.MatchResult::isMatch)
+          .verifyComplete();
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/config/SecurityMatcherTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/config/SecurityMatcherTest.java
@@ -1,0 +1,159 @@
+package com.ids.keycloak.security.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
+import reactor.test.StepVerifier;
+
+/**
+ * SecurityMatcher (Reactive) include/exclude 패턴 매칭 동작 테스트.
+ *
+ * <p>{@link KeycloakWebFluxConstants} 및 {@link PathPatternParserServerWebExchangeMatcher}를 조합한
+ * 실제 Reactive 매처 동작을 {@code MockServerWebExchange}로 검증합니다.</p>
+ *
+ * <p>buildSecurityMatcher 로직은 webflux-starter에 있으므로
+ * 여기서는 동일 로직을 인라인으로 재현하여 검증합니다.</p>
+ */
+class SecurityMatcherTest {
+
+  /**
+   * KeycloakWebFluxAutoConfiguration.buildSecurityMatcher 와 동일한 로직.
+   */
+  private ServerWebExchangeMatcher buildMatcher(List<String> includes, List<String> excludes) {
+    ServerWebExchangeMatcher includeMatcher = toOrMatcher(includes);
+
+    if (excludes == null || excludes.isEmpty()) {
+      return includeMatcher;
+    }
+
+    ServerWebExchangeMatcher excludeMatcher = toOrMatcher(excludes);
+    return exchange -> includeMatcher.matches(exchange)
+        .flatMap(includeResult -> {
+          if (!includeResult.isMatch()) {
+            return ServerWebExchangeMatcher.MatchResult.notMatch();
+          }
+          return excludeMatcher.matches(exchange)
+              .flatMap(excludeResult ->
+                  excludeResult.isMatch()
+                      ? ServerWebExchangeMatcher.MatchResult.notMatch()
+                      : ServerWebExchangeMatcher.MatchResult.match());
+        });
+  }
+
+  private ServerWebExchangeMatcher toOrMatcher(List<String> patterns) {
+    if (patterns == null || patterns.isEmpty()) {
+      return exchange -> ServerWebExchangeMatchers.anyExchange().matches(exchange);
+    }
+    if (patterns.size() == 1) {
+      return new PathPatternParserServerWebExchangeMatcher(patterns.get(0));
+    }
+    List<ServerWebExchangeMatcher> matchers = new ArrayList<>();
+    for (String pattern : patterns) {
+      matchers.add(new PathPatternParserServerWebExchangeMatcher(pattern));
+    }
+    return ServerWebExchangeMatchers.matchers(matchers.toArray(new ServerWebExchangeMatcher[0]));
+  }
+
+  private MockServerWebExchange exchange(String path) {
+    MockServerHttpRequest request = MockServerHttpRequest.get(path).build();
+    return MockServerWebExchange.from(request);
+  }
+
+  // ==========================================================================
+  // include 패턴만 (exclude 없음)
+  // ==========================================================================
+
+  @Nested
+  class include_패턴 {
+
+    @Test
+    void include_패턴이_없으면_모든_경로_매칭() {
+      ServerWebExchangeMatcher matcher = buildMatcher(List.of(), List.of());
+
+      StepVerifier.create(matcher.matches(exchange("/any/path")))
+          .expectNextMatches(ServerWebExchangeMatcher.MatchResult::isMatch)
+          .verifyComplete();
+    }
+
+    @Test
+    void include_패턴에_매칭되는_경로_match() {
+      ServerWebExchangeMatcher matcher = buildMatcher(List.of("/api/**"), List.of());
+
+      StepVerifier.create(matcher.matches(exchange("/api/users")))
+          .expectNextMatches(ServerWebExchangeMatcher.MatchResult::isMatch)
+          .verifyComplete();
+    }
+
+    @Test
+    void include_패턴에_매칭되지_않는_경로_notMatch() {
+      ServerWebExchangeMatcher matcher = buildMatcher(List.of("/api/**"), List.of());
+
+      StepVerifier.create(matcher.matches(exchange("/health")))
+          .expectNextMatches(result -> !result.isMatch())
+          .verifyComplete();
+    }
+
+    @Test
+    void 여러_include_패턴_중_하나_매칭되면_match() {
+      ServerWebExchangeMatcher matcher = buildMatcher(
+          List.of("/api/**", "/v2/**"), List.of());
+
+      StepVerifier.create(matcher.matches(exchange("/v2/items")))
+          .expectNextMatches(ServerWebExchangeMatcher.MatchResult::isMatch)
+          .verifyComplete();
+    }
+  }
+
+  // ==========================================================================
+  // exclude 패턴 (include + exclude)
+  // ==========================================================================
+
+  @Nested
+  class exclude_패턴 {
+
+    @Test
+    void include_매칭이지만_exclude_매칭이면_notMatch() {
+      ServerWebExchangeMatcher matcher = buildMatcher(List.of("/**"), List.of("/actuator/**"));
+
+      StepVerifier.create(matcher.matches(exchange("/actuator/health")))
+          .expectNextMatches(result -> !result.isMatch())
+          .verifyComplete();
+    }
+
+    @Test
+    void include_매칭이고_exclude_미매칭이면_match() {
+      ServerWebExchangeMatcher matcher = buildMatcher(List.of("/**"), List.of("/actuator/**"));
+
+      StepVerifier.create(matcher.matches(exchange("/api/users")))
+          .expectNextMatches(ServerWebExchangeMatcher.MatchResult::isMatch)
+          .verifyComplete();
+    }
+
+    @Test
+    void include_미매칭이면_exclude_와_무관하게_notMatch() {
+      ServerWebExchangeMatcher matcher = buildMatcher(
+          List.of("/api/**"), List.of("/api/public/**"));
+
+      StepVerifier.create(matcher.matches(exchange("/other")))
+          .expectNextMatches(result -> !result.isMatch())
+          .verifyComplete();
+    }
+
+    @Test
+    void logout_경로_exclude_설정시_notMatch() {
+      // /actuator/** 는 보안 체인에서 제외하는 대표 패턴
+      ServerWebExchangeMatcher matcher = buildMatcher(
+          List.of("/**"), List.of("/actuator/**", "/public/**"));
+
+      StepVerifier.create(matcher.matches(exchange("/public/info")))
+          .expectNextMatches(result -> !result.isMatch())
+          .verifyComplete();
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/controller/KeycloakReactiveTokenControllerTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/controller/KeycloakReactiveTokenControllerTest.java
@@ -1,0 +1,173 @@
+package com.ids.keycloak.security.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import com.sd.KeycloakClient.client.auth.async.KeycloakAuthAsyncClient;
+import com.sd.KeycloakClient.dto.KeycloakResponse;
+import com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * M-N1: {@link KeycloakReactiveTokenController} 단위 테스트.
+ *
+ * <p>{@code WebTestClient.bindToController}로 컨트롤러를 직접 바인딩하여
+ * 검증 실패 시 OAuth2 표준 에러 포맷({@code error/error_description}) + 400 응답을 확인합니다.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class KeycloakReactiveTokenControllerTest {
+
+  @Mock
+  private KeycloakClient keycloakClient;
+
+  @Mock
+  private KeycloakAuthAsyncClient authAsyncClient;
+
+  private WebTestClient webTestClient;
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(keycloakClient.authAsync()).thenReturn(authAsyncClient);
+    KeycloakReactiveTokenController controller =
+        new KeycloakReactiveTokenController(keycloakClient, "/auth");
+
+    webTestClient = WebTestClient
+        .bindToController(controller)
+        .build();
+  }
+
+  // ===========================================================================
+  // M-N1: @Valid 위반 → 400 + OAuth2 표준 에러 포맷 검증
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("M-N1: @Valid 위반 시 OAuth2 표준 에러 포맷(400) 반환")
+  class 유효성검증_실패 {
+
+    @Test
+    @DisplayName("username 빈 값 → 400 + error=invalid_request 포함")
+    void username_빈값_400_invalid_request() {
+      String body = webTestClient.post()
+          .uri("/auth/token")
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue("{\"username\":\"\",\"password\":\"secret\"}")
+          .exchange()
+          .expectStatus().isBadRequest()
+          .expectBody(String.class)
+          .returnResult()
+          .getResponseBody();
+
+      assertThat(body).contains("invalid_request");
+      assertThat(body).contains("error_description");
+      // Spring 기본 에러 포맷 키 없음 확인
+      assertThat(body).doesNotContain("\"timestamp\"");
+      assertThat(body).doesNotContain("\"status\"");
+    }
+
+    @Test
+    @DisplayName("password 빈 값 → 400 + error=invalid_request 포함")
+    void password_빈값_400_invalid_request() {
+      String body = webTestClient.post()
+          .uri("/auth/token")
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue("{\"username\":\"user1\",\"password\":\"\"}")
+          .exchange()
+          .expectStatus().isBadRequest()
+          .expectBody(String.class)
+          .returnResult()
+          .getResponseBody();
+
+      assertThat(body).contains("invalid_request");
+      assertThat(body).contains("error_description");
+    }
+
+    @Test
+    @DisplayName("username과 password 모두 빈 값 → 400 + error=invalid_request 포함")
+    void 모두_빈값_400_invalid_request() {
+      String body = webTestClient.post()
+          .uri("/auth/token")
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue("{\"username\":\"\",\"password\":\"\"}")
+          .exchange()
+          .expectStatus().isBadRequest()
+          .expectBody(String.class)
+          .returnResult()
+          .getResponseBody();
+
+      assertThat(body).contains("invalid_request");
+      assertThat(body).contains("error_description");
+    }
+
+    @Test
+    @DisplayName("Spring 기본 에러 포맷(timestamp/status) 키 없음 확인")
+    void spring_기본_에러_포맷_없음() {
+      String body = webTestClient.post()
+          .uri("/auth/token")
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue("{\"username\":\"\",\"password\":\"secret\"}")
+          .exchange()
+          .expectStatus().isBadRequest()
+          .expectBody(String.class)
+          .returnResult()
+          .getResponseBody();
+
+      assertThat(body).doesNotContain("\"timestamp\"");
+      assertThat(body).doesNotContain("\"status\"");
+      assertThat(body).contains("\"error\"");
+    }
+  }
+
+  // ===========================================================================
+  // 정상 경로: 기존 동작 회귀 없음 확인
+  // ===========================================================================
+
+  @Nested
+  @DisplayName("정상 경로: 기존 동작 회귀 없음")
+  class 정상_경로 {
+
+    @Test
+    @DisplayName("유효한 요청 → Keycloak 호출 후 200 + access_token 포함 응답")
+    void 유효한_요청_200() {
+      KeycloakTokenInfo tokenInfo = KeycloakTokenInfo.builder()
+          .accessToken("access-token-value")
+          .refreshToken("refresh-token-value")
+          .idToken("id-token-value")
+          .expireTime(300)
+          .build();
+
+      KeycloakResponse<KeycloakTokenInfo> response =
+          KeycloakResponse.<KeycloakTokenInfo>builder()
+              .status(200)
+              .body(tokenInfo)
+              .build();
+
+      when(authAsyncClient.basicAuth(anyString(), anyString()))
+          .thenReturn(Mono.just(response));
+
+      String body = webTestClient.post()
+          .uri("/auth/token")
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue("{\"username\":\"user1\",\"password\":\"secret\"}")
+          .exchange()
+          .expectStatus().isOk()
+          .expectBody(String.class)
+          .returnResult()
+          .getResponseBody();
+
+      assertThat(body).contains("access-token-value");
+      assertThat(body).contains("Bearer");
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/dto/ReactiveDtoValidationTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/dto/ReactiveDtoValidationTest.java
@@ -1,0 +1,82 @@
+package com.ids.keycloak.security.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * H-3: Reactive DTO @NotBlank 검증 테스트.
+ */
+class ReactiveDtoValidationTest {
+
+  private static Validator validator;
+
+  @BeforeAll
+  static void setup() {
+    validator = Validation.buildDefaultValidatorFactory().getValidator();
+  }
+
+  @Test
+  @DisplayName("ReactiveTokenRequest - username 비어있으면 위반")
+  void tokenRequest_username_blank_위반() {
+    var req = new ReactiveTokenRequest("", "pass123");
+    Set<ConstraintViolation<ReactiveTokenRequest>> violations = validator.validate(req);
+    assertThat(violations).isNotEmpty();
+    assertThat(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("username"))).isTrue();
+  }
+
+  @Test
+  @DisplayName("ReactiveTokenRequest - password 비어있으면 위반")
+  void tokenRequest_password_blank_위반() {
+    var req = new ReactiveTokenRequest("user1", "");
+    Set<ConstraintViolation<ReactiveTokenRequest>> violations = validator.validate(req);
+    assertThat(violations).isNotEmpty();
+    assertThat(violations.stream().anyMatch(v -> v.getPropertyPath().toString().equals("password"))).isTrue();
+  }
+
+  @Test
+  @DisplayName("ReactiveTokenRequest - 정상 입력이면 위반 없음")
+  void tokenRequest_정상() {
+    var req = new ReactiveTokenRequest("user1", "pass123");
+    Set<ConstraintViolation<ReactiveTokenRequest>> violations = validator.validate(req);
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  @DisplayName("ReactiveRefreshRequest - refreshToken 비어있으면 위반")
+  void refreshRequest_blank_위반() {
+    var req = new ReactiveRefreshRequest("");
+    Set<ConstraintViolation<ReactiveRefreshRequest>> violations = validator.validate(req);
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("ReactiveRefreshRequest - 정상 입력이면 위반 없음")
+  void refreshRequest_정상() {
+    var req = new ReactiveRefreshRequest("refresh-token-value");
+    Set<ConstraintViolation<ReactiveRefreshRequest>> violations = validator.validate(req);
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  @DisplayName("ReactiveLogoutRequest - refreshToken 비어있으면 위반")
+  void logoutRequest_blank_위반() {
+    var req = new ReactiveLogoutRequest("");
+    Set<ConstraintViolation<ReactiveLogoutRequest>> violations = validator.validate(req);
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("ReactiveLogoutRequest - 정상 입력이면 위반 없음")
+  void logoutRequest_정상() {
+    var req = new ReactiveLogoutRequest("refresh-token-value");
+    Set<ConstraintViolation<ReactiveLogoutRequest>> violations = validator.validate(req);
+    assertThat(violations).isEmpty();
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/filter/ReactiveAuthLoggingFilterTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/filter/ReactiveAuthLoggingFilterTest.java
@@ -1,0 +1,113 @@
+package com.ids.keycloak.security.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ids.keycloak.security.config.KeycloakLoggingProperties;
+import com.ids.keycloak.security.config.KeycloakSecurityProperties;
+import com.ids.keycloak.security.logging.LoggingContextKeys;
+import com.ids.keycloak.security.logging.ReactiveLoggingContextAccessor;
+import com.ids.keycloak.security.model.KeycloakPrincipal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.util.context.Context;
+
+/**
+ * ReactiveAuthLoggingFilter 단위 테스트.
+ * - H-1: 인증 완료 후 userId/username/sessionId가 Reactor Context에 실제로 적재되는지 검증.
+ */
+class ReactiveAuthLoggingFilterTest {
+
+  private KeycloakSecurityProperties securityProperties;
+  private ReactiveAuthLoggingFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    securityProperties = new KeycloakSecurityProperties();
+    KeycloakLoggingProperties loggingProperties = securityProperties.getLogging();
+    loggingProperties.setIncludeUserId(true);
+    loggingProperties.setIncludeUsername(true);
+    loggingProperties.setIncludeSessionId(true);
+    filter = new ReactiveAuthLoggingFilter(securityProperties);
+  }
+
+  @Test
+  @DisplayName("KeycloakPrincipal 인증 시 userId, username, sessionId가 Context에 적재된다")
+  void KeycloakPrincipal_인증_컨텍스트_적재() {
+    KeycloakPrincipal principal = buildKeycloakPrincipal("sub-abc", "user1", "sid-xyz");
+
+    var authentication = new UsernamePasswordAuthenticationToken(
+        principal, null, List.of());
+
+    MockServerWebExchange exchange = MockServerWebExchange.from(
+        MockServerHttpRequest.get("/test").build());
+
+    AtomicReference<Map<String, String>> capturedContext = new AtomicReference<>();
+
+    Mono<Void> result = filter.filter(exchange, serverWebExchange ->
+        Mono.deferContextual(ctx -> {
+          capturedContext.set(ReactiveLoggingContextAccessor.getLoggingContext(ctx));
+          return Mono.empty();
+        })
+    ).contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
+
+    StepVerifier.create(result)
+        .verifyComplete();
+
+    Map<String, String> ctx = capturedContext.get();
+    assertThat(ctx).isNotNull();
+    assertThat(ctx.get(LoggingContextKeys.USER_ID)).isEqualTo("sub-abc");
+    assertThat(ctx.get(LoggingContextKeys.USERNAME)).isEqualTo("user1");
+    assertThat(ctx.get(LoggingContextKeys.SESSION_ID)).isEqualTo("sid-xyz");
+  }
+
+  @Test
+  @DisplayName("인증 정보 없을 때 Context에 아무것도 추가되지 않는다")
+  void 미인증_컨텍스트_빔() {
+    MockServerWebExchange exchange = MockServerWebExchange.from(
+        MockServerHttpRequest.get("/test").build());
+
+    AtomicReference<Map<String, String>> capturedContext = new AtomicReference<>();
+
+    Mono<Void> result = filter.filter(exchange, serverWebExchange ->
+        Mono.deferContextual(ctx -> {
+          capturedContext.set(ReactiveLoggingContextAccessor.getLoggingContext(ctx));
+          return Mono.empty();
+        })
+    );
+
+    StepVerifier.create(result)
+        .verifyComplete();
+
+    Map<String, String> ctx = capturedContext.get();
+    assertThat(ctx.get(LoggingContextKeys.USER_ID)).isNull();
+    assertThat(ctx.get(LoggingContextKeys.USERNAME)).isNull();
+  }
+
+  private KeycloakPrincipal buildKeycloakPrincipal(
+      String subject, String username, String sid) {
+    OidcIdToken idToken = new OidcIdToken(
+        "id-tok",
+        Instant.now(),
+        Instant.now().plusSeconds(3600),
+        Map.of("sub", subject, "sid", sid, "preferred_username", username));
+    OidcUserInfo userInfo = new OidcUserInfo(
+        Map.of("sub", subject, "preferred_username", username, "sid", sid));
+    return new KeycloakPrincipal(subject, List.of(), idToken, userInfo);
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/filter/ReactiveBasicAuthenticationFilterTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/filter/ReactiveBasicAuthenticationFilterTest.java
@@ -1,0 +1,354 @@
+package com.ids.keycloak.security.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ids.keycloak.security.authentication.BasicAuthenticationToken;
+import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.ids.keycloak.security.util.JwtUtil;
+import com.sd.KeycloakClient.client.auth.async.KeycloakAuthAsyncClient;
+import com.sd.KeycloakClient.client.user.async.KeycloakUserAsyncClient;
+import com.sd.KeycloakClient.dto.KeycloakResponse;
+import com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo;
+import com.sd.KeycloakClient.dto.user.KeycloakUserInfo;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * {@link ReactiveBasicAuthenticationFilter} 단위 테스트.
+ *
+ * <p>Basic Auth 성공 시 {@code userAsync().getUserInfo(accessToken)}을 호출하여
+ * 상세 권한까지 Principal에 반영하는지 StepVerifier로 검증합니다.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class ReactiveBasicAuthenticationFilterTest {
+
+  @Mock
+  private KeycloakClient keycloakClient;
+
+  @Mock
+  private KeycloakAuthAsyncClient authAsyncClient;
+
+  @Mock
+  private KeycloakUserAsyncClient userAsyncClient;
+
+  private ReactiveBasicAuthenticationFilter filter;
+
+  private static final String CLIENT_ID = "test-client";
+  private static final String USERNAME = "testuser";
+  private static final String PASSWORD = "testpass";
+  private static final String ID_TOKEN = "id.token.value";
+  private static final String ACCESS_TOKEN = "access.token.value";
+  private static final String USER_SUB = "user-sub-123";
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(keycloakClient.authAsync()).thenReturn(authAsyncClient);
+    lenient().when(keycloakClient.userAsync()).thenReturn(userAsyncClient);
+    filter = new ReactiveBasicAuthenticationFilter(keycloakClient, CLIENT_ID);
+  }
+
+  private String buildBasicHeader(String username, String password) {
+    String credentials = username + ":" + password;
+    return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private MockServerWebExchange exchangeWithBasicAuth(String username, String password) {
+    MockServerHttpRequest request = MockServerHttpRequest.get("/api/test")
+        .header(HttpHeaders.AUTHORIZATION, buildBasicHeader(username, password))
+        .build();
+    return MockServerWebExchange.from(request);
+  }
+
+  private MockServerWebExchange exchangeWithoutAuth() {
+    MockServerHttpRequest request = MockServerHttpRequest.get("/api/test").build();
+    return MockServerWebExchange.from(request);
+  }
+
+  private KeycloakResponse<KeycloakTokenInfo> tokenResponse(int status) {
+    if (status == 200) {
+      KeycloakTokenInfo tokenInfo = KeycloakTokenInfo.builder()
+          .idToken(ID_TOKEN)
+          .accessToken(ACCESS_TOKEN)
+          .build();
+      return KeycloakResponse.<KeycloakTokenInfo>builder().status(200).body(tokenInfo).build();
+    }
+    return KeycloakResponse.<KeycloakTokenInfo>builder().status(status).build();
+  }
+
+  private KeycloakResponse<KeycloakUserInfo> userInfoResponse(int status, String role) {
+    if (status == 200) {
+      KeycloakUserInfo userInfo = new KeycloakUserInfo();
+      userInfo.setOtherInfo("sub", USER_SUB);
+      userInfo.setOtherInfo("preferred_username", USERNAME);
+      if (role != null) {
+        // resource_access 권한 포함 (클라이언트 역할)
+        Map<String, Object> clientRoles = new HashMap<>();
+        clientRoles.put("roles", java.util.List.of(role));
+        Map<String, Object> resourceAccess = new HashMap<>();
+        resourceAccess.put(CLIENT_ID, clientRoles);
+        userInfo.setOtherInfo("resource_access", resourceAccess);
+      }
+      return KeycloakResponse.<KeycloakUserInfo>builder().status(200).body(userInfo).build();
+    }
+    return KeycloakResponse.<KeycloakUserInfo>builder().status(status).build();
+  }
+
+  private Map<String, Object> buildIdTokenClaims() {
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("sub", USER_SUB);
+    return claims;
+  }
+
+  // ==========================================================================
+  // Basic 헤더 없음 → 다음 필터 통과
+  // ==========================================================================
+
+  @Nested
+  class Basic헤더_없음 {
+
+    @Test
+    void Basic_헤더_없으면_다음_필터_통과() {
+      MockServerWebExchange exchange = exchangeWithoutAuth();
+      boolean[] chainCalled = {false};
+
+      WebFilterChain chain = ex -> {
+        chainCalled[0] = true;
+        return Mono.empty();
+      };
+
+      StepVerifier.create(filter.filter(exchange, chain))
+          .verifyComplete();
+
+      assertThat(chainCalled[0]).isTrue();
+    }
+
+    @Test
+    void Bearer_헤더는_Basic이_아니므로_다음_필터_통과() {
+      MockServerHttpRequest request = MockServerHttpRequest.get("/api/test")
+          .header(HttpHeaders.AUTHORIZATION, "Bearer some.token")
+          .build();
+      MockServerWebExchange exchange = MockServerWebExchange.from(request);
+      boolean[] chainCalled = {false};
+
+      WebFilterChain chain = ex -> {
+        chainCalled[0] = true;
+        return Mono.empty();
+      };
+
+      StepVerifier.create(filter.filter(exchange, chain))
+          .verifyComplete();
+
+      assertThat(chainCalled[0]).isTrue();
+    }
+  }
+
+  // ==========================================================================
+  // Basic 인증 성공 + UserInfo 조회
+  // ==========================================================================
+
+  @Nested
+  class Basic_인증_성공 {
+
+    @Test
+    void 인증_성공시_getUserInfo_호출_후_권한_반영된_Principal_생성() {
+      MockServerWebExchange exchange = exchangeWithBasicAuth(USERNAME, PASSWORD);
+
+      when(authAsyncClient.basicAuth(USERNAME, PASSWORD))
+          .thenReturn(Mono.just(tokenResponse(200)));
+      when(userAsyncClient.getUserInfo(ACCESS_TOKEN))
+          .thenReturn(Mono.just(userInfoResponse(200, "ROLE_USER")));
+
+      // SecurityContext에 담기는 Authentication 캡처
+      Authentication[] capturedAuth = new Authentication[1];
+      WebFilterChain chain = ex ->
+          ReactiveSecurityContextHolder.getContext()
+              .doOnNext(ctx -> capturedAuth[0] = ctx.getAuthentication())
+              .then();
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseSubjectWithoutValidation(ID_TOKEN))
+            .thenReturn(USER_SUB);
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(ID_TOKEN))
+            .thenReturn(buildIdTokenClaims());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+            .verifyComplete();
+      }
+
+      assertThat(capturedAuth[0]).isNotNull();
+      assertThat(capturedAuth[0].isAuthenticated()).isTrue();
+      assertThat(capturedAuth[0]).isInstanceOf(BasicAuthenticationToken.class);
+
+      BasicAuthenticationToken token = (BasicAuthenticationToken) capturedAuth[0];
+      assertThat(token.getPrincipal()).isInstanceOf(KeycloakPrincipal.class);
+      KeycloakPrincipal principal = (KeycloakPrincipal) token.getPrincipal();
+      assertThat(principal.getName()).isEqualTo(USER_SUB);
+    }
+
+    @Test
+    void getUserInfo_실패시_ID_Token_클레임으로_폴백() {
+      MockServerWebExchange exchange = exchangeWithBasicAuth(USERNAME, PASSWORD);
+
+      when(authAsyncClient.basicAuth(USERNAME, PASSWORD))
+          .thenReturn(Mono.just(tokenResponse(200)));
+      when(userAsyncClient.getUserInfo(ACCESS_TOKEN))
+          .thenReturn(Mono.just(userInfoResponse(401, null)));
+
+      Authentication[] capturedAuth = new Authentication[1];
+      WebFilterChain chain = ex ->
+          ReactiveSecurityContextHolder.getContext()
+              .doOnNext(ctx -> capturedAuth[0] = ctx.getAuthentication())
+              .then();
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseSubjectWithoutValidation(ID_TOKEN))
+            .thenReturn(USER_SUB);
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(ID_TOKEN))
+            .thenReturn(buildIdTokenClaims());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+            .verifyComplete();
+      }
+
+      // UserInfo 실패해도 폴백으로 인증 성공
+      assertThat(capturedAuth[0]).isNotNull();
+      assertThat(capturedAuth[0].isAuthenticated()).isTrue();
+    }
+
+    @Test
+    void getUserInfo_통신_오류시_ID_Token_클레임으로_폴백() {
+      MockServerWebExchange exchange = exchangeWithBasicAuth(USERNAME, PASSWORD);
+
+      when(authAsyncClient.basicAuth(USERNAME, PASSWORD))
+          .thenReturn(Mono.just(tokenResponse(200)));
+      when(userAsyncClient.getUserInfo(ACCESS_TOKEN))
+          .thenReturn(Mono.error(new RuntimeException("network error")));
+
+      Authentication[] capturedAuth = new Authentication[1];
+      WebFilterChain chain = ex ->
+          ReactiveSecurityContextHolder.getContext()
+              .doOnNext(ctx -> capturedAuth[0] = ctx.getAuthentication())
+              .then();
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseSubjectWithoutValidation(ID_TOKEN))
+            .thenReturn(USER_SUB);
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(ID_TOKEN))
+            .thenReturn(buildIdTokenClaims());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+            .verifyComplete();
+      }
+
+      // 오류 시에도 폴백으로 인증 성공
+      assertThat(capturedAuth[0]).isNotNull();
+      assertThat(capturedAuth[0].isAuthenticated()).isTrue();
+    }
+
+    @Test
+    void getUserInfo_성공시_UserInfo에서_OidcUserInfo_설정됨() {
+      MockServerWebExchange exchange = exchangeWithBasicAuth(USERNAME, PASSWORD);
+
+      when(authAsyncClient.basicAuth(USERNAME, PASSWORD))
+          .thenReturn(Mono.just(tokenResponse(200)));
+      when(userAsyncClient.getUserInfo(ACCESS_TOKEN))
+          .thenReturn(Mono.just(userInfoResponse(200, null)));
+
+      Authentication[] capturedAuth = new Authentication[1];
+      WebFilterChain chain = ex ->
+          ReactiveSecurityContextHolder.getContext()
+              .doOnNext(ctx -> capturedAuth[0] = ctx.getAuthentication())
+              .then();
+
+      try (MockedStatic<JwtUtil> jwtMock = mockStatic(JwtUtil.class)) {
+        jwtMock.when(() -> JwtUtil.parseSubjectWithoutValidation(ID_TOKEN))
+            .thenReturn(USER_SUB);
+        jwtMock.when(() -> JwtUtil.parseClaimsWithoutValidation(ID_TOKEN))
+            .thenReturn(buildIdTokenClaims());
+
+        StepVerifier.create(filter.filter(exchange, chain))
+            .verifyComplete();
+      }
+
+      BasicAuthenticationToken token = (BasicAuthenticationToken) capturedAuth[0];
+      KeycloakPrincipal principal = (KeycloakPrincipal) token.getPrincipal();
+      // UserInfo 조회 성공 시 UserInfo가 설정됨
+      assertThat(principal.getUserInfo()).isNotNull();
+    }
+  }
+
+  // ==========================================================================
+  // Basic 인증 실패
+  // ==========================================================================
+
+  @Nested
+  class Basic_인증_실패 {
+
+    @Test
+    void keycloak_401_응답시_다음_필터_통과() {
+      MockServerWebExchange exchange = exchangeWithBasicAuth(USERNAME, PASSWORD);
+      boolean[] chainCalled = {false};
+
+      when(authAsyncClient.basicAuth(USERNAME, PASSWORD))
+          .thenReturn(Mono.just(tokenResponse(401)));
+
+      WebFilterChain chain = ex -> {
+        chainCalled[0] = true;
+        return Mono.empty();
+      };
+
+      StepVerifier.create(filter.filter(exchange, chain))
+          .verifyComplete();
+
+      assertThat(chainCalled[0]).isTrue();
+      // UserInfo 조회 미호출
+      verify(userAsyncClient, never()).getUserInfo(any());
+    }
+
+    @Test
+    void 통신_오류시_다음_필터_통과() {
+      MockServerWebExchange exchange = exchangeWithBasicAuth(USERNAME, PASSWORD);
+      boolean[] chainCalled = {false};
+
+      when(authAsyncClient.basicAuth(USERNAME, PASSWORD))
+          .thenReturn(Mono.error(new RuntimeException("Connection refused")));
+
+      WebFilterChain chain = ex -> {
+        chainCalled[0] = true;
+        return Mono.empty();
+      };
+
+      StepVerifier.create(filter.filter(exchange, chain))
+          .verifyComplete();
+
+      assertThat(chainCalled[0]).isTrue();
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/logging/MdcContextPropagationAccessorTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/logging/MdcContextPropagationAccessorTest.java
@@ -1,0 +1,194 @@
+package com.ids.keycloak.security.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.util.context.Context;
+
+/**
+ * {@link MdcContextPropagationAccessor} 단위 테스트.
+ *
+ * <p>Reactor Context ↔ MDC 브릿지가 올바르게 동작하는지 검증합니다.
+ * MDC 전파는 {@code Hooks.enableAutomaticContextPropagation()} 전역 훅이 필요하므로
+ * 직접 accessor 메서드를 호출하여 검증합니다.</p>
+ */
+class MdcContextPropagationAccessorTest {
+
+  private final MdcContextPropagationAccessor accessor = new MdcContextPropagationAccessor();
+
+  @AfterEach
+  void clearMdc() {
+    MDC.clear();
+  }
+
+  // ==========================================================================
+  // key() 검증
+  // ==========================================================================
+
+  @Test
+  void key_returns_KEYCLOAK_LOGGING_CONTEXT() {
+    assertThat(accessor.key()).isEqualTo(ReactiveLoggingContextAccessor.CONTEXT_KEY);
+  }
+
+  // ==========================================================================
+  // getValue() — 현재 MDC에서 로깅 컨텍스트 추출
+  // ==========================================================================
+
+  @Nested
+  class getValue {
+
+    @Test
+    void MDC_비어있으면_빈_맵_반환() {
+      Map<String, String> result = accessor.getValue();
+      assertThat(result).isEmpty();
+    }
+
+    @Test
+    void MDC에_traceId_있으면_포함하여_반환() {
+      MDC.put(LoggingContextKeys.TRACE_ID, "trace-123");
+
+      Map<String, String> result = accessor.getValue();
+
+      assertThat(result).containsEntry(LoggingContextKeys.TRACE_ID, "trace-123");
+    }
+
+    @Test
+    void MDC에_여러_로깅키_있으면_모두_반환() {
+      MDC.put(LoggingContextKeys.TRACE_ID, "t1");
+      MDC.put(LoggingContextKeys.USER_ID, "user1");
+      MDC.put(LoggingContextKeys.HTTP_METHOD, "GET");
+      MDC.put("unrelated-key", "should-not-be-included");
+
+      Map<String, String> result = accessor.getValue();
+
+      assertThat(result).containsEntry(LoggingContextKeys.TRACE_ID, "t1");
+      assertThat(result).containsEntry(LoggingContextKeys.USER_ID, "user1");
+      assertThat(result).containsEntry(LoggingContextKeys.HTTP_METHOD, "GET");
+      // 관리 키가 아닌 값은 포함되지 않음
+      assertThat(result).doesNotContainKey("unrelated-key");
+    }
+  }
+
+  // ==========================================================================
+  // restore() — Reactor Context → MDC 복원
+  // ==========================================================================
+
+  @Nested
+  class restore {
+
+    @Test
+    void null_전달시_MDC_변경_없음() {
+      accessor.restore(null);
+      assertThat(MDC.getCopyOfContextMap()).isNullOrEmpty();
+    }
+
+    @Test
+    void 빈_맵_전달시_MDC_변경_없음() {
+      accessor.restore(new HashMap<>());
+      assertThat(MDC.getCopyOfContextMap()).isNullOrEmpty();
+    }
+
+    @Test
+    void 로깅컨텍스트_맵_전달시_MDC에_설정됨() {
+      Map<String, String> context = new HashMap<>();
+      context.put(LoggingContextKeys.TRACE_ID, "restored-trace");
+      context.put(LoggingContextKeys.USER_ID, "restored-user");
+
+      accessor.restore(context);
+
+      assertThat(MDC.get(LoggingContextKeys.TRACE_ID)).isEqualTo("restored-trace");
+      assertThat(MDC.get(LoggingContextKeys.USER_ID)).isEqualTo("restored-user");
+    }
+  }
+
+  // ==========================================================================
+  // setValue() — MDC 설정 (restore와 동일)
+  // ==========================================================================
+
+  @Nested
+  class setValue {
+
+    @Test
+    void setValue_호출시_MDC에_설정됨() {
+      Map<String, String> context = new HashMap<>();
+      context.put(LoggingContextKeys.TRACE_ID, "set-trace");
+
+      accessor.setValue(context);
+
+      assertThat(MDC.get(LoggingContextKeys.TRACE_ID)).isEqualTo("set-trace");
+    }
+  }
+
+  // ==========================================================================
+  // reset() — MDC 정리
+  // ==========================================================================
+
+  @Nested
+  class reset {
+
+    @Test
+    void reset_호출시_로깅키_MDC에서_제거됨() {
+      MDC.put(LoggingContextKeys.TRACE_ID, "trace");
+      MDC.put(LoggingContextKeys.USER_ID, "user");
+      MDC.put("unrelated-key", "keep");
+
+      accessor.reset();
+
+      assertThat(MDC.get(LoggingContextKeys.TRACE_ID)).isNull();
+      assertThat(MDC.get(LoggingContextKeys.USER_ID)).isNull();
+      // 관리하지 않는 키는 유지
+      assertThat(MDC.get("unrelated-key")).isEqualTo("keep");
+    }
+  }
+
+  // ==========================================================================
+  // Reactor Context ↔ MDC 브릿지 통합 검증
+  // ==========================================================================
+
+  @Nested
+  class Reactor_Context_MDC_브릿지 {
+
+    /**
+     * ReactiveLoggingContextAccessor.putValue로 Reactor Context에 저장된 값이
+     * bridgeToMdc 호출 시 MDC에 복사되는지 검증합니다.
+     */
+    @Test
+    void Reactor_Context에서_bridgeToMdc_호출시_MDC에_설정됨() {
+      Context ctx = ReactiveLoggingContextAccessor.putValue(
+          Context.empty(), LoggingContextKeys.TRACE_ID, "ctx-trace");
+
+      Mono<String> mono = Mono.deferContextual(contextView -> {
+        ReactiveLoggingContextAccessor.bridgeToMdc(contextView);
+        String mdcValue = MDC.get(LoggingContextKeys.TRACE_ID);
+        ReactiveLoggingContextAccessor.clearMdc(contextView);
+        return Mono.just(mdcValue != null ? mdcValue : "null");
+      }).contextWrite(ctx);
+
+      StepVerifier.create(mono)
+          .expectNext("ctx-trace")
+          .verifyComplete();
+    }
+
+    @Test
+    void Reactor_Context_에_없는_키는_MDC에_없음() {
+      Context ctx = Context.empty();
+
+      Mono<String> mono = Mono.deferContextual(contextView -> {
+        ReactiveLoggingContextAccessor.bridgeToMdc(contextView);
+        String mdcValue = MDC.get(LoggingContextKeys.TRACE_ID);
+        return Mono.just(mdcValue != null ? mdcValue : "null");
+      }).contextWrite(ctx);
+
+      StepVerifier.create(mono)
+          .expectNext("null")
+          .verifyComplete();
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/manager/KeycloakReactiveAuthorizationManagerTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/manager/KeycloakReactiveAuthorizationManagerTest.java
@@ -1,0 +1,217 @@
+package com.ids.keycloak.security.manager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ids.keycloak.security.authentication.BasicAuthenticationToken;
+import com.ids.keycloak.security.authentication.KeycloakAuthentication;
+import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.sd.KeycloakClient.client.auth.async.KeycloakAuthAsyncClient;
+import com.sd.KeycloakClient.dto.KeycloakResponse;
+import com.sd.KeycloakClient.dto.auth.KeycloakAuthorizationResult;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
+import org.springframework.security.web.server.authorization.AuthorizationContext;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * {@link KeycloakReactiveAuthorizationManager} 단위 테스트.
+ *
+ * <p>flat mock 방식으로 deep stub UnfinishedStubbing 을 회피합니다.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class KeycloakReactiveAuthorizationManagerTest {
+
+  private KeycloakReactiveAuthorizationManager manager;
+
+  @Mock
+  private KeycloakClient keycloakClient;
+
+  @Mock
+  private KeycloakAuthAsyncClient authAsyncClient;
+
+  private static final String ACCESS_TOKEN = "test-access-token";
+  private static final String REQUEST_URI = "/api/resource";
+  private static final String REQUEST_METHOD = "GET";
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(keycloakClient.authAsync()).thenReturn(authAsyncClient);
+    manager = new KeycloakReactiveAuthorizationManager(keycloakClient);
+  }
+
+  // ------------------------------------------------------------------
+  // Helpers
+  // ------------------------------------------------------------------
+
+  private AuthorizationContext mockContext() {
+    MockServerHttpRequest request = MockServerHttpRequest
+        .method(org.springframework.http.HttpMethod.GET, REQUEST_URI)
+        .build();
+    MockServerWebExchange exchange = MockServerWebExchange.from(request);
+    AuthorizationContext context = mock(AuthorizationContext.class);
+    when(context.getExchange()).thenReturn(exchange);
+    return context;
+  }
+
+  private KeycloakAuthentication buildKeycloakAuth(boolean authenticated) {
+    OidcIdToken oidcIdToken = new OidcIdToken(
+        "token", Instant.now(), Instant.now().plusSeconds(3600), Map.of("sub", "user-1"));
+    KeycloakPrincipal principal =
+        new KeycloakPrincipal("user-1", Collections.emptyList(), oidcIdToken, null);
+    return new KeycloakAuthentication(principal, "token", ACCESS_TOKEN, authenticated);
+  }
+
+  private KeycloakResponse<KeycloakAuthorizationResult> grantedResponse(boolean granted) {
+    KeycloakAuthorizationResult result = KeycloakAuthorizationResult.builder()
+        .granted(granted)
+        .build();
+    return KeycloakResponse.<KeycloakAuthorizationResult>builder()
+        .status(200)
+        .body(result)
+        .build();
+  }
+
+  // ==========================================================================
+  // 허용
+  // ==========================================================================
+
+  @Nested
+  class 인가_허용 {
+
+    @Test
+    void KeycloakAuthentication_인증됨_Keycloak_허용_true_반환() {
+      when(authAsyncClient.authorization(ACCESS_TOKEN, REQUEST_URI, REQUEST_METHOD))
+          .thenReturn(Mono.just(grantedResponse(true)));
+
+      StepVerifier.create(manager.check(Mono.just(buildKeycloakAuth(true)), mockContext()))
+          .expectNextMatches(AuthorizationDecision::isGranted)
+          .verifyComplete();
+    }
+
+    @Test
+    void BearerTokenAuthentication_인증됨_Keycloak_허용_true_반환() {
+      BearerTokenAuthentication bearerAuth = mock(BearerTokenAuthentication.class);
+      OAuth2AccessToken oauthToken = mock(OAuth2AccessToken.class);
+      when(bearerAuth.isAuthenticated()).thenReturn(true);
+      when(bearerAuth.getToken()).thenReturn(oauthToken);
+      when(oauthToken.getTokenValue()).thenReturn(ACCESS_TOKEN);
+
+      when(authAsyncClient.authorization(ACCESS_TOKEN, REQUEST_URI, REQUEST_METHOD))
+          .thenReturn(Mono.just(grantedResponse(true)));
+
+      StepVerifier.create(manager.check(Mono.just(bearerAuth), mockContext()))
+          .expectNextMatches(AuthorizationDecision::isGranted)
+          .verifyComplete();
+    }
+
+    @Test
+    void BasicAuthenticationToken_AccessTokenHolder_인증됨_허용_true_반환() {
+      BasicAuthenticationToken basicAuth = mock(BasicAuthenticationToken.class);
+      when(basicAuth.isAuthenticated()).thenReturn(true);
+      when(basicAuth.getAccessToken()).thenReturn(ACCESS_TOKEN);
+
+      when(authAsyncClient.authorization(ACCESS_TOKEN, REQUEST_URI, REQUEST_METHOD))
+          .thenReturn(Mono.just(grantedResponse(true)));
+
+      StepVerifier.create(manager.check(Mono.just(basicAuth), mockContext()))
+          .expectNextMatches(AuthorizationDecision::isGranted)
+          .verifyComplete();
+    }
+  }
+
+  // ==========================================================================
+  // 거부
+  // ==========================================================================
+
+  @Nested
+  class 인가_거부 {
+
+    @Test
+    void Keycloak_거부_false_반환() {
+      when(authAsyncClient.authorization(ACCESS_TOKEN, REQUEST_URI, REQUEST_METHOD))
+          .thenReturn(Mono.just(grantedResponse(false)));
+
+      StepVerifier.create(manager.check(Mono.just(buildKeycloakAuth(true)), mockContext()))
+          .expectNextMatches(decision -> !decision.isGranted())
+          .verifyComplete();
+    }
+
+    @Test
+    void Keycloak_응답_body_없으면_false_반환() {
+      KeycloakResponse<KeycloakAuthorizationResult> emptyResp =
+          KeycloakResponse.<KeycloakAuthorizationResult>builder().status(200).build();
+
+      when(authAsyncClient.authorization(ACCESS_TOKEN, REQUEST_URI, REQUEST_METHOD))
+          .thenReturn(Mono.just(emptyResp));
+
+      StepVerifier.create(manager.check(Mono.just(buildKeycloakAuth(true)), mockContext()))
+          .expectNextMatches(decision -> !decision.isGranted())
+          .verifyComplete();
+    }
+
+    @Test
+    void Keycloak_통신_오류시_false_반환() {
+      when(authAsyncClient.authorization(ACCESS_TOKEN, REQUEST_URI, REQUEST_METHOD))
+          .thenReturn(Mono.error(new RuntimeException("Connection refused")));
+
+      StepVerifier.create(manager.check(Mono.just(buildKeycloakAuth(true)), mockContext()))
+          .expectNextMatches(decision -> !decision.isGranted())
+          .verifyComplete();
+    }
+  }
+
+  // ==========================================================================
+  // 미인증 / 미지원 타입
+  // ==========================================================================
+
+  @Nested
+  class 미인증_또는_미지원_타입 {
+
+    @Test
+    void 미인증_Authentication_false_반환() {
+      // 미인증 → Mono.filter 에서 empty → defaultIfEmpty(false)
+      StepVerifier.create(manager.check(Mono.just(buildKeycloakAuth(false)), mockContext()))
+          .expectNextMatches(decision -> !decision.isGranted())
+          .verifyComplete();
+    }
+
+    @Test
+    void empty_Mono_false_반환() {
+      StepVerifier.create(manager.check(Mono.empty(), mockContext()))
+          .expectNextMatches(decision -> !decision.isGranted())
+          .verifyComplete();
+    }
+
+    @Test
+    void UsernamePasswordAuthenticationToken_미지원_타입_false_반환() {
+      // UsernamePasswordAuthenticationToken 은 인증됨 상태지만 AccessTokenHolder 도 BearerToken 도 아님
+      // extractAccessToken → null → filter(null) → empty → defaultIfEmpty(false)
+      Authentication unsupported = new UsernamePasswordAuthenticationToken(
+          "user", "pass", Collections.emptyList());
+
+      StepVerifier.create(manager.check(Mono.just(unsupported), mockContext()))
+          .expectNextMatches(decision -> !decision.isGranted())
+          .verifyComplete();
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/web/reactive/KeycloakServerAuthenticationEntryPointTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/web/reactive/KeycloakServerAuthenticationEntryPointTest.java
@@ -1,0 +1,184 @@
+package com.ids.keycloak.security.web.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ids.keycloak.security.config.KeycloakErrorProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.BadCredentialsException;
+import reactor.test.StepVerifier;
+
+/**
+ * KeycloakServerAuthenticationEntryPoint 분기 단위 테스트.
+ * - Bearer Token 요청 → WWW-Authenticate: Bearer + 401
+ * - Basic Auth 요청 + basicAuthEnabled=true → WWW-Authenticate: Basic + 401
+ * - redirectEnabled=true + AJAX → JSON 401
+ * - redirectEnabled=true (비-AJAX) → 302 리다이렉트
+ * - API 모드 기본 → JSON 401
+ */
+class KeycloakServerAuthenticationEntryPointTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+  }
+
+  // =========================================================
+  // API 모드 (기본)
+  // =========================================================
+  @Nested
+  @DisplayName("API 모드 (redirect-enabled=false)")
+  class API_모드 {
+
+    @Test
+    @DisplayName("Bearer 헤더 요청 → 401 + WWW-Authenticate: Bearer")
+    void Bearer_요청_401_WWW_Authenticate() {
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(
+          objectMapper, new KeycloakErrorProperties(), false, "myrealm");
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/api/resource")
+              .header(HttpHeaders.AUTHORIZATION, "Bearer some.token.here")
+              .build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+      String wwwAuth = exchange.getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE);
+      assertThat(wwwAuth).startsWith("Bearer realm=\"myrealm\"");
+    }
+
+    @Test
+    @DisplayName("Basic 헤더 요청 + basicAuthEnabled=true → 401 + WWW-Authenticate: Basic")
+    void Basic_요청_WWW_Authenticate() {
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(
+          objectMapper, new KeycloakErrorProperties(), true, "myrealm");
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/api/resource")
+              .header(HttpHeaders.AUTHORIZATION, "Basic dXNlcjpwYXNz")
+              .build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+      String wwwAuth = exchange.getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE);
+      assertThat(wwwAuth).startsWith("Basic realm=\"myrealm\"");
+    }
+
+    @Test
+    @DisplayName("Basic 헤더 요청 + basicAuthEnabled=false → WWW-Authenticate 없이 401 JSON")
+    void Basic_요청_basicAuth_비활성화시_JSON() {
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(
+          objectMapper, new KeycloakErrorProperties(), false, "myrealm");
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/api/resource")
+              .header(HttpHeaders.AUTHORIZATION, "Basic dXNlcjpwYXNz")
+              .build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+      assertThat(exchange.getResponse().getHeaders().containsKey(HttpHeaders.WWW_AUTHENTICATE)).isFalse();
+    }
+
+    @Test
+    @DisplayName("일반 요청 → 401 JSON 응답")
+    void 일반_요청_401_JSON() {
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(objectMapper);
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/api/resource").build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  // =========================================================
+  // Redirect 모드
+  // =========================================================
+  @Nested
+  @DisplayName("Redirect 모드 (redirect-enabled=true)")
+  class Redirect_모드 {
+
+    @Test
+    @DisplayName("비-AJAX 요청 → 302 리다이렉트")
+    void 비_AJAX_리다이렉트() {
+      KeycloakErrorProperties errorProps = new KeycloakErrorProperties();
+      errorProps.setRedirectEnabled(true);
+      errorProps.setAuthenticationFailedRedirectUrl("/login");
+
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(
+          objectMapper, errorProps, false, null);
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/protected").build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FOUND);
+      assertThat(exchange.getResponse().getHeaders().getLocation().getPath()).isEqualTo("/login");
+    }
+
+    @Test
+    @DisplayName("AJAX 요청 + ajaxReturnsJson=true → 401 JSON")
+    void AJAX_요청_JSON() {
+      KeycloakErrorProperties errorProps = new KeycloakErrorProperties();
+      errorProps.setRedirectEnabled(true);
+      errorProps.setAjaxReturnsJson(true);
+      errorProps.setAuthenticationFailedRedirectUrl("/login");
+
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(
+          objectMapper, errorProps, false, null);
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/protected")
+              .header("X-Requested-With", "XMLHttpRequest")
+              .build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("Bearer 요청은 redirect 모드여도 WWW-Authenticate: Bearer 응답")
+    void Bearer_요청은_리다이렉트_아님() {
+      KeycloakErrorProperties errorProps = new KeycloakErrorProperties();
+      errorProps.setRedirectEnabled(true);
+
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(
+          objectMapper, errorProps, false, "realm");
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/api")
+              .header(HttpHeaders.AUTHORIZATION, "Bearer tok")
+              .build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+      assertThat(exchange.getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE))
+          .startsWith("Bearer");
+    }
+  }
+}


### PR DESCRIPTION
Closes #44

servlet(v1.7.0)을 정답지로 **WebFlux 스택 전체를 servlet과 기능 동등하게** 구현. core 모듈 재사용, web 계층만 reactive 포팅.

## 구현
OIDC 로그인(`oauth2Login`+쿠키/세션) · Bearer · Basic · 인가(Authorization Services) · RateLimit · CSRF · Front/Back-Channel 로그아웃 · MDC 로깅(Reactor Context)

- KeycloakClient `authAsync()`/`userAsync()` Mono API로 **완전 non-blocking**
- Fail-Open 방지(Bean 이름 조건 + `securityMatcher` + `@Order(LOWEST_PRECEDENCE)`) reactive 이식
- 설정은 servlet과 100% 공유 (core Properties)

## 품질 (문서화→구현→테스트→코드리뷰 2회)
- **코드리뷰 2회로 패리티 갭 + 런타임 버그 8건 발견·수정**:
  - 패리티: `oauth2Login` 누락, EntryPoint redirect/Bearer/Basic 분기, RP-Initiated 로그아웃, `ReactiveAuthLoggingFilter` 죽은 코드
  - 런타임: `session.save()` 미구독(Redis 영속 누락), Mono 즉시평가, `map` null→NPE, `onErrorResume` 과잉포착 등
- **테스트 96개**(StepVerifier 기반), **servlet/core 회귀 0**

## 차이 (아키텍처 특성)
- OAuth2 AuthorizedClient 기본 InMemory(프로덕션 Redis 권장), MDC Reactor 전파 기본 off(`mdc-propagation-enabled`)

## 버전
`1.7.0` → `1.8.0` (reactive 신규, servlet breaking 없음). `docs/GUIDE.md` §8 reactive 추가.