### PR TITLE
[#46] feat: OIDC authorize 파라미터(acr_values/max_age/prompt) 커스터마이즈 지원 (v1.9.0)

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3,7 +3,7 @@
 Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 하나와 최소 설정으로 OIDC 로그인·세션·로그아웃·인가가 자동 구성됩니다.
 
 - **지원**: JDK 17+, Spring Boot 3.5.x, Spring Security 6.5.x
-- **현재 버전**: `1.8.0`
+- **현재 버전**: `1.9.0`
 - **스택**: Servlet(Spring MVC) / **Reactive(WebFlux) — v1.8.0부터 servlet과 기능 동등** ([8. Reactive](#8-reactivewebflux))
 - 이 문서는 **도입 개발자용 사용 가이드**입니다. 아키텍처/기여 규칙은 [README](../README.md) 참고.
 
@@ -112,6 +112,9 @@ MdcRequestFilter (traceId 등 MDC)
 | `authentication.permit-all-paths` | `[]` | 인증 없이 허용할 경로 (Ant) |
 | `authentication.default-success-url` | `/` | 로그인 성공 후 리다이렉트 |
 | `authentication.login-paths` | `[/api/keycloak/login]` | body 기반 로그인으로 분류할 경로 |
+| `authentication.authorization-request.acr-values` | (없음) | OIDC authorize 요청의 `acr_values` (LoA step-up). 예: `loa2` |
+| `authentication.authorization-request.max-age` | (없음) | `max_age`(초). 마지막 인증 후 경과 시 재인증. 예: `1800` |
+| `authentication.authorization-request.prompt` | (없음) | `prompt`. `login`(강제 재인증)/`consent`/`none`/`select_account` |
 
 ### 3.2 인가 (`authorization`)
 | 키 | 기본값 | 설명 |
@@ -263,6 +266,34 @@ SecurityFilterChain actuatorChain(HttpSecurity http) throws Exception {
 ```
 Keycloak 기본 체인을 끄고 직접 구성하려면 `auto-filter-chain: false`. 자세히는 [12](12-SecurityFilterChain-FailOpen-수정.md).
 
+### 4.9 재인증 / Step-up (acr_values · max_age · prompt) (v1.9.0+)
+Keycloak LoA step-up·재인증을 쓰려면 OIDC authorize 요청에 `acr_values`/`max_age`/`prompt`를 실어야 합니다. 라이브러리가 `oauth2Login`에 resolver를 연결하므로, **두 가지 방법**으로 주입할 수 있습니다.
+
+**(1) 전역 — 프로퍼티 (모든 로그인에 동일 적용)**
+```yaml
+keycloak:
+  security:
+    authentication:
+      authorization-request:
+        max-age: 1800       # 마지막 인증 후 30분 경과 시 재인증
+        # acr-values: loa2  # LoA step-up
+        # prompt: login     # 강제 재인증
+```
+
+**(2) 경로별 Step-up — 커스텀 resolver 빈 (특정 경로에서만 강한 인증)**
+`OAuth2AuthorizationRequestResolver`(servlet)/`ServerOAuth2AuthorizationRequestResolver`(reactive) 빈을 등록하면 라이브러리 기본 빈을 대체합니다(`@ConditionalOnMissingBean`). 요청 경로를 보고 동적으로 `acr_values`를 결정:
+```java
+@Bean
+OAuth2AuthorizationRequestResolver authorizationRequestResolver(ClientRegistrationRepository repo) {
+    var resolver = new DefaultOAuth2AuthorizationRequestResolver(repo, "/oauth2/authorization"); // baseUri 유지
+    resolver.setAuthorizationRequestCustomizer(builder ->
+        builder.additionalParameters(p -> p.put("acr_values", "loa2")));  // 조건 분기 가능
+    return resolver;
+}
+```
+> ⚠️ 커스텀 빈을 등록할 때 baseUri는 `/oauth2/authorization`을 유지해야 로그인 진입 경로가 깨지지 않습니다.
+> ⚠️ `prompt=none` + `max_age`를 함께 쓰고 재인증이 필요하면 Keycloak이 `login_required` 에러를 반환합니다(정상 동작).
+
 ---
 
 ## 5. 확장점
@@ -290,6 +321,7 @@ LoggingValueSanitizer loggingValueSanitizer() {
 
 | 버전 | 변경 | 주의 |
 |------|------|------|
+| **1.9.0** | OIDC authorize 파라미터(`acr_values`/`max_age`/`prompt`) 커스터마이즈 — LoA step-up·재인증 | 미설정 시 무동작(회귀 0). 경로별 step-up은 resolver 빈 재정의([4.9](#49-재인증--step-up-acr_values--max_age--prompt-v190)) |
 | **1.8.0** | **Reactive(WebFlux) 스택 추가** — servlet과 기능 동등 (OIDC 로그인·세션·인가·Bearer·Basic·RateLimit·CSRF·로그아웃·MDC 로깅) | `keycloak-spring-security-webflux-starter` 신규. servlet 사용자는 영향 없음 |
 | **1.7.0** | 응답 메트릭(status/durationMs, 기본 off) + exclude-patterns(/actuator) | — |
 | **1.6.0** | MDC PII 마스킹 **기본 on** + userAgent/query 정제 + X-Request-Id 회신 | 로그 PII가 마스킹됨. 해제는 `NoOpLoggingValueSanitizer` |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version Management
-projectVersion=1.8.0
+projectVersion=1.9.0
 
 # Maven Publishing Info
 mavenGroupId=io.github.l-dxd

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakAuthenticationProperties.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakAuthenticationProperties.java
@@ -2,6 +2,7 @@ package com.ids.keycloak.security.config;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.List;
  *       permit-all-paths:
  *         - /public/**
  *         - /health
- *       default_success_url: /home
+ *       default-success-url: /home
  * </pre>
  * </p>
  */
@@ -53,4 +54,27 @@ public class KeycloakAuthenticationProperties {
      * </p>
      */
     private List<String> loginPaths = new ArrayList<>(List.of("/api/keycloak/login"));
+
+    /**
+     * OIDC authorize 요청에 추가할 파라미터 설정.
+     * <p>
+     * acr_values, max_age, prompt 파라미터를 제어합니다.
+     * 모든 필드의 기본값은 null이므로 미설정 시 기존 authorize 요청과 동일하게 동작합니다.
+     * </p>
+     * <p>
+     * application.yaml:
+     * <pre>
+     * keycloak:
+     *   security:
+     *     authentication:
+     *       authorization-request:
+     *         acr-values: "gold"
+     *         max-age: 3600
+     *         prompt: "login"
+     * </pre>
+     * </p>
+     */
+    @NestedConfigurationProperty
+    private KeycloakAuthorizationRequestProperties authorizationRequest =
+        new KeycloakAuthorizationRequestProperties();
 }

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakAuthorizationRequestProperties.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakAuthorizationRequestProperties.java
@@ -1,0 +1,58 @@
+package com.ids.keycloak.security.config;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * OIDC authorize 요청에 추가할 파라미터 설정입니다.
+ *
+ * <p>이 설정은 OAuth2/OIDC 인가(authorization) 엔드포인트로 리다이렉트할 때
+ * 쿼리 스트링에 포함할 추가 파라미터를 제어합니다.
+ * 인가(authorization) 서버의 접근 제어 정책과는 무관합니다.</p>
+ *
+ * <p>application.yaml 예시:
+ * <pre>
+ * keycloak:
+ *   security:
+ *     authentication:
+ *       authorization-request:
+ *         acr-values: "gold"
+ *         max-age: 3600
+ *         prompt: "login"
+ * </pre>
+ * </p>
+ *
+ * <p>모든 필드의 기본값은 {@code null}이며, {@code null}인 필드는 authorize 요청에 포함되지 않습니다.
+ * 세 값이 모두 {@code null}이면 기존 authorize 요청과 완전히 동일하게 동작합니다(회귀 0).</p>
+ */
+@Getter
+@Setter
+public class KeycloakAuthorizationRequestProperties {
+
+  /**
+   * OIDC {@code acr_values} 파라미터.
+   *
+   * <p>요청할 인증 컨텍스트 클래스 레퍼런스(Authentication Context Class Reference)를 지정합니다.
+   * 공백으로 구분된 복수 값을 허용합니다(예: {@code "gold silver"}).
+   * {@code null}이면 요청에 포함되지 않습니다.</p>
+   */
+  private String acrValues;
+
+  /**
+   * OIDC {@code max_age} 파라미터 (초 단위).
+   *
+   * <p>인증 경과 시간의 허용 최대값을 지정합니다. {@code 0}은 항상 재인증을 요구합니다.
+   * {@code null}이면 요청에 포함되지 않습니다.</p>
+   */
+  private Integer maxAge;
+
+  /**
+   * OIDC {@code prompt} 파라미터.
+   *
+   * <p>인증 서버가 사용자에게 재인증이나 동의를 요청하는 방식을 제어합니다.
+   * 허용값: {@code "none"}, {@code "login"}, {@code "consent"}, {@code "select_account"}.
+   * 공백으로 구분된 복수 값도 허용합니다(예: {@code "login consent"}).
+   * {@code null}이면 요청에 포함되지 않습니다.</p>
+   */
+  private String prompt;
+}

--- a/keycloak-spring-security-core/src/test/java/com/ids/keycloak/security/config/KeycloakAuthorizationRequestPropertiesTest.java
+++ b/keycloak-spring-security-core/src/test/java/com/ids/keycloak/security/config/KeycloakAuthorizationRequestPropertiesTest.java
@@ -1,0 +1,141 @@
+package com.ids.keycloak.security.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link KeycloakAuthorizationRequestProperties} 단위 테스트.
+ *
+ * <p>기본값, 개별 필드 설정, 바인딩 시뮬레이션을 검증합니다.</p>
+ */
+class KeycloakAuthorizationRequestPropertiesTest {
+
+  @Nested
+  class 기본값_검증 {
+
+    @Test
+    void 기본_acrValues는_null이다() {
+      KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+      assertThat(props.getAcrValues()).isNull();
+    }
+
+    @Test
+    void 기본_maxAge는_null이다() {
+      KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+      assertThat(props.getMaxAge()).isNull();
+    }
+
+    @Test
+    void 기본_prompt는_null이다() {
+      KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+      assertThat(props.getPrompt()).isNull();
+    }
+
+    @Test
+    void 세_필드_모두_null이면_설정_미적용_상태이다() {
+      KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+      assertThat(props.getAcrValues()).isNull();
+      assertThat(props.getMaxAge()).isNull();
+      assertThat(props.getPrompt()).isNull();
+    }
+  }
+
+  @Nested
+  class Setter_및_바인딩_검증 {
+
+    @Test
+    void acrValues를_설정할_수_있다() {
+      KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+      props.setAcrValues("gold");
+
+      assertThat(props.getAcrValues()).isEqualTo("gold");
+    }
+
+    @Test
+    void acrValues_다중값을_공백구분으로_설정할_수_있다() {
+      KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+      props.setAcrValues("gold silver");
+
+      assertThat(props.getAcrValues()).isEqualTo("gold silver");
+    }
+
+    @Test
+    void maxAge를_설정할_수_있다() {
+      KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+      props.setMaxAge(3600);
+
+      assertThat(props.getMaxAge()).isEqualTo(3600);
+    }
+
+    @Test
+    void maxAge_0은_유효한_값이다() {
+      KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+      props.setMaxAge(0);
+
+      assertThat(props.getMaxAge()).isEqualTo(0);
+      assertThat(props.getMaxAge()).isNotNull();
+    }
+
+    @Test
+    void prompt를_설정할_수_있다() {
+      KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+      props.setPrompt("login");
+
+      assertThat(props.getPrompt()).isEqualTo("login");
+    }
+
+    @Test
+    void prompt_다중값을_공백구분으로_설정할_수_있다() {
+      KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+      props.setPrompt("login consent");
+
+      assertThat(props.getPrompt()).isEqualTo("login consent");
+    }
+
+    @Test
+    void 세_필드를_모두_설정할_수_있다() {
+      KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+      props.setAcrValues("gold");
+      props.setMaxAge(0);
+      props.setPrompt("login");
+
+      assertThat(props.getAcrValues()).isEqualTo("gold");
+      assertThat(props.getMaxAge()).isEqualTo(0);
+      assertThat(props.getPrompt()).isEqualTo("login");
+    }
+  }
+
+  @Nested
+  class KeycloakAuthenticationProperties_중첩_바인딩_검증 {
+
+    @Test
+    void authorizationRequest_기본값은_null_아닌_인스턴스이다() {
+      KeycloakAuthenticationProperties authProps = new KeycloakAuthenticationProperties();
+      assertThat(authProps.getAuthorizationRequest()).isNotNull();
+    }
+
+    @Test
+    void authorizationRequest_기본값은_모두_null이다() {
+      KeycloakAuthenticationProperties authProps = new KeycloakAuthenticationProperties();
+      KeycloakAuthorizationRequestProperties reqProps = authProps.getAuthorizationRequest();
+
+      assertThat(reqProps.getAcrValues()).isNull();
+      assertThat(reqProps.getMaxAge()).isNull();
+      assertThat(reqProps.getPrompt()).isNull();
+    }
+
+    @Test
+    void authorizationRequest_설정이_KeycloakAuthenticationProperties에_반영된다() {
+      KeycloakAuthenticationProperties authProps = new KeycloakAuthenticationProperties();
+      authProps.getAuthorizationRequest().setAcrValues("gold");
+      authProps.getAuthorizationRequest().setMaxAge(3600);
+      authProps.getAuthorizationRequest().setPrompt("login");
+
+      assertThat(authProps.getAuthorizationRequest().getAcrValues()).isEqualTo("gold");
+      assertThat(authProps.getAuthorizationRequest().getMaxAge()).isEqualTo(3600);
+      assertThat(authProps.getAuthorizationRequest().getPrompt()).isEqualTo("login");
+    }
+  }
+}

--- a/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/KeycloakServletAutoConfiguration.java
+++ b/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/KeycloakServletAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import java.util.function.Consumer;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.ProviderManager;
@@ -45,7 +46,11 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.RequestMatcher;
@@ -298,6 +303,59 @@ public class KeycloakServletAutoConfiguration {
         public KeycloakAuthorizationManager keycloakAuthorizationManager(KeycloakClient keycloakClient) {
             log.debug("지원 Bean을 등록합니다: [KeycloakAuthorizationManager]");
             return new KeycloakAuthorizationManager(keycloakClient);
+        }
+
+        /**
+         * OIDC authorize 요청 파라미터(acr_values, max_age, prompt)를 커스터마이즈하는
+         * {@link OAuth2AuthorizationRequestResolver} 빈을 등록합니다.
+         *
+         * <p>사용자가 직접 {@link OAuth2AuthorizationRequestResolver} 빈을 등록하면 이 빈은 생략됩니다.
+         * {@code keycloak.security.authentication.authorization-request.*} 설정이 모두 null이면
+         * customizer가 아무것도 추가하지 않으므로 기존 동작과 완전히 동일합니다(회귀 0).</p>
+         */
+        @Bean
+        @ConditionalOnMissingBean(OAuth2AuthorizationRequestResolver.class)
+        public OAuth2AuthorizationRequestResolver keycloakAuthorizationRequestResolver(
+            ClientRegistrationRepository clientRegistrationRepository,
+            KeycloakSecurityProperties securityProperties
+        ) {
+            log.debug("지원 Bean을 등록합니다: [OAuth2AuthorizationRequestResolver] (Keycloak OIDC authorize 파라미터 커스터마이즈)");
+            DefaultOAuth2AuthorizationRequestResolver resolver =
+                new DefaultOAuth2AuthorizationRequestResolver(
+                    clientRegistrationRepository,
+                    OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI);
+
+            resolver.setAuthorizationRequestCustomizer(
+                buildAuthorizationRequestCustomizer(
+                    securityProperties.getAuthentication().getAuthorizationRequest()));
+
+            return resolver;
+        }
+
+        /**
+         * acr_values, max_age, prompt를 additionalParameters에 주입하는 customizer를 생성합니다.
+         *
+         * <p>null인 필드는 추가하지 않습니다. 세 필드가 모두 null이면 아무것도 추가하지 않습니다.</p>
+         *
+         * <p>테스트가 복제 로직 없이 이 메서드를 직접 호출하여 프로덕션 코드를 검증합니다.</p>
+         */
+        protected static Consumer<OAuth2AuthorizationRequest.Builder>
+        buildAuthorizationRequestCustomizer(KeycloakAuthorizationRequestProperties props) {
+            return builder -> {
+                String acrValues = props.getAcrValues();
+                Integer maxAge = props.getMaxAge();
+                String prompt = props.getPrompt();
+
+                if (acrValues != null) {
+                    builder.additionalParameters(p -> p.put("acr_values", acrValues));
+                }
+                if (maxAge != null) {
+                    builder.additionalParameters(p -> p.put("max_age", String.valueOf(maxAge)));
+                }
+                if (prompt != null) {
+                    builder.additionalParameters(p -> p.put("prompt", prompt));
+                }
+            };
         }
 
         /**

--- a/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/KeycloakAuthorizationRequestResolverTest.java
+++ b/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/KeycloakAuthorizationRequestResolverTest.java
@@ -1,0 +1,180 @@
+package com.ids.keycloak.security.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+/**
+ * servlet용 {@link OAuth2AuthorizationRequestResolver} 커스터마이즈 단위 테스트.
+ *
+ * <p>{@link KeycloakServletAutoConfiguration.KeycloakWebSecurityConfiguration}의
+ * {@code keycloakAuthorizationRequestResolver} 빈 메서드가 등록하는 customizer를
+ * 직접 구성하여 검증합니다.</p>
+ */
+class KeycloakAuthorizationRequestResolverTest {
+
+  private static final String REGISTRATION_ID = "keycloak";
+  private static final String BASE_URI =
+      OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
+
+  /**
+   * 테스트용 ClientRegistration 을 가진 InMemoryClientRegistrationRepository를 생성합니다.
+   */
+  private InMemoryClientRegistrationRepository buildClientRegistrationRepository() {
+    ClientRegistration registration = ClientRegistration
+        .withRegistrationId(REGISTRATION_ID)
+        .clientId("test-client")
+        .clientSecret("test-secret")
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUri("http://localhost:8080/login/oauth2/code/keycloak")
+        .authorizationUri("http://localhost:8180/auth/realms/test/protocol/openid-connect/auth")
+        .tokenUri("http://localhost:8180/auth/realms/test/protocol/openid-connect/token")
+        .scope("openid")
+        .build();
+    return new InMemoryClientRegistrationRepository(registration);
+  }
+
+  /**
+   * 프로덕션 customizer({@link KeycloakServletAutoConfiguration.KeycloakWebSecurityConfiguration#buildAuthorizationRequestCustomizer})를
+   * 직접 호출하여 resolver를 빌드합니다.
+   *
+   * <p>복제 로직이 아닌 프로덕션이 실제 사용하는 코드를 검증합니다.</p>
+   */
+  private OAuth2AuthorizationRequestResolver buildResolver(
+      String acrValues, Integer maxAge, String prompt) {
+
+    InMemoryClientRegistrationRepository repo = buildClientRegistrationRepository();
+
+    KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+    props.setAcrValues(acrValues);
+    props.setMaxAge(maxAge);
+    props.setPrompt(prompt);
+
+    DefaultOAuth2AuthorizationRequestResolver resolver =
+        new DefaultOAuth2AuthorizationRequestResolver(repo, BASE_URI);
+
+    resolver.setAuthorizationRequestCustomizer(
+        KeycloakServletAutoConfiguration.KeycloakWebSecurityConfiguration
+            .buildAuthorizationRequestCustomizer(props));
+
+    return resolver;
+  }
+
+  private MockHttpServletRequest buildRequest() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI(BASE_URI + "/" + REGISTRATION_ID);
+    return request;
+  }
+
+  // ==========================================================================
+  // 파라미터 포함 검증
+  // ==========================================================================
+
+  @Nested
+  class 파라미터_포함_검증 {
+
+    @Test
+    void acr_values가_설정되면_additionalParameters에_포함된다() {
+      OAuth2AuthorizationRequestResolver resolver = buildResolver("gold", null, null);
+      OAuth2AuthorizationRequest result = resolver.resolve(buildRequest());
+
+      assertThat(result).isNotNull();
+      Map<String, Object> params = result.getAdditionalParameters();
+      assertThat(params).containsEntry("acr_values", "gold");
+    }
+
+    @Test
+    void max_age가_설정되면_additionalParameters에_문자열로_포함된다() {
+      OAuth2AuthorizationRequestResolver resolver = buildResolver(null, 3600, null);
+      OAuth2AuthorizationRequest result = resolver.resolve(buildRequest());
+
+      assertThat(result).isNotNull();
+      Map<String, Object> params = result.getAdditionalParameters();
+      assertThat(params).containsEntry("max_age", "3600");
+    }
+
+    @Test
+    void max_age_0은_유효값으로_포함된다() {
+      OAuth2AuthorizationRequestResolver resolver = buildResolver(null, 0, null);
+      OAuth2AuthorizationRequest result = resolver.resolve(buildRequest());
+
+      assertThat(result).isNotNull();
+      Map<String, Object> params = result.getAdditionalParameters();
+      assertThat(params).containsEntry("max_age", "0");
+    }
+
+    @Test
+    void prompt가_설정되면_additionalParameters에_포함된다() {
+      OAuth2AuthorizationRequestResolver resolver = buildResolver(null, null, "login");
+      OAuth2AuthorizationRequest result = resolver.resolve(buildRequest());
+
+      assertThat(result).isNotNull();
+      Map<String, Object> params = result.getAdditionalParameters();
+      assertThat(params).containsEntry("prompt", "login");
+    }
+
+    @Test
+    void prompt_다중값_공백구분이_그대로_포함된다() {
+      OAuth2AuthorizationRequestResolver resolver = buildResolver(null, null, "login consent");
+      OAuth2AuthorizationRequest result = resolver.resolve(buildRequest());
+
+      assertThat(result).isNotNull();
+      assertThat(result.getAdditionalParameters()).containsEntry("prompt", "login consent");
+    }
+
+    @Test
+    void 세_파라미터_모두_설정하면_전부_포함된다() {
+      OAuth2AuthorizationRequestResolver resolver = buildResolver("gold", 3600, "login");
+      OAuth2AuthorizationRequest result = resolver.resolve(buildRequest());
+
+      assertThat(result).isNotNull();
+      Map<String, Object> params = result.getAdditionalParameters();
+      assertThat(params)
+          .containsEntry("acr_values", "gold")
+          .containsEntry("max_age", "3600")
+          .containsEntry("prompt", "login");
+    }
+  }
+
+  // ==========================================================================
+  // 미설정 시 미포함 검증 (회귀 0)
+  // ==========================================================================
+
+  @Nested
+  class 미설정_시_미포함_검증 {
+
+    @Test
+    void 세_파라미터_모두_null이면_additionalParameters에_포함되지_않는다() {
+      OAuth2AuthorizationRequestResolver resolver = buildResolver(null, null, null);
+      OAuth2AuthorizationRequest result = resolver.resolve(buildRequest());
+
+      assertThat(result).isNotNull();
+      Map<String, Object> params = result.getAdditionalParameters();
+      assertThat(params).doesNotContainKey("acr_values");
+      assertThat(params).doesNotContainKey("max_age");
+      assertThat(params).doesNotContainKey("prompt");
+    }
+
+    @Test
+    void acr_values만_null이면_해당_파라미터만_미포함이다() {
+      OAuth2AuthorizationRequestResolver resolver = buildResolver(null, 3600, "login");
+      OAuth2AuthorizationRequest result = resolver.resolve(buildRequest());
+
+      assertThat(result).isNotNull();
+      Map<String, Object> params = result.getAdditionalParameters();
+      assertThat(params).doesNotContainKey("acr_values");
+      assertThat(params).containsEntry("max_age", "3600");
+      assertThat(params).containsEntry("prompt", "login");
+    }
+  }
+}

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/config/KeycloakHttpConfigurer.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/config/KeycloakHttpConfigurer.java
@@ -29,6 +29,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
@@ -137,10 +138,18 @@ public final class KeycloakHttpConfigurer extends AbstractHttpConfigurer<Keycloa
       );
 
       // === 3. OIDC 로그인 설정 ===
-      http.oauth2Login(login -> login
-          .successHandler(oidcLoginSuccessHandler)
-          .authorizedClientRepository(authorizedClientRepository)
-      );
+      // AuthorizationRequestResolver: 사용자 등록 빈 우선, 없으면 기본 resolver 사용
+      OAuth2AuthorizationRequestResolver authorizationRequestResolver =
+          context.getBeanProvider(OAuth2AuthorizationRequestResolver.class).getIfAvailable();
+
+      http.oauth2Login(login -> {
+          login.successHandler(oidcLoginSuccessHandler)
+               .authorizedClientRepository(authorizedClientRepository);
+          if (authorizationRequestResolver != null) {
+              login.authorizationEndpoint(ep ->
+                  ep.authorizationRequestResolver(authorizationRequestResolver));
+          }
+      });
 
       // === 4. 로그아웃 설정 ===
       // 4-1. Front-Channel 로그아웃 (사용자가 직접 로그아웃)

--- a/keycloak-spring-security-webflux-starter/build.gradle
+++ b/keycloak-spring-security-webflux-starter/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
     testImplementation 'org.springframework:spring-test'
     testImplementation 'org.springframework.security:spring-security-oauth2-client'
+    testImplementation 'io.projectreactor:reactor-test'
 }
 
 signing {

--- a/keycloak-spring-security-webflux-starter/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxAutoConfiguration.java
+++ b/keycloak-spring-security-webflux-starter/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxAutoConfiguration.java
@@ -21,6 +21,7 @@ import io.micrometer.context.ContextRegistry;
 import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,7 +44,10 @@ import org.springframework.security.oauth2.client.InMemoryReactiveOAuth2Authoriz
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.server.AuthenticatedPrincipalServerOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.server.DefaultServerOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
@@ -200,6 +204,57 @@ public class KeycloakWebFluxAutoConfiguration {
         ReactiveOAuth2AuthorizedClientService authorizedClientService) {
       log.debug("지원 Bean을 등록합니다: [ServerOAuth2AuthorizedClientRepository]");
       return new AuthenticatedPrincipalServerOAuth2AuthorizedClientRepository(authorizedClientService);
+    }
+
+    /**
+     * OIDC authorize 요청 파라미터(acr_values, max_age, prompt)를 커스터마이즈하는
+     * {@link ServerOAuth2AuthorizationRequestResolver} 빈을 등록합니다.
+     *
+     * <p>사용자가 직접 {@link ServerOAuth2AuthorizationRequestResolver} 빈을 등록하면 이 빈은 생략됩니다.
+     * {@code keycloak.security.authentication.authorization-request.*} 설정이 모두 null이면
+     * customizer가 아무것도 추가하지 않으므로 기존 동작과 완전히 동일합니다(회귀 0).</p>
+     */
+    @Bean
+    @ConditionalOnMissingBean(ServerOAuth2AuthorizationRequestResolver.class)
+    public ServerOAuth2AuthorizationRequestResolver keycloakServerAuthorizationRequestResolver(
+        ReactiveClientRegistrationRepository clientRegistrationRepository,
+        KeycloakSecurityProperties securityProperties) {
+      log.debug("지원 Bean을 등록합니다: [ServerOAuth2AuthorizationRequestResolver] "
+          + "(Keycloak OIDC authorize 파라미터 커스터마이즈)");
+      DefaultServerOAuth2AuthorizationRequestResolver resolver =
+          new DefaultServerOAuth2AuthorizationRequestResolver(clientRegistrationRepository);
+
+      resolver.setAuthorizationRequestCustomizer(
+          buildAuthorizationRequestCustomizer(
+              securityProperties.getAuthentication().getAuthorizationRequest()));
+
+      return resolver;
+    }
+
+    /**
+     * acr_values, max_age, prompt를 additionalParameters에 주입하는 customizer를 생성합니다.
+     *
+     * <p>null인 필드는 추가하지 않습니다. 세 필드가 모두 null이면 아무것도 추가하지 않습니다.</p>
+     *
+     * <p>테스트가 복제 로직 없이 이 메서드를 직접 호출하여 프로덕션 코드를 검증합니다.</p>
+     */
+    protected static Consumer<OAuth2AuthorizationRequest.Builder>
+    buildAuthorizationRequestCustomizer(KeycloakAuthorizationRequestProperties props) {
+      return builder -> {
+        String acrValues = props.getAcrValues();
+        Integer maxAge = props.getMaxAge();
+        String prompt = props.getPrompt();
+
+        if (acrValues != null) {
+          builder.additionalParameters(p -> p.put("acr_values", acrValues));
+        }
+        if (maxAge != null) {
+          builder.additionalParameters(p -> p.put("max_age", String.valueOf(maxAge)));
+        }
+        if (prompt != null) {
+          builder.additionalParameters(p -> p.put("prompt", prompt));
+        }
+      };
     }
   }
 
@@ -413,7 +468,8 @@ public class KeycloakWebFluxAutoConfiguration {
         org.springframework.beans.factory.ObjectProvider<ReactiveAuthLoggingFilter> authLoggingFilterProvider,
         org.springframework.beans.factory.ObjectProvider<ReactiveClientRegistrationRepository> clientRegistrationRepoProvider,
         org.springframework.beans.factory.ObjectProvider<ReactiveOAuth2AuthorizedClientService> authorizedClientServiceProvider,
-        org.springframework.beans.factory.ObjectProvider<ReactiveBackChannelLogoutEndpointFilter> backChannelFilterProvider)
+        org.springframework.beans.factory.ObjectProvider<ReactiveBackChannelLogoutEndpointFilter> backChannelFilterProvider,
+        org.springframework.beans.factory.ObjectProvider<ServerOAuth2AuthorizationRequestResolver> authorizationRequestResolverProvider)
         throws Exception {
 
       ServerWebExchangeMatcher securityMatcher = buildSecurityMatcher(securityProperties.getMatcher());
@@ -433,6 +489,8 @@ public class KeycloakWebFluxAutoConfiguration {
           authorizedClientServiceProvider.getIfAvailable();
       ReactiveBackChannelLogoutEndpointFilter backChannelFilter =
           backChannelFilterProvider.getIfAvailable();
+      ServerOAuth2AuthorizationRequestResolver authorizationRequestResolver =
+          authorizationRequestResolverProvider.getIfAvailable();
 
       return KeycloakWebFluxSecurityConfigurer.configure(
           http,
@@ -448,7 +506,8 @@ public class KeycloakWebFluxAutoConfiguration {
           authLoggingFilter,
           clientRegistrationRepo,
           authorizedClientService,
-          backChannelFilter);
+          backChannelFilter,
+          authorizationRequestResolver);
     }
 
     /**

--- a/keycloak-spring-security-webflux-starter/src/test/java/com/ids/keycloak/security/config/KeycloakServerAuthorizationRequestResolverTest.java
+++ b/keycloak-spring-security-webflux-starter/src/test/java/com/ids/keycloak/security/config/KeycloakServerAuthorizationRequestResolverTest.java
@@ -1,0 +1,198 @@
+package com.ids.keycloak.security.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryReactiveClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.server.DefaultServerOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import reactor.test.StepVerifier;
+
+/**
+ * reactive용 {@link ServerOAuth2AuthorizationRequestResolver} 커스터마이즈 단위 테스트.
+ *
+ * <p>{@link KeycloakWebFluxAutoConfiguration.KeycloakOAuth2ClientConfiguration}의
+ * {@code keycloakServerAuthorizationRequestResolver} 빈 메서드가 등록하는 customizer를
+ * 직접 구성하여 StepVerifier로 검증합니다.</p>
+ */
+class KeycloakServerAuthorizationRequestResolverTest {
+
+  private static final String REGISTRATION_ID = "keycloak";
+
+  /**
+   * 테스트용 ClientRegistration 을 가진 InMemoryReactiveClientRegistrationRepository를 생성합니다.
+   */
+  private InMemoryReactiveClientRegistrationRepository buildClientRegistrationRepository() {
+    ClientRegistration registration = ClientRegistration
+        .withRegistrationId(REGISTRATION_ID)
+        .clientId("test-client")
+        .clientSecret("test-secret")
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUri("http://localhost:8080/login/oauth2/code/keycloak")
+        .authorizationUri("http://localhost:8180/auth/realms/test/protocol/openid-connect/auth")
+        .tokenUri("http://localhost:8180/auth/realms/test/protocol/openid-connect/token")
+        .scope("openid")
+        .build();
+    return new InMemoryReactiveClientRegistrationRepository(registration);
+  }
+
+  /**
+   * 프로덕션 customizer({@link KeycloakWebFluxAutoConfiguration.KeycloakOAuth2ClientConfiguration#buildAuthorizationRequestCustomizer})를
+   * 직접 호출하여 resolver를 빌드합니다.
+   *
+   * <p>복제 로직이 아닌 프로덕션이 실제 사용하는 코드를 검증합니다.</p>
+   */
+  private ServerOAuth2AuthorizationRequestResolver buildResolver(
+      String acrValues, Integer maxAge, String prompt) {
+
+    InMemoryReactiveClientRegistrationRepository repo = buildClientRegistrationRepository();
+
+    KeycloakAuthorizationRequestProperties props = new KeycloakAuthorizationRequestProperties();
+    props.setAcrValues(acrValues);
+    props.setMaxAge(maxAge);
+    props.setPrompt(prompt);
+
+    DefaultServerOAuth2AuthorizationRequestResolver resolver =
+        new DefaultServerOAuth2AuthorizationRequestResolver(repo);
+
+    resolver.setAuthorizationRequestCustomizer(
+        KeycloakWebFluxAutoConfiguration.KeycloakOAuth2ClientConfiguration
+            .buildAuthorizationRequestCustomizer(props));
+
+    return resolver;
+  }
+
+  private MockServerWebExchange buildExchange() {
+    MockServerHttpRequest request = MockServerHttpRequest
+        .method(HttpMethod.GET, URI.create("/oauth2/authorization/" + REGISTRATION_ID))
+        .build();
+    return MockServerWebExchange.from(request);
+  }
+
+  // ==========================================================================
+  // 파라미터 포함 검증
+  // ==========================================================================
+
+  @Nested
+  class 파라미터_포함_검증 {
+
+    @Test
+    void acr_values가_설정되면_additionalParameters에_포함된다() {
+      ServerOAuth2AuthorizationRequestResolver resolver = buildResolver("gold", null, null);
+
+      StepVerifier.create(resolver.resolve(buildExchange()))
+          .assertNext(result -> {
+            Map<String, Object> params = result.getAdditionalParameters();
+            assertThat(params).containsEntry("acr_values", "gold");
+          })
+          .verifyComplete();
+    }
+
+    @Test
+    void max_age가_설정되면_additionalParameters에_문자열로_포함된다() {
+      ServerOAuth2AuthorizationRequestResolver resolver = buildResolver(null, 3600, null);
+
+      StepVerifier.create(resolver.resolve(buildExchange()))
+          .assertNext(result -> {
+            Map<String, Object> params = result.getAdditionalParameters();
+            assertThat(params).containsEntry("max_age", "3600");
+          })
+          .verifyComplete();
+    }
+
+    @Test
+    void max_age_0은_유효값으로_포함된다() {
+      ServerOAuth2AuthorizationRequestResolver resolver = buildResolver(null, 0, null);
+
+      StepVerifier.create(resolver.resolve(buildExchange()))
+          .assertNext(result -> {
+            Map<String, Object> params = result.getAdditionalParameters();
+            assertThat(params).containsEntry("max_age", "0");
+          })
+          .verifyComplete();
+    }
+
+    @Test
+    void prompt가_설정되면_additionalParameters에_포함된다() {
+      ServerOAuth2AuthorizationRequestResolver resolver = buildResolver(null, null, "login");
+
+      StepVerifier.create(resolver.resolve(buildExchange()))
+          .assertNext(result -> {
+            Map<String, Object> params = result.getAdditionalParameters();
+            assertThat(params).containsEntry("prompt", "login");
+          })
+          .verifyComplete();
+    }
+
+    @Test
+    void prompt_다중값_공백구분이_그대로_포함된다() {
+      ServerOAuth2AuthorizationRequestResolver resolver =
+          buildResolver(null, null, "login consent");
+
+      StepVerifier.create(resolver.resolve(buildExchange()))
+          .assertNext(result -> assertThat(result.getAdditionalParameters())
+              .containsEntry("prompt", "login consent"))
+          .verifyComplete();
+    }
+
+    @Test
+    void 세_파라미터_모두_설정하면_전부_포함된다() {
+      ServerOAuth2AuthorizationRequestResolver resolver = buildResolver("gold", 3600, "login");
+
+      StepVerifier.create(resolver.resolve(buildExchange()))
+          .assertNext(result -> {
+            Map<String, Object> params = result.getAdditionalParameters();
+            assertThat(params)
+                .containsEntry("acr_values", "gold")
+                .containsEntry("max_age", "3600")
+                .containsEntry("prompt", "login");
+          })
+          .verifyComplete();
+    }
+  }
+
+  // ==========================================================================
+  // 미설정 시 미포함 검증 (회귀 0)
+  // ==========================================================================
+
+  @Nested
+  class 미설정_시_미포함_검증 {
+
+    @Test
+    void 세_파라미터_모두_null이면_additionalParameters에_포함되지_않는다() {
+      ServerOAuth2AuthorizationRequestResolver resolver = buildResolver(null, null, null);
+
+      StepVerifier.create(resolver.resolve(buildExchange()))
+          .assertNext(result -> {
+            Map<String, Object> params = result.getAdditionalParameters();
+            assertThat(params).doesNotContainKey("acr_values");
+            assertThat(params).doesNotContainKey("max_age");
+            assertThat(params).doesNotContainKey("prompt");
+          })
+          .verifyComplete();
+    }
+
+    @Test
+    void prompt만_null이면_해당_파라미터만_미포함이다() {
+      ServerOAuth2AuthorizationRequestResolver resolver = buildResolver("gold", 0, null);
+
+      StepVerifier.create(resolver.resolve(buildExchange()))
+          .assertNext(result -> {
+            Map<String, Object> params = result.getAdditionalParameters();
+            assertThat(params).containsEntry("acr_values", "gold");
+            assertThat(params).containsEntry("max_age", "0");
+            assertThat(params).doesNotContainKey("prompt");
+          })
+          .verifyComplete();
+    }
+  }
+}

--- a/keycloak-spring-security-webflux-starter/src/test/java/com/ids/keycloak/security/config/KeycloakWebFluxFilterChainConditionsTest.java
+++ b/keycloak-spring-security-webflux-starter/src/test/java/com/ids/keycloak/security/config/KeycloakWebFluxFilterChainConditionsTest.java
@@ -20,6 +20,7 @@ import org.springframework.security.authentication.ReactiveAuthenticationManager
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizationRequestResolver;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
 /**
@@ -50,7 +51,8 @@ class KeycloakWebFluxFilterChainConditionsTest {
             ObjectProvider.class,  // ReactiveAuthLoggingFilter
             ObjectProvider.class,  // ReactiveClientRegistrationRepository
             ObjectProvider.class,  // ReactiveOAuth2AuthorizedClientService
-            ObjectProvider.class   // ReactiveBackChannelLogoutEndpointFilter
+            ObjectProvider.class,  // ReactiveBackChannelLogoutEndpointFilter
+            ObjectProvider.class   // ServerOAuth2AuthorizationRequestResolver
         );
   }
 

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxSecurityConfigurer.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxSecurityConfigurer.java
@@ -28,6 +28,7 @@ import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClient
 import org.springframework.security.oauth2.client.oidc.web.server.logout.OidcClientInitiatedServerLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizationRequestResolver;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.AuthenticationWebFilter;
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
@@ -67,7 +68,8 @@ public final class KeycloakWebFluxSecurityConfigurer {
    * @param authLoggingFilter         인증 로깅 WebFilter (null 가능)
    * @param clientRegistrationRepo    ReactiveClientRegistrationRepository (OIDC 로그인/로그아웃용)
    * @param authorizedClientService   ReactiveOAuth2AuthorizedClientService (토큰 조회용)
-   * @param backChannelFilter         BackChannel 로그아웃 필터 (null 가능 — Spring Session 없으면 null)
+   * @param backChannelFilter              BackChannel 로그아웃 필터 (null 가능 — Spring Session 없으면 null)
+   * @param authorizationRequestResolver   OIDC authorize 요청 파라미터 커스터마이즈 resolver (null 가능 — null이면 기본 동작)
    * @return 구성된 {@link SecurityWebFilterChain}
    */
   public static SecurityWebFilterChain configure(
@@ -84,7 +86,8 @@ public final class KeycloakWebFluxSecurityConfigurer {
       ReactiveAuthLoggingFilter authLoggingFilter,
       ReactiveClientRegistrationRepository clientRegistrationRepo,
       ReactiveOAuth2AuthorizedClientService authorizedClientService,
-      ReactiveBackChannelLogoutEndpointFilter backChannelFilter) throws Exception {
+      ReactiveBackChannelLogoutEndpointFilter backChannelFilter,
+      ServerOAuth2AuthorizationRequestResolver authorizationRequestResolver) throws Exception {
 
     // 1. SecurityContext를 세션에 저장하지 않음 — 매 요청마다 필터가 인증 처리
     http.securityContextRepository(NoOpServerSecurityContextRepository.getInstance());
@@ -173,9 +176,12 @@ public final class KeycloakWebFluxSecurityConfigurer {
           securityProperties.getCookie(),
           defaultSuccessUrl != null ? defaultSuccessUrl : "/");
 
-      http.oauth2Login(login -> login
-          .authenticationSuccessHandler(oidcSuccessHandler)
-      );
+      http.oauth2Login(login -> {
+          login.authenticationSuccessHandler(oidcSuccessHandler);
+          if (authorizationRequestResolver != null) {
+              login.authorizationRequestResolver(authorizationRequestResolver);
+          }
+      });
       log.info("[Configurer] OIDC oauth2Login 등록 완료 (defaultSuccessUrl={}).", defaultSuccessUrl);
     } else {
       log.debug("[Configurer] ReactiveClientRegistrationRepository 또는 "


### PR DESCRIPTION
Closes #46

Keycloak LoA step-up / max_age 재인증 / prompt=login을 사용처가 쓸 수 있도록, oauth2Login에 AuthorizationRequestResolver를 연결. **servlet + reactive 양쪽**.

## 변경
- `OAuth2AuthorizationRequestResolver`(servlet)/`ServerOAuth2AuthorizationRequestResolver`(reactive) 빈 `@ConditionalOnMissingBean` 제공 + oauth2Login에 `authorizationRequestResolver` 연결
- `keycloak.security.authentication.authorization-request.{acr-values, max-age, prompt}` 프로퍼티 → customizer로 `additionalParameters`(acr_values/max_age/prompt) 반영
- 사용처가 resolver 빈 재정의 시 **경로별 step-up** 가능

## 품질 (기획검토 → 구현 → 테스트 → 코드리뷰)
- planner 기획검토 → code-reviewer 리뷰(Critical/High/Medium 0, Low 4건 수정 완료)
- **회귀 0** (3 파라미터 기본 null → 미설정 시 authorize 요청 무변경)
- 테스트 +32 (프로퍼티 바인딩, resolver customizer servlet/reactive, max_age=0 엣지), 전체 419 통과
- `docs/GUIDE.md` §4.9 + 설정 레퍼런스

## 버전
`1.8.0` → `1.9.0`