### PR TITLE
ci: GitHub Release 변경내역 자동 생성 (generate_release_notes)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,29 @@
+# GitHub 자동 릴리스 노트("What's Changed") 카테고리 설정
+# publish.yml의 generate_release_notes: true 와 함께 동작한다.
+# PR 라벨이 있으면 해당 카테고리로, 없으면 "🔧 기타 변경"으로 분류된다.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - skip-changelog
+  categories:
+    - title: 🚀 New Features
+      labels:
+        - enhancement
+        - feature
+        - feat
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+        - bugfix
+    - title: 🔒 Security
+      labels:
+        - security
+    - title: 📝 Documentation
+      labels:
+        - documentation
+        - docs
+    - title: 🔧 기타 변경
+      labels:
+        - "*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,6 +109,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: "v${{ steps.version.outputs.version }}"
+          # 직전 태그 이후 머지된 PR 기반 "What's Changed" 변경내역 자동 생성 (.github/release.yml 카테고리 적용)
+          generate_release_notes: true
           body: |
             ## Keycloak Spring Security v${{ steps.version.outputs.version }}
 


### PR DESCRIPTION
릴리스 시 GitHub Release "What's Changed"가 비어 있어 버전별 변경내역을 알 수 없던 문제 해결.

- `publish.yml`: `softprops/action-gh-release`에 `generate_release_notes: true` 추가 → 직전 태그 이후 머지된 PR 자동 수집
- `.github/release.yml`: 🚀 Features / 🐛 Bug Fixes / 🔒 Security / 📝 Documentation / 🔧 기타 카테고리 분류 (PR 라벨 기반, 라벨 없으면 기타)

다음 릴리스(v1.9.x+)부터 변경내역이 Release 노트에 자동 표시됩니다. 버전/배포 변경 없음.