### PR TITLE
chore: tmpclaude-ff5b-cwd 추적 제거 + .gitignore 보강

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ postman/
 
 # GPG signing key (절대 커밋 금지)
 secret.asc
+
+# Claude Code Bash 도구가 생성하는 cwd 추적 임시파일 (커밋 금지)
+tmpclaude-*

--- a/tmpclaude-ff5b-cwd
+++ b/tmpclaude-ff5b-cwd
@@ -1,1 +1,0 @@
-/c/Users/yui52/OneDrive/Desktop/security/keyclaok-spring-security


### PR DESCRIPTION
Claude Code Bash 도구의 cwd 추적 임시파일(`tmpclaude-ff5b-cwd`)이 과거 OneDrive 작업 시점(`302cb96` redis 세션 작업)에 실수로 커밋되어 main에 추적되던 것을 제거. `.gitignore`에 `tmpclaude-*` 패턴 추가로 재발 방지. 코드/버전 변경 없음.