### PR TITLE
[#52] fix: isAjaxRequest가 브라우저 Accept */* 를 JSON으로 오판하던 문제 수정 (v1.10.1)

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3,7 +3,7 @@
 Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 하나와 최소 설정으로 OIDC 로그인·세션·로그아웃·인가가 자동 구성됩니다.
 
 - **지원**: JDK 17+, Spring Boot 3.5.x, Spring Security 6.5.x
-- **현재 버전**: `1.10.0`
+- **현재 버전**: `1.10.1`
 - **스택**: Servlet(Spring MVC) / **Reactive(WebFlux) — v1.8.0부터 servlet과 기능 동등** ([8. Reactive](#8-reactivewebflux))
 - 이 문서는 **도입 개발자용 사용 가이드**입니다. 아키텍처/기여 규칙은 [README](../README.md) 참고.
 
@@ -27,10 +27,10 @@ Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 
 
 ```gradle
 // Servlet (Spring MVC)
-implementation("io.github.l-dxd:keycloak-spring-security-web-starter:1.8.0")
+implementation("io.github.l-dxd:keycloak-spring-security-web-starter:1.10.1")
 
 // 또는 Reactive (WebFlux)
-implementation("io.github.l-dxd:keycloak-spring-security-webflux-starter:1.8.0")
+implementation("io.github.l-dxd:keycloak-spring-security-webflux-starter:1.10.1")
 ```
 > Redis 세션을 쓸 경우에만 추가:
 > ```gradle
@@ -322,6 +322,7 @@ LoggingValueSanitizer loggingValueSanitizer() {
 
 | 버전 | 변경 | 주의 |
 |------|------|------|
+| **1.10.1** | (버그픽스 #52) webflux/servlet AJAX 판정 통일 — 브라우저 `Accept: */*`를 JSON으로 오판하던 문제 수정(`ajax-returns-json=true` 시 브라우저 리다이렉트 정상화) | breaking 없음 |
 | **1.10.0** ⚠️ | **보안 강화** (보안검토 13건) — reactive 백채널 JWKS 서명+aud 검증, 쿠키 secure 기본 true, XFF 신뢰 프록시, servlet SameSite/토큰 no-store, PII 마스킹 확장(JWT/OAuth2), 인가 캐시·require-user-info 토글, Redis JSON 직렬화 | **Breaking 3건** — 아래 [마이그레이션](#마이그레이션-v190--v1100-breaking) |
 | **1.9.0** | OIDC authorize 파라미터(`acr_values`/`max_age`/`prompt`) 커스터마이즈 — LoA step-up·재인증 | 미설정 시 무동작(회귀 0). 경로별 step-up은 resolver 빈 재정의([4.9](#49-재인증--step-up-acr_values--max_age--prompt-v190)) |
 | **1.8.0** | **Reactive(WebFlux) 스택 추가** — servlet과 기능 동등 (OIDC 로그인·세션·인가·Bearer·Basic·RateLimit·CSRF·로그아웃·MDC 로깅) | `keycloak-spring-security-webflux-starter` 신규. servlet 사용자는 영향 없음 |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version Management
-projectVersion=1.10.0
+projectVersion=1.10.1
 
 # Maven Publishing Info
 mavenGroupId=io.github.l-dxd

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/util/SecurityHandlerUtil.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/util/SecurityHandlerUtil.java
@@ -5,10 +5,10 @@ import com.ids.keycloak.security.error.ErrorResponse;
 import com.ids.keycloak.security.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.MediaType;
-
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.List;
+import org.springframework.http.MediaType;
 
 public class SecurityHandlerUtil {
 
@@ -21,14 +21,32 @@ public class SecurityHandlerUtil {
 
     /**
      * AJAX 요청인지 확인합니다.
-     * X-Requested-With 헤더가 XMLHttpRequest이거나 Accept 헤더가 application/json인 경우 AJAX 요청으로 판단합니다.
+     *
+     * <p>판정 기준:
+     * <ol>
+     *   <li>{@code X-Requested-With: XMLHttpRequest} 헤더가 있으면 AJAX</li>
+     *   <li>Accept 헤더에 {@code text/html}이 포함되어 있으면 브라우저 네비게이션 → non-AJAX</li>
+     *   <li>Accept 헤더에 명시적 JSON(subtype이 "json" 또는 "+json"으로 끝나는 타입) 타입이 있고
+     *       text/html이 없으면 AJAX</li>
+     *   <li>{@code Accept: *&#47;*} 단독이나 Accept 헤더 없음 → non-AJAX</li>
+     * </ol>
+     * 기존 {@code acceptHeader.contains("application/json")} 방식은 webflux 모듈과
+     * 동일한 규칙으로 통일한다.
      */
     public static boolean isAjaxRequest(HttpServletRequest request) {
         String xRequestedWith = request.getHeader(X_REQUESTED_WITH);
+        if (XML_HTTP_REQUEST.equals(xRequestedWith)) {
+            return true;
+        }
         String acceptHeader = request.getHeader("Accept");
-
-        return XML_HTTP_REQUEST.equals(xRequestedWith) ||
-            (acceptHeader != null && acceptHeader.contains(MediaType.APPLICATION_JSON_VALUE));
+        if (acceptHeader == null || acceptHeader.isBlank()) {
+            return false;
+        }
+        List<MediaType> accepts = MediaType.parseMediaTypes(acceptHeader);
+        boolean acceptsHtml = accepts.stream().anyMatch(MediaType.TEXT_HTML::isCompatibleWith);
+        boolean explicitJson = accepts.stream()
+            .anyMatch(mt -> "json".equals(mt.getSubtype()) || mt.getSubtype().endsWith("+json"));
+        return explicitJson && !acceptsHtml;
     }
 
     /**

--- a/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/util/SecurityHandlerUtilTest.java
+++ b/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/util/SecurityHandlerUtilTest.java
@@ -1,0 +1,173 @@
+package com.ids.keycloak.security.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * SecurityHandlerUtil.isAjaxRequest() 단위 테스트.
+ *
+ * <p>이슈 #52: 브라우저 {@code Accept: *}{@code /*} 와일드카드를 application/json 포함으로 오판하던
+ * 기존 {@code acceptHeader.contains("application/json")} 방식을 개선한 로직을 검증한다.
+ *
+ * <p>검증 케이스:
+ * <ul>
+ *   <li>브라우저 표준 Accept (text/html,...,*&#47;*;q=0.8) → false</li>
+ *   <li>Accept: application/json 단독 → true</li>
+ *   <li>X-Requested-With: XMLHttpRequest (임의 Accept) → true</li>
+ *   <li>Accept: *&#47;* 단독 → false</li>
+ *   <li>Accept 없음/빈 값 → false</li>
+ * </ul>
+ */
+class SecurityHandlerUtilTest {
+
+  // =========================================================
+  // X-Requested-With 헤더 기반 판정
+  // =========================================================
+  @Nested
+  @DisplayName("X-Requested-With 헤더 기반 판정")
+  class XRequestedWith_헤더 {
+
+    @Test
+    @DisplayName("X-Requested-With: XMLHttpRequest → true (Accept 무관)")
+    void XRequestedWith_XMLHttpRequest_AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("X-Requested-With", "XMLHttpRequest");
+      // Accept가 */* 이어도 X-Requested-With가 있으면 AJAX
+      request.addHeader("Accept", "*/*");
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isTrue();
+    }
+
+    @Test
+    @DisplayName("X-Requested-With: XMLHttpRequest (Accept 없음) → true")
+    void XRequestedWith_XMLHttpRequest_Accept_없음() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("X-Requested-With", "XMLHttpRequest");
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isTrue();
+    }
+
+    @Test
+    @DisplayName("X-Requested-With 값이 다른 경우 → X-Requested-With로 AJAX 판정 안 함")
+    void XRequestedWith_다른값_비AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("X-Requested-With", "fetch");
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isFalse();
+    }
+  }
+
+  // =========================================================
+  // Accept 헤더 기반 판정
+  // =========================================================
+  @Nested
+  @DisplayName("Accept 헤더 기반 판정")
+  class Accept_헤더 {
+
+    @Test
+    @DisplayName("브라우저 표준 Accept (text/html,...,*/*;q=0.8) → false")
+    void 브라우저_표준_Accept_비AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      // Chrome/Firefox 계열 브라우저 표준 Accept
+      request.addHeader("Accept",
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Accept: application/json 단독 → true")
+    void Accept_application_json_단독_AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Accept", "application/json");
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Accept: application/json;charset=UTF-8 → true")
+    void Accept_application_json_charset_AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Accept", "application/json;charset=UTF-8");
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Accept: application/vnd.api+json → true (+json subtype)")
+    void Accept_plus_json_subtype_AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Accept", "application/vnd.api+json");
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Accept: */* 단독 → false")
+    void Accept_wildcard_단독_비AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Accept", "*/*");
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Accept 헤더 없음 → false")
+    void Accept_헤더_없음_비AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      // Accept 헤더 설정 안 함
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Accept 빈 값 → false")
+    void Accept_빈값_비AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("Accept", "");
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Accept: application/json,text/html → text/html 포함 → false")
+    void Accept_json_and_html_비AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      // application/json이 있더라도 text/html도 있으면 브라우저 네비게이션으로 판정
+      request.addHeader("Accept", "application/json, text/html");
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isFalse();
+    }
+  }
+
+  // =========================================================
+  // 복합 케이스
+  // =========================================================
+  @Nested
+  @DisplayName("복합 케이스")
+  class 복합_케이스 {
+
+    @Test
+    @DisplayName("X-Requested-With + 브라우저 Accept → X-Requested-With 우선 → true")
+    void XRequestedWith_우선_AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("X-Requested-With", "XMLHttpRequest");
+      request.addHeader("Accept",
+          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isTrue();
+    }
+
+    @Test
+    @DisplayName("헤더 전혀 없음 → false")
+    void 헤더_없음_비AJAX() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+
+      assertThat(SecurityHandlerUtil.isAjaxRequest(request)).isFalse();
+    }
+  }
+}

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/web/reactive/KeycloakServerAuthenticationEntryPoint.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/web/reactive/KeycloakServerAuthenticationEntryPoint.java
@@ -6,6 +6,7 @@ import com.ids.keycloak.security.config.KeycloakErrorProperties;
 import com.ids.keycloak.security.exception.ErrorCode;
 import com.ids.keycloak.security.exception.KeycloakSecurityException;
 import java.net.URI;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
@@ -137,19 +138,30 @@ public class KeycloakServerAuthenticationEntryPoint implements ServerAuthenticat
 
   /**
    * AJAX 요청 여부를 판단합니다.
-   * {@code X-Requested-With: XMLHttpRequest} 또는 {@code Accept: application/json} 기준.
+   *
+   * <p>판정 기준:
+   * <ol>
+   *   <li>{@code X-Requested-With: XMLHttpRequest} 헤더가 있으면 AJAX</li>
+   *   <li>Accept 헤더에 {@code text/html}이 포함되어 있으면 브라우저 네비게이션 → non-AJAX</li>
+   *   <li>Accept 헤더에 명시적 JSON(subtype이 "json" 또는 "+json"으로 끝나는 타입) 타입이 있고
+   *       text/html이 없으면 AJAX</li>
+   *   <li>{@code Accept: *&#47;*} 단독이나 Accept 헤더 없음 → non-AJAX</li>
+   * </ol>
+   * 브라우저는 보통 {@code text/html,...,*&#47;*;q=0.8} 형태로 Accept를 보내므로
+   * {@code *&#47;*} 와일드카드 매칭({@link MediaType#includes})을 사용하면
+   * application/json과 compatible로 판정되어 오분류가 발생한다. 이를 방지하기 위해
+   * subtype을 직접 비교한다.
    */
   private boolean isAjaxRequest(ServerWebExchange exchange) {
     HttpHeaders headers = exchange.getRequest().getHeaders();
-    String xRequestedWith = headers.getFirst(AJAX_HEADER);
-    if (AJAX_HEADER_VALUE.equalsIgnoreCase(xRequestedWith)) {
+    if (AJAX_HEADER_VALUE.equalsIgnoreCase(headers.getFirst(AJAX_HEADER))) {
       return true;
     }
-    MediaType accept = headers.getAccept().stream()
-        .filter(mt -> mt.includes(MediaType.APPLICATION_JSON))
-        .findFirst()
-        .orElse(null);
-    return accept != null;
+    List<MediaType> accepts = headers.getAccept();
+    boolean acceptsHtml = accepts.stream().anyMatch(MediaType.TEXT_HTML::isCompatibleWith);
+    boolean explicitJson = accepts.stream()
+        .anyMatch(mt -> "json".equals(mt.getSubtype()) || mt.getSubtype().endsWith("+json"));
+    return explicitJson && !acceptsHtml;
   }
 
   /**

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/web/reactive/KeycloakServerAuthenticationEntryPointTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/web/reactive/KeycloakServerAuthenticationEntryPointTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -151,6 +152,123 @@ class KeycloakServerAuthenticationEntryPointTest {
       MockServerWebExchange exchange = MockServerWebExchange.from(
           MockServerHttpRequest.get("/protected")
               .header("X-Requested-With", "XMLHttpRequest")
+              .build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("브라우저 Accept(text/html,...,*/*) → 비-AJAX → 302 리다이렉트")
+    void 브라우저_Accept_비AJAX_리다이렉트() {
+      KeycloakErrorProperties errorProps = new KeycloakErrorProperties();
+      errorProps.setRedirectEnabled(true);
+      errorProps.setAjaxReturnsJson(true);
+      errorProps.setAuthenticationFailedRedirectUrl("/login");
+
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(
+          objectMapper, errorProps, false, null);
+
+      // 브라우저 표준 Accept 헤더: text/html 포함 + */* 포함
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/protected")
+              .accept(MediaType.TEXT_HTML,
+                  MediaType.parseMediaType("application/xhtml+xml"),
+                  MediaType.parseMediaType("application/xml;q=0.9"),
+                  MediaType.ALL)
+              .build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      // 브라우저 요청은 AJAX가 아니므로 302 리다이렉트
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FOUND);
+      assertThat(exchange.getResponse().getHeaders().getLocation().getPath()).isEqualTo("/login");
+    }
+
+    @Test
+    @DisplayName("Accept: application/json 단독 → AJAX → 401 JSON")
+    void Accept_application_json_단독_AJAX() {
+      KeycloakErrorProperties errorProps = new KeycloakErrorProperties();
+      errorProps.setRedirectEnabled(true);
+      errorProps.setAjaxReturnsJson(true);
+      errorProps.setAuthenticationFailedRedirectUrl("/login");
+
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(
+          objectMapper, errorProps, false, null);
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/protected")
+              .accept(MediaType.APPLICATION_JSON)
+              .build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("Accept: */* 단독 → 비-AJAX → 302 리다이렉트")
+    void Accept_wildcard_단독_비AJAX_리다이렉트() {
+      KeycloakErrorProperties errorProps = new KeycloakErrorProperties();
+      errorProps.setRedirectEnabled(true);
+      errorProps.setAjaxReturnsJson(true);
+      errorProps.setAuthenticationFailedRedirectUrl("/login");
+
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(
+          objectMapper, errorProps, false, null);
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/protected")
+              .accept(MediaType.ALL)
+              .build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      // */* 단독은 AJAX가 아니므로 302 리다이렉트
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FOUND);
+    }
+
+    @Test
+    @DisplayName("Accept 헤더 없음 → 비-AJAX → 302 리다이렉트")
+    void Accept_헤더_없음_비AJAX_리다이렉트() {
+      KeycloakErrorProperties errorProps = new KeycloakErrorProperties();
+      errorProps.setRedirectEnabled(true);
+      errorProps.setAjaxReturnsJson(true);
+      errorProps.setAuthenticationFailedRedirectUrl("/login");
+
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(
+          objectMapper, errorProps, false, null);
+
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/protected").build());
+
+      StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))
+          .verifyComplete();
+
+      assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FOUND);
+    }
+
+    @Test
+    @DisplayName("X-Requested-With: XMLHttpRequest (임의 Accept) → AJAX → 401 JSON")
+    void XRequestedWith_AJAX_JSON() {
+      KeycloakErrorProperties errorProps = new KeycloakErrorProperties();
+      errorProps.setRedirectEnabled(true);
+      errorProps.setAjaxReturnsJson(true);
+      errorProps.setAuthenticationFailedRedirectUrl("/login");
+
+      var entryPoint = new KeycloakServerAuthenticationEntryPoint(
+          objectMapper, errorProps, false, null);
+
+      // X-Requested-With만으로 AJAX 판정 — Accept는 */* 또는 없어도 무관
+      MockServerWebExchange exchange = MockServerWebExchange.from(
+          MockServerHttpRequest.get("/protected")
+              .header("X-Requested-With", "XMLHttpRequest")
+              .accept(MediaType.ALL)
               .build());
 
       StepVerifier.create(entryPoint.commence(exchange, new BadCredentialsException("bad")))


### PR DESCRIPTION
Closes #52

## 버그
webflux `KeycloakServerAuthenticationEntryPoint.isAjaxRequest()`가 브라우저 `Accept: */*`를 `MediaType.includes(APPLICATION_JSON)==true`로 판정 → 모든 브라우저 네비게이션을 AJAX로 오분류. `ajax-returns-json=true` + `redirect-enabled=true` 시 미인증 브라우저가 로그인 리다이렉트 대신 401 JSON.

## 수정
- webflux/servlet 모두 **"명시적 JSON(subtype=json/+json) & HTML 비수용 + X-Requested-With"** 규칙으로 통일
- `*/*`(subtype `*`)는 json equals/+json 둘 다 false → 와일드카드 오분류 원천 차단

## 동작 변화 (breaking 아님)
- 브라우저(`Accept: ...,*/*`) → 302 리다이렉트(정상화)
- `text/html, application/json` 혼재 → false(브라우저 정확 배제), `application/vnd.api+json` → true

## 테스트
webflux 5 + servlet 13 케이스(이슈 제안 4 + 경계) → 469개 전체 통과, 회귀 0

버전 `1.10.0` → `1.10.1` (patch)