### PR TITLE
[#54] fix(webflux): 토큰 무효화 후 재발급 실패가 500 나던 문제 (v1.10.2)

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3,7 +3,7 @@
 Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 하나와 최소 설정으로 OIDC 로그인·세션·로그아웃·인가가 자동 구성됩니다.
 
 - **지원**: JDK 17+, Spring Boot 3.5.x, Spring Security 6.5.x
-- **현재 버전**: `1.10.1`
+- **현재 버전**: `1.10.2`
 - **스택**: Servlet(Spring MVC) / **Reactive(WebFlux) — v1.8.0부터 servlet과 기능 동등** ([8. Reactive](#8-reactivewebflux))
 - 이 문서는 **도입 개발자용 사용 가이드**입니다. 아키텍처/기여 규칙은 [README](../README.md) 참고.
 
@@ -27,10 +27,10 @@ Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 
 
 ```gradle
 // Servlet (Spring MVC)
-implementation("io.github.l-dxd:keycloak-spring-security-web-starter:1.10.1")
+implementation("io.github.l-dxd:keycloak-spring-security-web-starter:1.10.2")
 
 // 또는 Reactive (WebFlux)
-implementation("io.github.l-dxd:keycloak-spring-security-webflux-starter:1.10.1")
+implementation("io.github.l-dxd:keycloak-spring-security-webflux-starter:1.10.2")
 ```
 > Redis 세션을 쓸 경우에만 추가:
 > ```gradle
@@ -322,6 +322,7 @@ LoggingValueSanitizer loggingValueSanitizer() {
 
 | 버전 | 변경 | 주의 |
 |------|------|------|
+| **1.10.2** | (버그픽스 #54) webflux 토큰 무효화(백채널 로그아웃 등) 후 보호 경로 접근 시 refresh 재발급 실패가 500 나던 문제 → 미인증 처리로 EntryPoint(로그인 리다이렉트/401) 경유 | breaking 없음 |
 | **1.10.1** | (버그픽스 #52) webflux/servlet AJAX 판정 통일 — 브라우저 `Accept: */*`를 JSON으로 오판하던 문제 수정(`ajax-returns-json=true` 시 브라우저 리다이렉트 정상화) | breaking 없음 |
 | **1.10.0** ⚠️ | **보안 강화** (보안검토 13건) — reactive 백채널 JWKS 서명+aud 검증, 쿠키 secure 기본 true, XFF 신뢰 프록시, servlet SameSite/토큰 no-store, PII 마스킹 확장(JWT/OAuth2), 인가 캐시·require-user-info 토글, Redis JSON 직렬화 | **Breaking 3건** — 아래 [마이그레이션](#마이그레이션-v190--v1100-breaking) |
 | **1.9.0** | OIDC authorize 파라미터(`acr_values`/`max_age`/`prompt`) 커스터마이즈 — LoA step-up·재인증 | 미설정 시 무동작(회귀 0). 경로별 step-up은 resolver 빈 재정의([4.9](#49-재인증--step-up-acr_values--max_age--prompt-v190)) |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version Management
-projectVersion=1.10.1
+projectVersion=1.10.2
 
 # Maven Publishing Info
 mavenGroupId=io.github.l-dxd

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakServerAuthenticationConverter.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakServerAuthenticationConverter.java
@@ -1,7 +1,6 @@
 package com.ids.keycloak.security.authentication;
 
 import com.ids.keycloak.security.config.KeycloakCookieProperties;
-import com.ids.keycloak.security.exception.AuthenticationFailedException;
 import com.ids.keycloak.security.exception.RefreshTokenException;
 import com.ids.keycloak.security.model.KeycloakPrincipal;
 import com.ids.keycloak.security.session.ReactiveSessionManager;
@@ -76,7 +75,17 @@ public class KeycloakServerAuthenticationConverter implements ServerAuthenticati
 
       // WebSession을 비동기로 가져온 뒤, Refresh Token 확인
       return exchange.getSession()
-          .flatMap(session -> handleWithSession(exchange, session, idToken, accessToken));
+          .flatMap(session -> handleWithSession(exchange, session, idToken, accessToken))
+          .onErrorResume(
+              e -> !(e instanceof org.springframework.security.core.AuthenticationException),
+              e -> {
+                // convert()에서 AuthenticationException이 아닌 예외가 전파되면
+                // AuthenticationWebFilter.onErrorResume(AuthenticationException.class)가 잡지 못해
+                // HTTP 500이 발생한다. 여기서 최종 방어막으로 미인증(empty)으로 처리한다.
+                log.error("[Converter] 예상치 못한 오류로 인증 불가 ({}). 미인증으로 처리.", e.getMessage());
+                ReactiveCookieUtil.deleteAllTokenCookies(exchange.getResponse(), cookieProperties);
+                return Mono.empty();
+              });
     });
   }
 
@@ -175,23 +184,37 @@ public class KeycloakServerAuthenticationConverter implements ServerAuthenticati
                   return Mono.just(auth);
                 });
 
-          } else if (status == 401) {
-            log.warn("[Converter] Refresh Token 만료 또는 유효하지 않음 (401).");
+          } else if (status == 400 || status == 401) {
+            // 토큰 무효 (Refresh Token 만료/폐기): 미인증으로 처리 → Mono.empty()
+            // AuthenticationWebFilter.switchIfEmpty → 체인 계속 → authorizeExchange 거부
+            // → ExceptionTranslationWebFilter → 사용처가 등록한 EntryPoint(리다이렉트/401)
+            log.warn("[Converter] Refresh Token 만료 또는 유효하지 않음 ({}). 미인증(empty)으로 처리.", status);
             ReactiveCookieUtil.deleteAllTokenCookies(exchange.getResponse(), cookieProperties);
             return sessionManager.invalidateSession(session)
-                .then(Mono.error(new RefreshTokenException("Refresh Token이 만료되었습니다.")));
+                .then(Mono.empty());
           } else {
-            log.error("[Converter] 토큰 재발급 중 예상치 못한 응답. 상태 코드: {}", status);
-            return Mono.<Authentication>error(
-                new AuthenticationFailedException("토큰 재발급 실패. 상태 코드: " + status));
+            // 서버 오류(5xx) 또는 예상치 못한 응답: 토큰 유효성 판단 불가.
+            // 현재는 미인증(empty)으로 통일 처리 — EntryPoint 경유하여 로그인 유도.
+            // 추후 운영 요구사항에 따라 Mono.error(new SomeAuthenticationException(...)) 으로
+            // 전환하면 AuthenticationWebFilter.onErrorResume(AuthenticationException.class)에서
+            // failureHandler가 처리하도록 변경 가능.
+            log.error("[Converter] 토큰 재발급 중 예상치 못한 응답 (status={}). 미인증으로 처리.", status);
+            ReactiveCookieUtil.deleteAllTokenCookies(exchange.getResponse(), cookieProperties);
+            return sessionManager.invalidateSession(session)
+                .then(Mono.empty());
           }
         })
         .onErrorResume(
-            e -> !(e instanceof org.springframework.security.core.AuthenticationException)
-                && !(e instanceof com.ids.keycloak.security.exception.KeycloakSecurityException),
+            e -> !(e instanceof org.springframework.security.core.AuthenticationException),
             e -> {
-              log.error("[Converter] 토큰 재발급 중 통신 오류: {}", e.getMessage());
-              return Mono.error(new AuthenticationFailedException("Keycloak 통신 실패: " + e.getMessage()));
+              // 통신 오류(네트워크, 타임아웃 등) 또는 KeycloakSecurityException 계열 중
+              // AuthenticationException이 아닌 모든 예외 → 미인증(empty)으로 처리.
+              // 이 경로에서 RuntimeException을 그대로 전파하면 AuthenticationWebFilter가
+              // onErrorResume(AuthenticationException.class) 로 잡지 못해 HTTP 500이 발생함.
+              log.error("[Converter] 토큰 재발급 중 오류 발생 ({}). 미인증으로 처리.", e.getMessage());
+              ReactiveCookieUtil.deleteAllTokenCookies(exchange.getResponse(), cookieProperties);
+              return sessionManager.invalidateSession(session)
+                  .then(Mono.empty());
             });
   }
 

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/KeycloakServerAuthenticationConverterTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/KeycloakServerAuthenticationConverterTest.java
@@ -194,8 +194,18 @@ class KeycloakServerAuthenticationConverterTest {
           org.mockito.ArgumentMatchers.isNull());
     }
 
+    /**
+     * 버그 수정 (#54): introspect 실패 후 refresh 재발급 401 → convert()가 빈 Mono 반환.
+     *
+     * <p>수정 전: RefreshTokenException(RuntimeException 계열)을 throw → AuthenticationWebFilter가
+     * onErrorResume(AuthenticationException.class)로 잡지 못해 HTTP 500 발생.</p>
+     *
+     * <p>수정 후: 토큰 무효(400/401) → 세션 무효화 → Mono.empty() 반환
+     * → AuthenticationWebFilter.switchIfEmpty(chain.filter(exchange)) → 미인증 진행
+     * → ExceptionTranslationWebFilter → 사용처 EntryPoint(리다이렉트/401).</p>
+     */
     @Test
-    void authManager_인증_실패시_IntrospectionFailedException_refresh_token_재발급_시도_401이면_RefreshTokenException() {
+    void introspect_실패_후_refresh_재발급_401_이면_빈_Mono_반환_non_AuthenticationException_미전파() {
       MockServerHttpRequest request = MockServerHttpRequest.get("/api/test")
           .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ID_TOKEN_COOKIE_NAME, ID_TOKEN))
           .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ACCESS_TOKEN_COOKIE_NAME, ACCESS_TOKEN))
@@ -210,7 +220,7 @@ class KeycloakServerAuthenticationConverterTest {
           .thenReturn(Mono.error(
               new com.ids.keycloak.security.exception.IntrospectionFailedException("토큰 만료")));
 
-      // keycloakClient.authAsync().reissueToken() — 401 응답
+      // reissueToken — 401 응답 (refresh token도 무효)
       KeycloakResponse<com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo> reissueResp =
           KeycloakResponse.<com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo>builder()
               .status(401)
@@ -222,10 +232,136 @@ class KeycloakServerAuthenticationConverterTest {
       when(sessionManager.invalidateSession(org.mockito.ArgumentMatchers.any()))
           .thenReturn(Mono.empty());
 
-      // refresh 401 → 세션 무효화 → RefreshTokenException 에러
+      // 수정 후: 빈 Mono → HTTP 500이 아닌 EntryPoint 경유(302/401)
       StepVerifier.create(converter.convert(exchange))
-          .expectError(com.ids.keycloak.security.exception.RefreshTokenException.class)
-          .verify();
+          .verifyComplete();
+    }
+
+    /**
+     * 버그 수정 (#54): introspect 실패 후 refresh 재발급 400 → convert()가 빈 Mono 반환.
+     *
+     * <p>Keycloak 백채널 로그아웃 후 refresh token 재발급 시 400 응답 케이스 (#54 원인 시나리오).</p>
+     */
+    @Test
+    void introspect_실패_후_refresh_재발급_400_이면_빈_Mono_반환() {
+      MockServerHttpRequest request = MockServerHttpRequest.get("/api/test")
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ID_TOKEN_COOKIE_NAME, ID_TOKEN))
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ACCESS_TOKEN_COOKIE_NAME, ACCESS_TOKEN))
+          .build();
+      MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+      when(sessionManager.getRefreshToken(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Optional.of(REFRESH_TOKEN));
+
+      when(authManager.authenticate(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.error(
+              new com.ids.keycloak.security.exception.IntrospectionFailedException("active=false")));
+
+      // reissueToken — 400 응답 (백채널 로그아웃 후 refresh token 폐기됨)
+      KeycloakResponse<com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo> reissueResp =
+          KeycloakResponse.<com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo>builder()
+              .status(400)
+              .build();
+
+      when(authAsyncClient.reissueToken(REFRESH_TOKEN))
+          .thenReturn(Mono.just(reissueResp));
+
+      when(sessionManager.invalidateSession(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.empty());
+
+      StepVerifier.create(converter.convert(exchange))
+          .verifyComplete();
+    }
+
+    /**
+     * 버그 수정 (#54): refresh 재발급 중 네트워크 오류 → convert()가 빈 Mono 반환.
+     *
+     * <p>RuntimeException이 convert() 밖으로 전파되면 HTTP 500이 발생하므로
+     * 최종 방어막(onErrorResume)에서 Mono.empty()로 변환한다.</p>
+     */
+    @Test
+    void refresh_재발급_중_네트워크_오류_이면_빈_Mono_반환_RuntimeException_미전파() {
+      MockServerHttpRequest request = MockServerHttpRequest.get("/api/test")
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ID_TOKEN_COOKIE_NAME, ID_TOKEN))
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ACCESS_TOKEN_COOKIE_NAME, ACCESS_TOKEN))
+          .build();
+      MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+      when(sessionManager.getRefreshToken(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Optional.of(REFRESH_TOKEN));
+
+      when(authManager.authenticate(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.error(
+              new com.ids.keycloak.security.exception.IntrospectionFailedException("통신 오류")));
+
+      // 네트워크 오류: reissueToken 자체가 예외 발생
+      when(authAsyncClient.reissueToken(REFRESH_TOKEN))
+          .thenReturn(Mono.error(new RuntimeException("Connection refused")));
+
+      when(sessionManager.invalidateSession(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.empty());
+
+      // RuntimeException이 convert()를 뚫고 나오면 HTTP 500 → 수정 후 빈 Mono
+      StepVerifier.create(converter.convert(exchange))
+          .verifyComplete();
+    }
+
+    /**
+     * 버그 수정 (#54): introspect 실패 후 refresh 재발급 5xx 서버 오류 → convert()가 빈 Mono 반환.
+     */
+    @Test
+    void introspect_실패_후_refresh_재발급_5xx_이면_빈_Mono_반환() {
+      MockServerHttpRequest request = MockServerHttpRequest.get("/api/test")
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ID_TOKEN_COOKIE_NAME, ID_TOKEN))
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ACCESS_TOKEN_COOKIE_NAME, ACCESS_TOKEN))
+          .build();
+      MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+      when(sessionManager.getRefreshToken(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Optional.of(REFRESH_TOKEN));
+
+      when(authManager.authenticate(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.error(
+              new com.ids.keycloak.security.exception.IntrospectionFailedException("서버 오류")));
+
+      // reissueToken — 500 응답 (Keycloak 서버 일시 오류)
+      KeycloakResponse<com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo> reissueResp =
+          KeycloakResponse.<com.sd.KeycloakClient.dto.auth.KeycloakTokenInfo>builder()
+              .status(500)
+              .build();
+
+      when(authAsyncClient.reissueToken(REFRESH_TOKEN))
+          .thenReturn(Mono.just(reissueResp));
+
+      when(sessionManager.invalidateSession(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.empty());
+
+      StepVerifier.create(converter.convert(exchange))
+          .verifyComplete();
+    }
+
+    /**
+     * 정상 경로 회귀: introspect 성공 시 Authentication 반환 (기존 동작 유지).
+     */
+    @Test
+    void introspect_성공시_Authentication_정상_반환_회귀_없음() {
+      MockServerHttpRequest request = MockServerHttpRequest.get("/api/test")
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ID_TOKEN_COOKIE_NAME, ID_TOKEN))
+          .cookie(new HttpCookie(KeycloakServerAuthenticationConverter.ACCESS_TOKEN_COOKIE_NAME, ACCESS_TOKEN))
+          .build();
+      MockServerWebExchange exchange = MockServerWebExchange.from(request);
+
+      when(sessionManager.getRefreshToken(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Optional.of(REFRESH_TOKEN));
+
+      Authentication authenticated = mock(Authentication.class);
+      when(authenticated.isAuthenticated()).thenReturn(true);
+      when(authManager.authenticate(org.mockito.ArgumentMatchers.any()))
+          .thenReturn(Mono.just(authenticated));
+
+      StepVerifier.create(converter.convert(exchange))
+          .expectNextMatches(Authentication::isAuthenticated)
+          .verifyComplete();
     }
   }
 }


### PR DESCRIPTION
Closes #54

## 버그
백채널 로그아웃 등으로 토큰이 무효화된 사용자가 보호 경로 접근 시, `KeycloakServerAuthenticationConverter`가 introspect+refresh 실패를 `AuthenticationFailedException`(Spring `AuthenticationException` 아님)으로 던져 `AuthenticationWebFilter`/`ExceptionTranslationWebFilter`가 미포착 → **500**. (사용처가 EntryPoint를 올바르게 연결해도 도달 불가)

## 수정
토큰 무효/재발급 실패를 **빈 Mono(미인증)** 로 반환 → `switchIfEmpty` → `authorizeExchange` 거부 → `ExceptionTranslationWebFilter` → **사용처 EntryPoint(로그인 리다이렉트 302/401)**. 세션 무효화 + 쿠키 삭제로 리다이렉트 루프 방지.
- 옵션 A 선택 근거: 빈 Mono는 사용처 `exceptionHandling().authenticationEntryPoint()`를 확실히 경유(옵션 B인 AuthenticationException 변환은 AuthenticationWebFilter 기본 failureHandler가 사용처 EntryPoint를 안 탐)
- servlet과 동일 결과(미인증 → EntryPoint)로 일관성 확보

## 검증
- identity-apigateway SecurityConfig 검증 → **사용처 오용 아님, 라이브러리 버그 확정** (이슈 #54 코멘트)
- 테스트 +5(401/400/5xx/네트워크 → 빈 Mono, 정상 경로 회귀 없음), 473 전체 통과

버전 `1.10.1` → `1.10.2` (patch, breaking 없음)