### PR TITLE
Security patch 2.0.1: external review fixes (4 findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-07-15
+### Security
+- **OIDC Access Token·ID Token subject 직접 비교 (외부 검토 High #1)**: 쿠키 기반 OIDC 인증에서 Access Token이 구조적으로 JWT이면 `TokenBindingValidator#validateAccessTokenSubject`로 Access Token의 `sub`를 ID Token `sub`와 직접 비교하도록 강화(servlet `KeycloakAuthenticationProvider`, webflux `KeycloakReactiveAuthenticationManager` 동일 적용). 기존에는 Access Token과 ID Token의 결합 여부를 UserInfo 엔드포인트 조회가 성공한 경우에만 확인했는데, UserInfo 조회가 실패하거나(장애) `require-user-info`가 기본값(`false`)이면 서로 다른 사용자의 Access Token과 ID Token이 조합되어도 인증이 성립할 수 있었음. **잔여 한계**: Opaque(불투명) Access Token은 로컬에서 `sub`를 파싱할 수 없어 이 직접 비교가 적용되지 않으며 여전히 UserInfo 일치 검증에만 의존함 — Opaque Access Token을 쓰는 환경은 `keycloak.security.authentication.require-user-info=true`로 UserInfo 검증을 필수화할 것을 권장.
+- **WebFlux CSRF 매처의 안전 메서드 예외 누락 수정 (외부 검토 Medium #3)**: `KeycloakWebFluxSecurityConfigurer#configureCsrf()`의 CSRF 보호 대상 매처가 면제 경로 부정(NOT)만으로 구성되어 있어, CSRF 활성화 시 GET/HEAD/OPTIONS/TRACE 등 안전 메서드 요청(조회, OIDC 콜백 등)까지 CSRF 토큰을 요구해 `403`을 반환하던 문제. Spring 표준 안전-메서드 제외 매처(`CsrfWebFilter.DEFAULT_CSRF_MATCHER`)와 면제 경로 부정 매처를 AND로 결합해 servlet(`CsrfConfigurer`)과 동일한 방식으로 정렬.
+- **브라우저 Front-Channel `/logout`의 강제 로그아웃 CSRF 우회 수정 (외부 검토 Medium #4, CWE-352)**: `bearer-token.enabled=true`일 때 CSRF 면제 경로 목록에 브라우저용 Front-Channel 로그아웃 경로(`/logout`)까지 함께 추가되던 로직을 제거(servlet `KeycloakHttpConfigurer`, webflux `KeycloakWebFluxSecurityConfigurer` 동일). Bearer 활성 여부와 무관하게 브라우저 폼 기반 `/logout`은 항상 CSRF 보호되며, Bearer 전용 로그아웃(`{prefix}/logout`)만 계속 면제됨.
+- **(외부 검토 Low #1~#4 묶음)**: Bearer Token 엔드포인트 `token-endpoint.prefix`가 공백이거나 `"/"` 자체이면 기동을 실패시키는 검증을 추가(prefix가 비정상이면 Bearer 전용 로그아웃 경로가 브라우저 Front-Channel `/logout`과 사실상 동일해져 위 Medium #4가 재현될 수 있는 설정을 fail-fast로 차단); webflux `KeycloakReactiveAuthenticationManager`의 토큰 결합 검증 순서를 servlet `KeycloakAuthenticationProvider`와 동일하게 정렬(검증 결과는 동일, 두 스택 간 일관성 목적); `KeycloakAuthenticationFilter`에서 `TokenBindingException`을 포괄 `catch(Exception)`보다 먼저 전용 처리해 전체 스택트레이스 대신 warn 로그 한 줄만 남기도록 정리; `TokenBindingValidator`의 결합 검증 실패 예외 메시지에 그대로 노출되던 subject(UUID)를 기존 `LogMaskingUtil`로 마스킹.
+### Changed (Breaking)
+- Servlet OIDC 인증용 `JwtDecoder` 빈(`keycloakJwtDecoder` → `keycloakOidcJwtDecoder`)의 대체 조건(`@ConditionalOnMissingBean`)이 타입(`JwtDecoder.class`) 기반에서 빈 이름(`keycloakOidcJwtDecoder`) 기반으로 변경됨(webflux `keycloakOidcReactiveJwtDecoder`와 동일 패턴으로 정렬). 애플리케이션이 다른 issuer/resource-server용 `JwtDecoder` 빈을 이미 등록한 경우, 과거에는 이 전용 decoder가 생성되지 않거나(조용히 대체) 두 빈이 동시에 존재해 `NoUniqueBeanDefinitionException`으로 기동이 실패할 수 있었음. 이 decoder를 커스텀 재정의(override)하던 경우 빈 이름을 `keycloakOidcJwtDecoder`로 맞춰야 하며, 별도 resource-server용 JWT decoder가 필요하면 다른 이름을 쓰거나 소비 지점에서 `@Qualifier`로 명시 구분할 것.
+
 ## [2.0.0] - 2026-07-14
 ### Security
 - **OIDC ID/Access Token 사용자·클라이언트 결합 검증 강화 (Advisory 1)**: 쿠키 기반 OIDC 인증에서 ID Token subject를 서명 검증 없이 파싱해 Principal로 신뢰하던 로직을 제거. `JwtDecoder`(servlet) / `ReactiveJwtDecoder`(webflux)로 서명·iss·exp·nbf를 검증한 뒤에만 subject를 사용하도록 변경하고, ID Token의 `aud`/`azp`가 애플리케이션 client-id와 일치하는지, ID Token subject와 UserInfo subject가 일치하는지 추가 검증(`TokenBindingValidator`)해 서로 다른 사용자·클라이언트의 토큰이 조합되어 인증되는 것을 차단(Access Token이 JWT 형식이면 `azp`도 함께 검증, Opaque Access Token은 UserInfo 일치 검증까지 — 회귀 없음). 함께, OIDC issuer(`iss`) 해석 우선순위를 명시 프로퍼티 → 표준 Spring Boot `issuer-uri` → `base-url` 파생 순으로 정리해, `base-url`이 서버간 통신용 내부 주소라 브라우저가 보는 실제 issuer와 다른 환경에서 로그인이 전면 실패하는 문제를 예방.
@@ -109,7 +118,8 @@
 ### Added
 - `@EnableMethodSecurity` 적용, 초기 OIDC 로그인/세션/로그아웃/Redis 세션 등 기반 기능
 
-[Unreleased]: https://github.com/L-DXD/keycloak-spring-security/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/L-DXD/keycloak-spring-security/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/L-DXD/keycloak-spring-security/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/L-DXD/keycloak-spring-security/compare/v1.10.2...v2.0.0
 [1.10.2]: https://github.com/L-DXD/keycloak-spring-security/compare/v1.10.1...v1.10.2
 [1.10.1]: https://github.com/L-DXD/keycloak-spring-security/compare/v1.10.0...v1.10.1

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,259 @@
+# Architecture & Development Guidelines
+
+[English](README.md) | **한국어**
+
+**도입 개발자 문서**
+
+- **[사용 가이드](docs/GUIDE.md)** — 빠른 시작 · 설정 레퍼런스 · 기능별 가이드 · 마이그레이션 · 트러블슈팅
+- **[변경 이력 (CHANGELOG)](CHANGELOG.md)** — 버전별 Added / Fixed / Deprecated / Security
+- **[보안 / 권장 버전 (SECURITY)](SECURITY.md)** — 지원 버전 표 · 취약점 신고
+
+> 아래 문서는 **라이브러리 기여자용** 아키텍처/개발 규칙입니다.
+
+이 문서는 **Keycloak Spring Security Open Source Library**의 아키텍처 원칙, 프로젝트 구조, 배포 전략, 그리고 설정 가이드를 정의합니다.
+본 프로젝트는 **Spring Security 공식 GitHub 리포지토리의 구조**를 따르며, **Servlet(Blocking)** 과 **Reactive(Non-blocking)** 스택을 모두 지원하는 것을 목표로 합니다.
+
+---
+
+## 1. Artifact Naming & Deployment (배포 명명 규칙)
+
+Maven Central 배포 시 라이브러리 식별 충돌 방지와 명확한 가독성을 위해 아래 규칙을 **엄격히 준수**합니다.
+단순 명사(예: `core`, `servlet`)를 ArtifactId로 사용하는 것을 금지합니다.
+
+### Coordinates
+* **GroupId**: `com.ids.keycloak`
+* **Version**: Semantic Versioning (ex: `1.0.0-SNAPSHOT`)
+
+### ArtifactId Policy
+모든 모듈의 ArtifactId는 **`keycloak-spring-security-`** 접두사를 포함해야 합니다.
+
+| Module Role | Folder Name | **ArtifactId (Maven/Gradle)** | Description |
+| :--- | :--- | :--- | :--- |
+| **Root** | `root` | `keycloak-spring-security` | BOM 및 공통 빌드 설정 관리 |
+| **Core** | `*-core` | **`keycloak-spring-security-core`** | 외부 프레임워크 의존성 없는 순수 로직 (POJO) |
+| **Servlet** | `*-servlet` | **`keycloak-spring-security-servlet`** | Spring MVC (Tomcat) 기반 구현체 |
+| **Reactive** | `*-reactive` | **`keycloak-spring-security-reactive`** | Spring WebFlux (Netty) 기반 구현체 |
+| **Servlet Starter** | `*-servlet-starter` | **`keycloak-spring-security-servlet-starter`** | Servlet (Spring MVC) 환경용 스타터 |
+| **Reactive Starter**| `*-reactive-starter`| **`keycloak-spring-security-reactive-starter`**| Reactive (WebFlux) 환경용 스타터 |
+
+> **Bad Practice (사용 금지):**
+> * `com.ids.keycloak:servlet:1.0.0` (X) -> 타 라이브러리(Jakarta Servlet 등)와 혼동됨
+> * `com.ids.keycloak:core:1.0.0` (X) -> 식별 불가능
+
+---
+
+## 2. Module Structure & Responsibility (모듈 구조)
+
+우리는 **Multi-Module** 전략을 취하며, 각 모듈의 역할은 엄격히 분리됩니다.
+
+### Core Module (`...-core`)
+* **역할:** 비즈니스 로직의 심장. Spring Web/Servlet/Reactive에 의존하지 않는 순수 Java 코드.
+* **주요 기능:** 토큰 파싱(Parsing), 검증(Verification), 권한 매핑(Authority Mapping), 도메인 모델.
+* **제약:** `javax.servlet`, `org.springframework.web` 패키지 import 금지.
+
+### Servlet Module (`...-servlet`)
+* **역할:** Blocking I/O 기반의 Spring MVC 애플리케이션 지원.
+* **의존성:** `core`, `spring-security-web`, `jakarta.servlet-api`
+* **주요 기능:** `OncePerRequestFilter`, `AuthenticationProvider`, `AbstractHttpConfigurer`.
+
+### Reactive Module (`...-reactive`)
+* **역할:** Non-blocking I/O 기반의 Spring WebFlux 애플리케이션 지원.
+* **의존성:** `core`, `spring-security-webflux`, `reactor-core`
+* **주요 기능:** `ReactiveAuthenticationManager`, `ServerAuthenticationConverter`.
+
+### Starter Modules (`...-servlet-starter`, `...-reactive-starter`)
+* **역할:** 사용자가 자신의 환경에 맞는 의존성 하나만 추가하여 라이브러리 기능을 쉽게 사용할 수 있도록 하는 **환경별 진입점**입니다.
+* **구조:**
+    * **`servlet-starter`:** `servlet` 구현체 모듈과 자동 설정 로직을 포함합니다. Servlet 기반의 Spring MVC 환경에서 사용됩니다.
+    * **`reactive-starter`:** `reactive` 구현체 모듈과 자동 설정 로직을 포함합니다. Reactive 기반의 Spring WebFlux 환경에서 사용됩니다.
+* **주의:** 기존의 통합 `starter`는 두 개의 환경별 `starter`로 분리되었습니다.
+
+---
+
+## 3. Package Structure Strategy (패키지 구조)
+
+패키지명은 **`com.ids.keycloak.security`** 를 Root로 하며, **계층(Layer)** 이 아닌 **기능(Feature)** 단위로 구성합니다.
+
+### Common Pattern
+```text
+com.ids.keycloak.security
+  ├── config          // 설정 지원 (Configurer, Customizer)
+  ├── authentication  // 인증 처리 (Provider, Manager, Token)
+  ├── authorization   // 인가 처리 (Provider, Manager)
+  ├── filter          // (Servlet only) 필터 체인 관련
+  ├── web             // (Reactive only) 웹 교환 처리
+  ├── exception       // 예외 처리
+  └── util            // 유틸리티
+```
+
+### Core Module Detail
+```text
+├── token           // TokenVerifier, TokenParser
+├── authority       // GrantedAuthoritiesMapper
+└── model           // KeycloakUserDetails, KeycloakPrincipal
+```
+
+---
+
+## 4. Development Principles (개발 원칙)
+
+오픈소스 라이브러리로서 **확장성**을 최우선으로 고려합니다.
+
+### Extension Points (확장성)
+1.  **`@ConditionalOnMissingBean` 활용:**
+   * Starter의 모든 Bean 등록에는 이 어노테이션을 붙여, 사용자가 재정의(Override)할 수 있는 구멍을 열어둡니다.
+2.  **Customizer 패턴:**
+   * 설정 클래스는 `Customizer<T>`를 인자로 받아, 사용자가 람다식으로 설정을 추가할 수 있게 합니다.
+3.  **상속 허용:**
+   * 보안상 필수적인 경우를 제외하고는 `final` 클래스 사용을 지양합니다.
+
+### Coding Convention
+1.  **Logging:**
+   * `System.out.println` 절대 금지.
+   * `slf4j` 인터페이스 사용 (`@Slf4j` 권장).
+2.  **Exception:**
+   * Checked Exception 지양, `RuntimeException` 기반의 커스텀 예외(`KeycloakSecurityException`) 사용.
+
+---
+
+## 5. Configuration Strategy (설정 및 확장 전략) 
+
+사용자에게 편의성과 제어권을 동시에 제공하며, **환경별 Starter를 통해 명시적인 의존성 관리**를 유도하는 전략을 사용합니다.
+
+### Strategy A: Explicit Environment Selection (환경별 스타터 선택)
+사용자는 자신의 애플리케이션 환경(Spring MVC 또는 WebFlux)을 명확히 인지하고, 그에 맞는 `starter` 의존성 하나를 직접 선택하여 추가해야 합니다. 이를 통해 불필요한 `reactive` 또는 `servlet` 의존성이 프로젝트에 포함되는 것을 방지합니다.
+ 
+* **Mechanism:** Gradle/Maven 의존성 관리
+* **Implementation:**
+    * **Servlet 환경:** 사용자는 `keycloak-spring-security-servlet-starter` 의존성을 추가합니다.
+    * **Reactive 환경:** 사용자는 `keycloak-spring-security-reactive-starter` 의존성을 추가합니다.
+
+### Strategy B: Zero-Configuration (Auto Config)
+초기 설정 없이 동작하도록 기본 `SecurityFilterChain`을 제공합니다.
+단, 사용자의 커스텀 설정을 방해하지 않기 위해 **반드시 `@ConditionalOnMissingBean`을 사용**합니다.
+
+```java
+// Servlet AutoConfiguration Example
+@Bean
+@ConditionalOnMissingBean(SecurityFilterChain.class)
+public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) {
+    return http.with(KeycloakHttpConfigurer.keycloak(), Customizer.withDefaults()).build();
+}
+```
+### Strategy C: Modular Configuration (Configurer Pattern)
+사용자가 직접 설정을 구성할 때를 대비해, 내부 로직을 캡슐화한 Configurer를 제공합니다.
+
+```java
+// User Usage Example
+@Bean
+public SecurityFilterChain filterChain(HttpSecurity http) {
+    return http
+        .authorizeHttpRequests(...) 
+        .addFilterBefore(new MyCustomFilter(), ...) 
+        .with(KeycloakHttpConfigurer.keycloak(), Customizer.withDefaults()) // 한 줄로 기능 적용
+        .build();
+}
+
+```
+
+---
+
+## 6. Build Configuration (Gradle)
+
+* **Build Tool:** Gradle
+* **Java Version:** JDK 17 이상
+* **Supported Versions:**
+    *   Spring Boot 3.5.9 (Stable)
+    *   Spring Security 6.5.7 (Stable)
+* **Usage:** 사용자는 환경 구분 없이 아래 의존성 하나만 사용합니다.
+
+```build.gradle
+// for MVC and Servlet environment
+implementation("com.ids.keycloak:keycloak-spring-security-web-starter:1.0.0")
+
+// for WebFlux and Reactive environment
+implementation("com.ids.keycloak:keycloak-spring-security-webflux-starter:1.0.0")
+```
+
+---
+
+## 7. Feature Toggle Configuration (기능별 설정 가이드)
+
+모든 기능은 `keycloak.security.*` 네임스페이스의 yaml 설정으로 제어됩니다.
+
+### CSRF Protection
+
+CSRF(Cross-Site Request Forgery) 보호 설정입니다. 기본값은 **활성화(true)** 이며, 로그아웃 및 토큰 발급 엔드포인트는 자동으로 면제됩니다.
+
+```yaml
+keycloak:
+  security:
+    csrf:
+      enabled: true                     # 기본값: true (CSRF 보호 활성화)
+      ignore-paths:                     # 추가 CSRF 면제 경로 (Ant 패턴)
+        - /api/**
+        - /webhook/**
+```
+
+| 속성 | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `enabled` | boolean | `true` | CSRF 보호 활성화 여부. `false` 시 완전 비활성화 |
+| `ignore-paths` | List&lt;String&gt; | `[]` | 추가 CSRF 면제 경로. Ant 패턴 지원 (`/api/**` 등) |
+
+**기본 면제 경로 (하드코딩):**
+- `/logout` (Front-Channel 로그아웃)
+- `/logout/connect/back-channel/**` (Back-Channel 로그아웃)
+- Bearer Token 활성화 시: `/auth/token`, `/auth/refresh`, `/auth/logout`
+
+**Basic Auth와 CSRF (보안 경고):**
+`basic-auth.enabled: true`로 설정해도 `Authorization: Basic` 헤더 보유만으로 CSRF가 자동 면제되지 **않습니다**. HTTP Basic 자격증명은 브라우저가 origin 단위로 캐시해 이후 요청(공격자의 cross-origin 폼 제출 포함)에 자동 재전송할 수 있는 ambient credential이라, 헤더 존재를 "비-브라우저 요청"의 증거로 삼을 수 없기 때문입니다(CWE-352). Basic Auth는 브라우저가 개입하지 않는 머신 클라이언트(curl, 서버-to-서버 호출 등) 전용으로 사용하고, CSRF 면제가 필요한 경로는 반드시 `ignore-paths`에 명시적으로 등록하세요.
+
+### Basic Authentication
+
+```yaml
+keycloak:
+  security:
+    basic-auth:
+      enabled: false                    # 기본값: false (opt-in)
+```
+
+### Bearer Token
+
+```yaml
+keycloak:
+  security:
+    bearer-token:
+      enabled: false                    # 기본값: false (opt-in)
+      token-endpoint:
+        prefix: /auth                   # 기본값: /auth
+```
+
+### Rate Limiting
+
+```yaml
+keycloak:
+  security:
+    rate-limit:
+      enabled: false                    # 기본값: false (opt-in)
+      max-requests: 5                   # 시간 윈도우 내 최대 요청 수
+      window-seconds: 60               # 시간 윈도우 (초)
+      block-duration-seconds: 300      # 차단 지속 시간 (초)
+      key-strategy: IP_AND_USERNAME    # IP, USERNAME, IP_AND_USERNAME
+      include-basic-auth: true         # Basic Auth에도 적용
+      max-tracked-keys: 100000         # 인메모리 카운터 맵 최대 추적 키 수(카디널리티 공격 방지, 초과 시 fail-closed)
+```
+
+클라이언트 IP는 `ClientIpResolver`가 `trusted-proxy-count`(신뢰 프록시 수, 기본 `0`)를 기준으로 판정하므로, 리버스 프록시 뒤에서는 `keycloak.security.trusted-proxy-count`를 프록시 수에 맞게 설정해야 `X-Forwarded-For` 스푸핑으로 rate limit이 우회되지 않습니다.
+
+### Role 매핑 (Realm/Client 역할 네임스페이스)
+
+```yaml
+keycloak:
+  security:
+    role-mapping:
+      mode: SEPARATE_NAMESPACE          # 기본값. REALM_ONLY / CLIENT_ONLY / LEGACY_MERGED
+      realm-role-prefix: ROLE_REALM_    # mode=SEPARATE_NAMESPACE일 때 Realm 역할 접두사
+      client-role-prefix: ROLE_CLIENT_  # mode=SEPARATE_NAMESPACE일 때 Client 역할 접두사
+```
+
+**보안 경고(Breaking):** 과거에는 `realm_access.roles`와 `resource_access.{clientId}.roles`가 모두 동일한 `ROLE_<이름>` 권한으로 병합되어, 동명의 realm 역할과 client 역할을 구분할 수 없었습니다(CWE-863 — realm 역할 보유자가 client 전용 `hasRole(...)` 검사를 의도치 않게 통과 가능). 기본값이 realm/client 역할을 서로 다른 접두사(`ROLE_REALM_*`/`ROLE_CLIENT_<CLIENT>_*`)로 분리하는 `SEPARATE_NAMESPACE`로 바뀌었으므로, 기존 `hasRole(...)`/`hasAuthority(...)` 참조를 새 권한 문자열에 맞게 갱신하세요. 과도기적으로만 과거 동작이 필요하면 `mode: LEGACY_MERGED`(비권장, CWE-863 재노출)를 명시 설정할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -1,90 +1,92 @@
 # Architecture & Development Guidelines
 
-**📚 도입 개발자 문서**
+**English** | [한국어](README.ko.md)
 
-- 📖 **[사용 가이드](docs/GUIDE.md)** — 빠른 시작 · 설정 레퍼런스 · 기능별 가이드 · 마이그레이션 · 트러블슈팅
-- 📋 **[변경 이력 (CHANGELOG)](CHANGELOG.md)** — 버전별 Added / Fixed / Deprecated / Security
-- 🔒 **[보안 / 권장 버전 (SECURITY)](SECURITY.md)** — 지원 버전 표 · 취약점 신고
+**Guide for Adopting Developers**
 
-> ℹ️ 아래 문서는 **라이브러리 기여자용** 아키텍처/개발 규칙입니다.
+- **[User Guide](docs/GUIDE.md)** — Quick start · Configuration reference · Feature guides · Migration · Troubleshooting
+- **[Changelog](CHANGELOG.md)** — Added / Fixed / Deprecated / Security by version
+- **[Security / Recommended Versions](SECURITY.md)** — Supported version matrix · Vulnerability reporting
 
-이 문서는 **Keycloak Spring Security Open Source Library**의 아키텍처 원칙, 프로젝트 구조, 배포 전략, 그리고 설정 가이드를 정의합니다.
-본 프로젝트는 **Spring Security 공식 GitHub 리포지토리의 구조**를 따르며, **Servlet(Blocking)** 과 **Reactive(Non-blocking)** 스택을 모두 지원하는 것을 목표로 합니다.
+> The document below covers **library contributor** architecture/development guidelines.
+
+This document defines the architecture principles, project structure, deployment strategy, and configuration guide for the **Keycloak Spring Security Open Source Library**.
+This project follows the **structure of the official Spring Security GitHub repository**, and aims to support both the **Servlet (Blocking)** and **Reactive (Non-blocking)** stacks.
 
 ---
 
-## 1. Artifact Naming & Deployment (배포 명명 규칙)
+## 1. Artifact Naming & Deployment
 
-Maven Central 배포 시 라이브러리 식별 충돌 방지와 명확한 가독성을 위해 아래 규칙을 **엄격히 준수**합니다.
-단순 명사(예: `core`, `servlet`)를 ArtifactId로 사용하는 것을 금지합니다.
+To prevent library identification conflicts during Maven Central deployment and to keep things clearly readable, the following rules are **strictly enforced**.
+Using a plain noun (e.g., `core`, `servlet`) as an ArtifactId is prohibited.
 
-### 📦 Coordinates
+### Coordinates
 * **GroupId**: `com.ids.keycloak`
 * **Version**: Semantic Versioning (ex: `1.0.0-SNAPSHOT`)
 
-### 🏷️ ArtifactId Policy
-모든 모듈의 ArtifactId는 **`keycloak-spring-security-`** 접두사를 포함해야 합니다.
+### ArtifactId Policy
+Every module's ArtifactId must include the **`keycloak-spring-security-`** prefix.
 
 | Module Role | Folder Name | **ArtifactId (Maven/Gradle)** | Description |
 | :--- | :--- | :--- | :--- |
-| **Root** | `root` | `keycloak-spring-security` | BOM 및 공통 빌드 설정 관리 |
-| **Core** | `*-core` | **`keycloak-spring-security-core`** | 외부 프레임워크 의존성 없는 순수 로직 (POJO) |
-| **Servlet** | `*-servlet` | **`keycloak-spring-security-servlet`** | Spring MVC (Tomcat) 기반 구현체 |
-| **Reactive** | `*-reactive` | **`keycloak-spring-security-reactive`** | Spring WebFlux (Netty) 기반 구현체 |
-| **Servlet Starter** | `*-servlet-starter` | **`keycloak-spring-security-servlet-starter`** | Servlet (Spring MVC) 환경용 스타터 |
-| **Reactive Starter**| `*-reactive-starter`| **`keycloak-spring-security-reactive-starter`**| Reactive (WebFlux) 환경용 스타터 |
+| **Root** | `root` | `keycloak-spring-security` | Manages the BOM and common build configuration |
+| **Core** | `*-core` | **`keycloak-spring-security-core`** | Pure logic (POJO) with no external framework dependencies |
+| **Servlet** | `*-servlet` | **`keycloak-spring-security-servlet`** | Implementation based on Spring MVC (Tomcat) |
+| **Reactive** | `*-reactive` | **`keycloak-spring-security-reactive`** | Implementation based on Spring WebFlux (Netty) |
+| **Servlet Starter** | `*-servlet-starter` | **`keycloak-spring-security-servlet-starter`** | Starter for Servlet (Spring MVC) environments |
+| **Reactive Starter**| `*-reactive-starter`| **`keycloak-spring-security-reactive-starter`**| Starter for Reactive (WebFlux) environments |
 
-> 🚫 **Bad Practice (사용 금지):**
-> * `com.ids.keycloak:servlet:1.0.0` (X) -> 타 라이브러리(Jakarta Servlet 등)와 혼동됨
-> * `com.ids.keycloak:core:1.0.0` (X) -> 식별 불가능
-
----
-
-## 2. Module Structure & Responsibility (모듈 구조)
-
-우리는 **Multi-Module** 전략을 취하며, 각 모듈의 역할은 엄격히 분리됩니다.
-
-### 🔹 Core Module (`...-core`)
-* **역할:** 비즈니스 로직의 심장. Spring Web/Servlet/Reactive에 의존하지 않는 순수 Java 코드.
-* **주요 기능:** 토큰 파싱(Parsing), 검증(Verification), 권한 매핑(Authority Mapping), 도메인 모델.
-* **제약:** `javax.servlet`, `org.springframework.web` 패키지 import 금지.
-
-### 🔹 Servlet Module (`...-servlet`)
-* **역할:** Blocking I/O 기반의 Spring MVC 애플리케이션 지원.
-* **의존성:** `core`, `spring-security-web`, `jakarta.servlet-api`
-* **주요 기능:** `OncePerRequestFilter`, `AuthenticationProvider`, `AbstractHttpConfigurer`.
-
-### 🔹 Reactive Module (`...-reactive`)
-* **역할:** Non-blocking I/O 기반의 Spring WebFlux 애플리케이션 지원.
-* **의존성:** `core`, `spring-security-webflux`, `reactor-core`
-* **주요 기능:** `ReactiveAuthenticationManager`, `ServerAuthenticationConverter`.
-
-### 🔹 Starter Modules (`...-servlet-starter`, `...-reactive-starter`)
-* **역할:** 사용자가 자신의 환경에 맞는 의존성 하나만 추가하여 라이브러리 기능을 쉽게 사용할 수 있도록 하는 **환경별 진입점**입니다.
-* **구조:**
-    * **`servlet-starter`:** `servlet` 구현체 모듈과 자동 설정 로직을 포함합니다. Servlet 기반의 Spring MVC 환경에서 사용됩니다.
-    * **`reactive-starter`:** `reactive` 구현체 모듈과 자동 설정 로직을 포함합니다. Reactive 기반의 Spring WebFlux 환경에서 사용됩니다.
-* **주의:** 기존의 통합 `starter`는 두 개의 환경별 `starter`로 분리되었습니다.
+> **Bad Practice (do not use):**
+> * `com.ids.keycloak:servlet:1.0.0` (X) -> Can be confused with other libraries (e.g., Jakarta Servlet)
+> * `com.ids.keycloak:core:1.0.0` (X) -> Not identifiable
 
 ---
 
-## 3. Package Structure Strategy (패키지 구조)
+## 2. Module Structure & Responsibility
 
-패키지명은 **`com.ids.keycloak.security`** 를 Root로 하며, **계층(Layer)** 이 아닌 **기능(Feature)** 단위로 구성합니다.
+We adopt a **Multi-Module** strategy, with each module's responsibility strictly separated.
 
-### 📂 Common Pattern
+### Core Module (`...-core`)
+* **Role:** The heart of the business logic. Pure Java code with no dependency on Spring Web/Servlet/Reactive.
+* **Key Features:** Token parsing, verification, authority mapping, domain models.
+* **Constraint:** Importing `javax.servlet` or `org.springframework.web` packages is prohibited.
+
+### Servlet Module (`...-servlet`)
+* **Role:** Supports Blocking I/O based Spring MVC applications.
+* **Dependencies:** `core`, `spring-security-web`, `jakarta.servlet-api`
+* **Key Features:** `OncePerRequestFilter`, `AuthenticationProvider`, `AbstractHttpConfigurer`.
+
+### Reactive Module (`...-reactive`)
+* **Role:** Supports Non-blocking I/O based Spring WebFlux applications.
+* **Dependencies:** `core`, `spring-security-webflux`, `reactor-core`
+* **Key Features:** `ReactiveAuthenticationManager`, `ServerAuthenticationConverter`.
+
+### Starter Modules (`...-servlet-starter`, `...-reactive-starter`)
+* **Role:** Environment-specific entry points that let users adopt the library's functionality by adding a single dependency matching their own environment.
+* **Structure:**
+    * **`servlet-starter`:** Contains the `servlet` implementation module and its auto-configuration logic. Used in Servlet-based Spring MVC environments.
+    * **`reactive-starter`:** Contains the `reactive` implementation module and its auto-configuration logic. Used in Reactive-based Spring WebFlux environments.
+* **Note:** The former unified `starter` has been split into two environment-specific `starter` modules.
+
+---
+
+## 3. Package Structure Strategy
+
+The package name is rooted at **`com.ids.keycloak.security`**, and is organized by **feature**, not by **layer**.
+
+### Common Pattern
 ```text
 com.ids.keycloak.security
-  ├── config          // 설정 지원 (Configurer, Customizer)
-  ├── authentication  // 인증 처리 (Provider, Manager, Token)
-  ├── authorization   // 인가 처리 (Provider, Manager)
-  ├── filter          // (Servlet only) 필터 체인 관련
-  ├── web             // (Reactive only) 웹 교환 처리
-  ├── exception       // 예외 처리
-  └── util            // 유틸리티
+  ├── config          // Configuration support (Configurer, Customizer)
+  ├── authentication  // Authentication handling (Provider, Manager, Token)
+  ├── authorization   // Authorization handling (Provider, Manager)
+  ├── filter          // (Servlet only) Filter chain related
+  ├── web             // (Reactive only) Web exchange handling
+  ├── exception       // Exception handling
+  └── util            // Utilities
 ```
 
-### 📂 Core Module Detail
+### Core Module Detail
 ```text
 ├── token           // TokenVerifier, TokenParser
 ├── authority       // GrantedAuthoritiesMapper
@@ -93,42 +95,42 @@ com.ids.keycloak.security
 
 ---
 
-## 4. Development Principles (개발 원칙)
+## 4. Development Principles
 
-오픈소스 라이브러리로서 **확장성**을 최우선으로 고려합니다.
+As an open-source library, **extensibility** is our top priority.
 
-### ✅ Extension Points (확장성)
-1.  **`@ConditionalOnMissingBean` 활용:**
-   * Starter의 모든 Bean 등록에는 이 어노테이션을 붙여, 사용자가 재정의(Override)할 수 있는 구멍을 열어둡니다.
-2.  **Customizer 패턴:**
-   * 설정 클래스는 `Customizer<T>`를 인자로 받아, 사용자가 람다식으로 설정을 추가할 수 있게 합니다.
-3.  **상속 허용:**
-   * 보안상 필수적인 경우를 제외하고는 `final` 클래스 사용을 지양합니다.
+### Extension Points
+1.  **Use `@ConditionalOnMissingBean`:**
+   * Every Bean registration in a Starter carries this annotation, leaving room for users to override it.
+2.  **Customizer Pattern:**
+   * Configuration classes take a `Customizer<T>` argument, letting users add settings via lambda expressions.
+3.  **Allow Inheritance:**
+   * Avoid `final` classes except where required for security reasons.
 
-### 📝 Coding Convention
+### Coding Convention
 1.  **Logging:**
-   * `System.out.println` 절대 금지.
-   * `slf4j` 인터페이스 사용 (`@Slf4j` 권장).
+   * `System.out.println` is strictly forbidden.
+   * Use the `slf4j` interface (`@Slf4j` recommended).
 2.  **Exception:**
-   * Checked Exception 지양, `RuntimeException` 기반의 커스텀 예외(`KeycloakSecurityException`) 사용.
+   * Avoid checked exceptions; use custom `RuntimeException`-based exceptions (`KeycloakSecurityException`) instead.
 
 ---
 
-## 5. Configuration Strategy (설정 및 확장 전략) 
+## 5. Configuration Strategy
 
-사용자에게 편의성과 제어권을 동시에 제공하며, **환경별 Starter를 통해 명시적인 의존성 관리**를 유도하는 전략을 사용합니다.
+We aim to give users both convenience and control, while encouraging **explicit dependency management via environment-specific Starters**.
 
-### 🔹 Strategy A: Explicit Environment Selection (환경별 스타터 선택)
-사용자는 자신의 애플리케이션 환경(Spring MVC 또는 WebFlux)을 명확히 인지하고, 그에 맞는 `starter` 의존성 하나를 직접 선택하여 추가해야 합니다. 이를 통해 불필요한 `reactive` 또는 `servlet` 의존성이 프로젝트에 포함되는 것을 방지합니다.
+### Strategy A: Explicit Environment Selection
+Users must clearly recognize their application's environment (Spring MVC or WebFlux) and explicitly select and add the matching `starter` dependency. This prevents unnecessary `reactive` or `servlet` dependencies from ending up in the project.
  
-* **Mechanism:** Gradle/Maven 의존성 관리
+* **Mechanism:** Gradle/Maven dependency management
 * **Implementation:**
-    * **Servlet 환경:** 사용자는 `keycloak-spring-security-servlet-starter` 의존성을 추가합니다.
-    * **Reactive 환경:** 사용자는 `keycloak-spring-security-reactive-starter` 의존성을 추가합니다.
+    * **Servlet environment:** Add the `keycloak-spring-security-servlet-starter` dependency.
+    * **Reactive environment:** Add the `keycloak-spring-security-reactive-starter` dependency.
 
-### 🔹 Strategy B: Zero-Configuration (Auto Config)
-초기 설정 없이 동작하도록 기본 `SecurityFilterChain`을 제공합니다.
-단, 사용자의 커스텀 설정을 방해하지 않기 위해 **반드시 `@ConditionalOnMissingBean`을 사용**합니다.
+### Strategy B: Zero-Configuration (Auto Config)
+Provides a default `SecurityFilterChain` that works out of the box without any initial setup.
+However, it **always uses `@ConditionalOnMissingBean`** so as not to interfere with a user's custom configuration.
 
 ```java
 // Servlet AutoConfiguration Example
@@ -138,8 +140,8 @@ public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) {
     return http.with(KeycloakHttpConfigurer.keycloak(), Customizer.withDefaults()).build();
 }
 ```
-### 🔹 Strategy C: Modular Configuration (Configurer Pattern)
-사용자가 직접 설정을 구성할 때를 대비해, 내부 로직을 캡슐화한 Configurer를 제공합니다.
+### Strategy C: Modular Configuration (Configurer Pattern)
+Provides a Configurer that encapsulates the internal logic, for cases where users want to build their own configuration.
 
 ```java
 // User Usage Example
@@ -148,7 +150,7 @@ public SecurityFilterChain filterChain(HttpSecurity http) {
     return http
         .authorizeHttpRequests(...) 
         .addFilterBefore(new MyCustomFilter(), ...) 
-        .with(KeycloakHttpConfigurer.keycloak(), Customizer.withDefaults()) // 한 줄로 기능 적용
+        .with(KeycloakHttpConfigurer.keycloak(), Customizer.withDefaults()) // Apply the feature in a single line
         .build();
 }
 
@@ -159,11 +161,11 @@ public SecurityFilterChain filterChain(HttpSecurity http) {
 ## 6. Build Configuration (Gradle)
 
 * **Build Tool:** Gradle
-* **Java Version:** JDK 17 이상
+* **Java Version:** JDK 17 or higher
 * **Supported Versions:**
     *   Spring Boot 3.5.9 (Stable)
     *   Spring Security 6.5.7 (Stable)
-* **Usage:** 사용자는 환경 구분 없이 아래 의존성 하나만 사용합니다.
+* **Usage:** Users only need a single dependency below, regardless of their environment.
 
 ```build.gradle
 // for MVC and Servlet environment
@@ -175,83 +177,83 @@ implementation("com.ids.keycloak:keycloak-spring-security-webflux-starter:1.0.0"
 
 ---
 
-## 7. Feature Toggle Configuration (기능별 설정 가이드)
+## 7. Feature Toggle Configuration
 
-모든 기능은 `keycloak.security.*` 네임스페이스의 yaml 설정으로 제어됩니다.
+Every feature is controlled via yaml configuration under the `keycloak.security.*` namespace.
 
-### 🔹 CSRF Protection
+### CSRF Protection
 
-CSRF(Cross-Site Request Forgery) 보호 설정입니다. 기본값은 **활성화(true)** 이며, 로그아웃 및 토큰 발급 엔드포인트는 자동으로 면제됩니다.
+CSRF (Cross-Site Request Forgery) protection settings. The default is **enabled (true)**, and the logout and token issuance endpoints are automatically exempted.
 
 ```yaml
 keycloak:
   security:
     csrf:
-      enabled: true                     # 기본값: true (CSRF 보호 활성화)
-      ignore-paths:                     # 추가 CSRF 면제 경로 (Ant 패턴)
+      enabled: true                     # Default: true (CSRF protection enabled)
+      ignore-paths:                     # Additional CSRF-exempt paths (Ant pattern)
         - /api/**
         - /webhook/**
 ```
 
-| 속성 | 타입 | 기본값 | 설명 |
+| Property | Type | Default | Description |
 |------|------|--------|------|
-| `enabled` | boolean | `true` | CSRF 보호 활성화 여부. `false` 시 완전 비활성화 |
-| `ignore-paths` | List&lt;String&gt; | `[]` | 추가 CSRF 면제 경로. Ant 패턴 지원 (`/api/**` 등) |
+| `enabled` | boolean | `true` | Whether CSRF protection is enabled. Fully disabled when `false` |
+| `ignore-paths` | List&lt;String&gt; | `[]` | Additional CSRF-exempt paths. Supports Ant patterns (e.g., `/api/**`) |
 
-**기본 면제 경로 (하드코딩):**
-- `/logout` (Front-Channel 로그아웃)
-- `/logout/connect/back-channel/**` (Back-Channel 로그아웃)
-- Bearer Token 활성화 시: `/auth/token`, `/auth/refresh`, `/auth/logout`
+**Default exempt paths (hardcoded):**
+- `/logout` (Front-Channel logout)
+- `/logout/connect/back-channel/**` (Back-Channel logout)
+- When Bearer Token is enabled: `/auth/token`, `/auth/refresh`, `/auth/logout`
 
-**Basic Auth와 CSRF (보안 경고):**
-`basic-auth.enabled: true`로 설정해도 `Authorization: Basic` 헤더 보유만으로 CSRF가 자동 면제되지 **않습니다**. HTTP Basic 자격증명은 브라우저가 origin 단위로 캐시해 이후 요청(공격자의 cross-origin 폼 제출 포함)에 자동 재전송할 수 있는 ambient credential이라, 헤더 존재를 "비-브라우저 요청"의 증거로 삼을 수 없기 때문입니다(CWE-352). Basic Auth는 브라우저가 개입하지 않는 머신 클라이언트(curl, 서버-to-서버 호출 등) 전용으로 사용하고, CSRF 면제가 필요한 경로는 반드시 `ignore-paths`에 명시적으로 등록하세요.
+**Basic Auth and CSRF (security warning):**
+Even when `basic-auth.enabled: true` is set, simply presenting an `Authorization: Basic` header does **not** automatically exempt a request from CSRF. HTTP Basic credentials are an ambient credential — browsers cache them per origin and will automatically resend them on subsequent requests, including a cross-origin form submission from an attacker — so the mere presence of the header cannot be treated as proof of a "non-browser request" (CWE-352). Reserve Basic Auth for machine clients where no browser is involved (curl, server-to-server calls, etc.), and explicitly register any path that needs a CSRF exemption in `ignore-paths`.
 
-### 🔹 Basic Authentication
+### Basic Authentication
 
 ```yaml
 keycloak:
   security:
     basic-auth:
-      enabled: false                    # 기본값: false (opt-in)
+      enabled: false                    # Default: false (opt-in)
 ```
 
-### 🔹 Bearer Token
+### Bearer Token
 
 ```yaml
 keycloak:
   security:
     bearer-token:
-      enabled: false                    # 기본값: false (opt-in)
+      enabled: false                    # Default: false (opt-in)
       token-endpoint:
-        prefix: /auth                   # 기본값: /auth
+        prefix: /auth                   # Default: /auth
 ```
 
-### 🔹 Rate Limiting
+### Rate Limiting
 
 ```yaml
 keycloak:
   security:
     rate-limit:
-      enabled: false                    # 기본값: false (opt-in)
-      max-requests: 5                   # 시간 윈도우 내 최대 요청 수
-      window-seconds: 60               # 시간 윈도우 (초)
-      block-duration-seconds: 300      # 차단 지속 시간 (초)
+      enabled: false                    # Default: false (opt-in)
+      max-requests: 5                   # Max requests allowed within the time window
+      window-seconds: 60               # Time window (seconds)
+      block-duration-seconds: 300      # Block duration (seconds)
       key-strategy: IP_AND_USERNAME    # IP, USERNAME, IP_AND_USERNAME
-      include-basic-auth: true         # Basic Auth에도 적용
-      max-tracked-keys: 100000         # 인메모리 카운터 맵 최대 추적 키 수(카디널리티 공격 방지, 초과 시 fail-closed)
+      include-basic-auth: true         # Also applies to Basic Auth
+      max-tracked-keys: 100000         # Max number of tracked keys in the in-memory counter map (prevents cardinality attacks; fails closed when exceeded)
 ```
 
-클라이언트 IP는 `ClientIpResolver`가 `trusted-proxy-count`(신뢰 프록시 수, 기본 `0`)를 기준으로 판정하므로, 리버스 프록시 뒤에서는 `keycloak.security.trusted-proxy-count`를 프록시 수에 맞게 설정해야 `X-Forwarded-For` 스푸핑으로 rate limit이 우회되지 않습니다.
+The client IP is determined by `ClientIpResolver` based on `trusted-proxy-count` (the number of trusted proxies, default `0`). Behind a reverse proxy, you must set `keycloak.security.trusted-proxy-count` to match the number of proxies in front of the app, or rate limiting can be bypassed via `X-Forwarded-For` spoofing.
 
-### 🔹 Role 매핑 (Realm/Client 역할 네임스페이스)
+### Role Mapping (Realm/Client Role Namespace)
 
 ```yaml
 keycloak:
   security:
     role-mapping:
-      mode: SEPARATE_NAMESPACE          # 기본값. REALM_ONLY / CLIENT_ONLY / LEGACY_MERGED
-      realm-role-prefix: ROLE_REALM_    # mode=SEPARATE_NAMESPACE일 때 Realm 역할 접두사
-      client-role-prefix: ROLE_CLIENT_  # mode=SEPARATE_NAMESPACE일 때 Client 역할 접두사
+      mode: SEPARATE_NAMESPACE          # Default. REALM_ONLY / CLIENT_ONLY / LEGACY_MERGED
+      realm-role-prefix: ROLE_REALM_    # Realm role prefix when mode=SEPARATE_NAMESPACE
+      client-role-prefix: ROLE_CLIENT_  # Client role prefix when mode=SEPARATE_NAMESPACE
 ```
 
-**보안 경고(Breaking):** 과거에는 `realm_access.roles`와 `resource_access.{clientId}.roles`가 모두 동일한 `ROLE_<이름>` 권한으로 병합되어, 동명의 realm 역할과 client 역할을 구분할 수 없었습니다(CWE-863 — realm 역할 보유자가 client 전용 `hasRole(...)` 검사를 의도치 않게 통과 가능). 기본값이 realm/client 역할을 서로 다른 접두사(`ROLE_REALM_*`/`ROLE_CLIENT_<CLIENT>_*`)로 분리하는 `SEPARATE_NAMESPACE`로 바뀌었으므로, 기존 `hasRole(...)`/`hasAuthority(...)` 참조를 새 권한 문자열에 맞게 갱신하세요. 과도기적으로만 과거 동작이 필요하면 `mode: LEGACY_MERGED`(비권장, CWE-863 재노출)를 명시 설정할 수 있습니다.
+**Security warning (Breaking):** Previously, `realm_access.roles` and `resource_access.{clientId}.roles` were both merged into the same `ROLE_<name>` authority, making it impossible to distinguish between a realm role and a client role that share the same name (CWE-863 — a holder of a realm role could unintentionally pass a client-only `hasRole(...)` check). The default has been changed to `SEPARATE_NAMESPACE`, which separates realm and client roles with distinct prefixes (`ROLE_REALM_*`/`ROLE_CLIENT_<CLIENT>_*`), so update any existing `hasRole(...)`/`hasAuthority(...)` references to match the new authority strings. If you need the previous behavior purely as a transitional measure, you can explicitly set `mode: LEGACY_MERGED` (not recommended, re-exposes CWE-863).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | 버전 | 지원 | 비고 |
 |------|------|------|
-| **2.0.0+** | ✅ **권장** | 보안 전수 검토 8건 반영(Advisory 1/2/3/5/6/7/8). 프로덕션 권장 |
+| **2.0.1+** | ✅ **권장** | 외부 보안 검토 4건 반영(High/Medium/Low). OIDC Access/ID Token subject 직접 비교, WebFlux CSRF 안전 메서드 예외, Front-Channel `/logout` CSRF 우회 차단 등. 프로덕션 권장 |
+| 2.0.0 | ⚠️ 업그레이드 권고 | 외부 검토 4건(High #1/Medium #3/Medium #4/Low #1~#4) 미반영 (아래 "과거 보안 수정" 참고) |
 | 1.10.2 | ⚠️ 업그레이드 권고 | Advisory 1/2/3/5/6/7/8 미반영 — OIDC 토큰 결합 검증, 세션 고정 방지, CSRF 전면 면제 제거 등 (아래 "과거 보안 수정" 참고) |
 | 1.10.1 | ⚠️ 업그레이드 권고 | [#54](https://github.com/L-DXD/keycloak-spring-security/issues/54)(백채널 로그아웃 후 500) 미수정, Advisory 1/2/3/5/6/7/8도 미반영 |
 | 1.10.0 | ⚠️ 업그레이드 권고 | #52 / #54 미수정, Advisory 1/2/3/5/6/7/8도 미반영 |
@@ -17,6 +18,7 @@
 
 | 버전 | 내용 | 심각도 |
 |------|------|--------|
+| **2.0.1** | OIDC Access Token subject를 ID Token subject와 직접 비교해 UserInfo 조회 실패 시 서로 다른 사용자 토큰 결합 차단(외부 검토 High #1, Opaque Access Token은 잔여 한계 — `require-user-info` 권장), WebFlux CSRF 매처 안전 메서드 예외 누락 수정(Medium #3), 브라우저 Front-Channel `/logout` 강제 로그아웃 CSRF 우회 차단(Medium #4, CWE-352), Bearer prefix 검증·인증 검증 순서 정렬·로그 정리·subject 마스킹(Low #1~#4) — 외부 보안 검토 4건 | Mixed |
 | **2.0.0** | OIDC ID/Access Token 결합 검증 강화(Advisory 1), 로그인 세션 고정 방지(Advisory 2), Rate Limit IP 판정 일원화(Advisory 2), Basic Auth CSRF 전면 면제 제거(Advisory 3, CWE-352), 백채널 로그아웃 로그 마스킹(Advisory 5), 인메모리 세션 저장소 용량 상한(Advisory 6, CWE-400/CWE-770), Realm/Client Role 네임스페이스 분리(Advisory 7, CWE-863), WebFlux 백채널 decoder 검증 강화(Advisory 8) — 보안 전수 검토 8건 | Mixed |
 | **1.10.2** | webflux 토큰 무효화 후 재발급 실패가 500 (로그인 리다이렉트 대신) — DoS성 (#54) | Medium |
 | **1.10.0** | reactive 백채널 로그아웃 `logout_token` 서명 미검증 → 임의 세션 강제 종료 (CVSS 8.2) | **High** |

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3,7 +3,7 @@
 Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 하나와 최소 설정으로 OIDC 로그인·세션·로그아웃·인가가 자동 구성됩니다.
 
 - **지원**: JDK 17+, Spring Boot 3.5.x, Spring Security 6.5.x
-- **현재 버전**: `2.0.0`
+- **현재 버전**: `2.0.1`
 - **스택**: Servlet(Spring MVC) / **Reactive(WebFlux) — v1.8.0부터 servlet과 기능 동등** ([8. Reactive](#8-reactivewebflux))
 - 이 문서는 **도입 개발자용 사용 가이드**입니다. 아키텍처/기여 규칙은 [README](../README.md) 참고.
 
@@ -27,10 +27,10 @@ Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 
 
 ```gradle
 // Servlet (Spring MVC)
-implementation("io.github.l-dxd:keycloak-spring-security-web-starter:2.0.0")
+implementation("io.github.l-dxd:keycloak-spring-security-web-starter:2.0.1")
 
 // 또는 Reactive (WebFlux)
-implementation("io.github.l-dxd:keycloak-spring-security-webflux-starter:2.0.0")
+implementation("io.github.l-dxd:keycloak-spring-security-webflux-starter:2.0.1")
 ```
 > Redis 세션을 쓸 경우에만 추가:
 > ```gradle
@@ -366,6 +366,7 @@ LoggingValueSanitizer loggingValueSanitizer() {
 
 | 버전 | 변경 | 주의 |
 |------|------|------|
+| **2.0.1** ⚠️ | **외부 보안 검토 4건 대응** — OIDC Access Token subject를 ID Token subject와 직접 비교(High #1), WebFlux CSRF 안전 메서드 예외 누락 수정(Medium #3), 브라우저 Front-Channel `/logout` CSRF 우회 차단(Medium #4), Bearer prefix 검증·검증 순서 정렬·로그 정리·subject 마스킹(Low #1~#4) | **Breaking 1건** — 아래 [마이그레이션](#마이그레이션-201--외부-보안-검토-4건-breaking) |
 | **2.0.0** ⚠️ | **보안 강화 8건** — OIDC ID/Access Token 결합 검증(Advisory 1), 로그인 세션 고정 방지(Advisory 2), Rate Limit IP 판정 일원화(Advisory 2), Basic Auth CSRF 전면 면제 제거(Advisory 3), 백채널 로그아웃 로그 마스킹(Advisory 5), 인메모리 세션 저장소 용량 상한(Advisory 6), Realm/Client Role 네임스페이스 분리(Advisory 7), WebFlux 백채널 decoder 검증 강화(Advisory 8) | **Breaking 3건** — 아래 [마이그레이션](#마이그레이션-200--보안-강화-8건-breaking) |
 | **1.10.2** | (버그픽스 #54) webflux 토큰 무효화(백채널 로그아웃 등) 후 보호 경로 접근 시 refresh 재발급 실패가 500 나던 문제 → 미인증 처리로 EntryPoint(로그인 리다이렉트/401) 경유 | breaking 없음 |
 | **1.10.1** | (버그픽스 #52) webflux/servlet AJAX 판정 통일 — 브라우저 `Accept: */*`를 JSON으로 오판하던 문제 수정(`ajax-returns-json=true` 시 브라우저 리다이렉트 정상화) | breaking 없음 |
@@ -378,6 +379,24 @@ LoggingValueSanitizer loggingValueSanitizer() {
 | **1.4.x** | Bearer/Basic 인가 지원, stateless 세션 분리 | — |
 
 상세: `docs/12`, `docs/13`, `docs/14`
+
+### 마이그레이션 (2.0.1 — 외부 보안 검토 4건, breaking)
+외부 보안 검토(High #1/Medium #3/Medium #4/Low #1~#4) 반영으로 **API 변경 1건**이 있습니다. 나머지는 회귀 없는 보안 강화입니다.
+
+| # | 변경 | 영향 | 해제/대응 |
+|---|------|------|-----------|
+| 1 | Servlet OIDC 인증용 `JwtDecoder` 빈의 `@ConditionalOnMissingBean` 조건이 타입(`JwtDecoder.class`) 기반에서 빈 이름(`keycloakOidcJwtDecoder`) 기반으로 변경(webflux `keycloakOidcReactiveJwtDecoder`와 동일 패턴 정렬) | 이 decoder를 커스텀 빈으로 재정의(override)하던 코드가 빈 이름 불일치로 더 이상 대체되지 않음(라이브러리 기본 decoder와 사용자 decoder가 동시에 등록되어 `NoUniqueBeanDefinitionException`으로 기동 실패 가능) | 재정의 빈 이름을 `keycloakOidcJwtDecoder`로 맞출 것. 별도 resource-server용 JWT decoder가 필요하면 다른 이름을 쓰고 소비 지점에서 `@Qualifier`로 명시 구분 |
+
+**주의 (breaking은 아니지만 확인 필요) — Opaque Access Token + `require-user-info`**: 이번 버전은 Access Token이 구조적으로 JWT인 경우에 한해 `sub`를 ID Token과 직접 비교합니다(외부 검토 High #1). **Opaque(불투명) Access Token은 로컬에서 `sub`를 파싱할 수 없어 이 직접 비교의 보호를 받지 못하며**, 여전히 UserInfo 엔드포인트 조회 성공 시의 `sub` 일치 검증에만 의존합니다. Opaque Access Token을 발급하는 Keycloak 클라이언트를 쓴다면 다음을 반드시 켜세요.
+```yaml
+keycloak:
+  security:
+    authentication:
+      require-user-info: true   # UserInfo 조회 실패를 인증 실패로 승격(기본 false)
+```
+`require-user-info=false`(기본값)이면서 Opaque Access Token을 쓰는 환경은, UserInfo 조회가 실패(장애·타임아웃)했을 때 서로 다른 사용자의 Access Token과 ID Token이 조합되어도 인증이 성립할 수 있는 잔여 위험이 남습니다.
+
+그 외(회귀 없음): WebFlux CSRF 매처 안전 메서드(GET/HEAD/OPTIONS/TRACE) 예외 처리 정상화(Medium #3, 과거 CSRF 활성화 시 안전 메서드까지 403이 나던 문제 수정이라 오히려 허용 범위가 넓어짐), 브라우저 Front-Channel `/logout` CSRF 보호 강화(Medium #4 — Bearer 활성 시에만 `/logout`이 CSRF 면제되던 것을 제거, 정상적인 CSRF 토큰을 포함한 로그아웃 요청은 영향 없음), Bearer prefix 기동 시 검증(Low #1, 공백/`"/"` prefix를 쓰던 비정상 설정만 영향), webflux 토큰 결합 검증 순서 정렬·로그 정리·예외 메시지 마스킹(Low #2~#4).
 
 ### 마이그레이션 (2.0.0 — 보안 강화 8건, breaking)
 보안 검토(Advisory 1/2/3/5/6/7/8) 반영으로 **기본 동작 2가지가 변경**되고, **수동 배선(auto-filter-chain 미사용) 사용자에 한해** API 변경이 하나 있습니다.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version Management
-projectVersion=2.0.0
+projectVersion=2.0.1
 
 # Maven Publishing Info
 mavenGroupId=io.github.l-dxd

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakBearerTokenProperties.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakBearerTokenProperties.java
@@ -36,4 +36,18 @@ public class KeycloakBearerTokenProperties {
      */
     @NestedConfigurationProperty
     private TokenEndpointProperties tokenEndpoint = new TokenEndpointProperties();
+
+    /**
+     * 기동 시 검증입니다. Bearer Token이 비활성({@link #enabled} = {@code false})이면
+     * {@link TokenEndpointProperties}의 {@code prefix}는 CSRF 면제 경로 계산에 쓰이지 않으므로
+     * 검증을 생략합니다.
+     *
+     * @throws IllegalStateException {@link TokenEndpointProperties#validate()} 참고
+     */
+    public void validate() {
+        if (!enabled) {
+            return;
+        }
+        tokenEndpoint.validate();
+    }
 }

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakSecurityProperties.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/KeycloakSecurityProperties.java
@@ -158,10 +158,15 @@ public class KeycloakSecurityProperties implements InitializingBean {
      * 오설정으로 인한 Advisory 7(CWE-863) 재현을 막기 위해 {@link #roleMapping}의 접두사 조합을
      * 검증하고, 위반 시 기동을 즉시 실패시킵니다.
      *
-     * @throws IllegalStateException {@link KeycloakRoleMappingProperties#validate()} 참고
+     * <p>또한 Bearer Token(Medium #4, CWE-352) 오설정으로 인한 CSRF 면제 무력화를 막기 위해
+     * {@link #bearerToken}의 토큰 발급 엔드포인트 {@code prefix}도 함께 검증합니다.</p>
+     *
+     * @throws IllegalStateException {@link KeycloakRoleMappingProperties#validate()},
+     *     {@link KeycloakBearerTokenProperties#validate()} 참고
      */
     @Override
     public void afterPropertiesSet() {
         roleMapping.validate();
+        bearerToken.validate();
     }
 }

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/TokenEndpointProperties.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/config/TokenEndpointProperties.java
@@ -33,4 +33,37 @@ public class TokenEndpointProperties {
      * </p>
      */
     private String prefix = "/auth";
+
+    /**
+     * 오설정으로 인한 Medium #4(CWE-352) 재현을 막기 위한 기동 시 검증입니다.
+     *
+     * <p>Bearer Token 전용 로그아웃 경로는 {@code prefix + "/logout"}로 계산되어 CSRF 면제
+     * 목록에 추가됩니다. 이때 {@code prefix}가 공백이거나 {@code "/"}이면 계산된 경로가 브라우저
+     * Front-Channel 로그아웃 경로({@code /logout})와 같아지거나(빈 문자열) 컨테이너의 중복 슬래시
+     * 정규화로 인해 사실상 같은 경로로 취급되어("/" + "/logout" = "//logout"), 브라우저 폼 기반
+     * {@code /logout}까지 CSRF 검증 없이 호출 가능해집니다 — 즉 Medium #4로 막았던 강제
+     * 로그아웃 CSRF(CWE-352)가 다시 열립니다. 이를 조용히 허용하지 않고 기동 실패로 즉시
+     * 드러냅니다.</p>
+     *
+     * @throws IllegalStateException prefix가 공백이거나, {@code "/"}로 시작하지 않거나, {@code "/"} 그
+     *     자체인 경우
+     */
+    public void validate() {
+        if (prefix == null || prefix.isBlank()) {
+            throw new IllegalStateException(
+                "keycloak.security.bearer-token.token-endpoint.prefix: 공백일 수 없습니다 (prefix="
+                    + prefix + "). prefix가 공백이면 Bearer 전용 로그아웃 경로(prefix + \"/logout\")가 "
+                    + "브라우저 Front-Channel 로그아웃 경로(\"/logout\")와 동일해져, 브라우저 폼 기반 "
+                    + "/logout까지 CSRF 검증 없이 호출 가능해집니다(Medium #4 무력화, CWE-352).");
+        }
+
+        if (!prefix.startsWith("/") || prefix.equals("/")) {
+            throw new IllegalStateException(
+                "keycloak.security.bearer-token.token-endpoint.prefix: \"/\"로 시작하되 \"/\" 그 "
+                    + "자체는 아니어야 합니다 (prefix=\"" + prefix + "\"). prefix가 \"/\"이면 Bearer "
+                    + "전용 로그아웃 경로가 \"//logout\"이 되어, 컨테이너/프록시의 중복 슬래시 정규화에 "
+                    + "따라 브라우저 Front-Channel 로그아웃 경로(\"/logout\")와 사실상 동일하게 취급될 "
+                    + "수 있습니다(Medium #4 무력화, CWE-352).");
+        }
+    }
 }

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/exception/TokenBindingException.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/exception/TokenBindingException.java
@@ -10,6 +10,7 @@ package com.ids.keycloak.security.exception;
  *   <li>ID Token의 {@code sub}와 UserInfo의 {@code sub}가 불일치</li>
  *   <li>ID Token의 {@code aud}에 client-id가 없음</li>
  *   <li>{@code azp} 클레임이 있는데 client-id와 불일치 (ID Token/Access Token 공통)</li>
+ *   <li>(2.0.1 패치) JWT Access Token의 {@code sub}와 ID Token의 {@code sub}가 불일치</li>
  * </ul>
  * 이 예외는 {@link AuthenticationFailedException} 등과 마찬가지로 {@link KeycloakSecurityException}을
  * 상속하는 unchecked 예외이며, Refresh Token 재시도 대상이 아닙니다(재발급으로 해소되지 않는

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/util/TokenBindingValidator.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/util/TokenBindingValidator.java
@@ -104,14 +104,16 @@ public class TokenBindingValidator {
      * @param accessToken    서명 검증이 완료된 Access Token {@link Jwt} (JWT 형식일 때만 호출)
      * @param idTokenSubject 서명 검증이 완료된 ID Token에서 추출한 subject
      * @throws TokenBindingException Access Token의 subject가 ID Token의 subject와 다를 경우(둘 중
-     *     하나라도 null이어서 비교 불가한 경우 포함)
+     *     하나라도 null이어서 비교 불가한 경우 포함). 예외 메시지의 subject는 {@link LogMaskingUtil}로
+     *     마스킹되어 노출됩니다(원문 UUID가 warn 로그로 그대로 남지 않도록, Low #4).
      */
     public static void validateAccessTokenSubject(Jwt accessToken, String idTokenSubject) {
         String accessTokenSubject = accessToken.getSubject();
         if (accessTokenSubject == null || !accessTokenSubject.equals(idTokenSubject)) {
             throw new TokenBindingException(
-                "Access Token의 subject(" + accessTokenSubject + ")가 ID Token의 subject("
-                    + idTokenSubject + ")와 일치하지 않습니다.");
+                "Access Token의 subject(" + LogMaskingUtil.maskIdentifier(accessTokenSubject)
+                    + ")가 ID Token의 subject(" + LogMaskingUtil.maskIdentifier(idTokenSubject)
+                    + ")와 일치하지 않습니다.");
         }
     }
 
@@ -149,7 +151,9 @@ public class TokenBindingValidator {
      *
      * @param idTokenSubject  서명 검증이 완료된 ID Token에서 추출한 subject
      * @param userInfoSubject UserInfo 응답의 subject (조회 실패/미사용 시 {@code null})
-     * @throws TokenBindingException 두 subject가 다를 경우
+     * @throws TokenBindingException 두 subject가 다를 경우. 예외 메시지의 subject는
+     *     {@link LogMaskingUtil}로 마스킹되어 노출됩니다(원문 UUID가 warn 로그로 그대로 남지 않도록,
+     *     Low #4).
      */
     public static void validateSubjectBinding(String idTokenSubject, String userInfoSubject) {
         if (userInfoSubject == null) {
@@ -157,7 +161,8 @@ public class TokenBindingValidator {
         }
         if (!userInfoSubject.equals(idTokenSubject)) {
             throw new TokenBindingException(
-                "ID Token의 subject(" + idTokenSubject + ")와 UserInfo의 subject(" + userInfoSubject
+                "ID Token의 subject(" + LogMaskingUtil.maskIdentifier(idTokenSubject)
+                    + ")와 UserInfo의 subject(" + LogMaskingUtil.maskIdentifier(userInfoSubject)
                     + ")가 일치하지 않습니다.");
         }
     }

--- a/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/util/TokenBindingValidator.java
+++ b/keycloak-spring-security-core/src/main/java/com/ids/keycloak/security/util/TokenBindingValidator.java
@@ -24,6 +24,14 @@ import org.springframework.security.oauth2.jwt.Jwt;
  * 포함하지 않는 경우가 흔합니다(예: {@code aud=["account"]}). 따라서 Access Token에는 {@code aud}
  * 포함 여부를 강제하지 않고, {@code azp}(있는 경우에 한해)만 검증합니다. ID Token은 OIDC Core 스펙상
  * {@code aud}에 client-id가 항상 포함되어야 하므로 이 클래스에서 엄격히 강제합니다.</p>
+ *
+ * <p><b>보안 패치 2.0.1(외부 검토 High #1) 대응 배경:</b> Advisory 1 도입 당시에는 Access Token에
+ * 대해 {@code azp}만 검증하고 {@code sub}는 UserInfo를 통해서만 간접 확인했습니다({@link
+ * #validateSubjectBinding}). 그런데 {@code require-user-info=false}(기본값)이고 UserInfo 조회가
+ * 실패하면 이 간접 sub 검증 자체가 스킵되어, 같은 Client에 발급된 서로 다른 사용자의 ID Token과
+ * Access Token 조합(Principal=A, 토큰=B)이 azp 일치만으로 통과할 수 있었습니다. 이를 막기 위해
+ * {@link #validateAccessTokenSubject}를 추가해 JWT Access Token의 {@code sub}를 ID Token의
+ * {@code sub}와 UserInfo 가용성과 무관하게 직접 비교합니다.</p>
  */
 @UtilityClass
 public class TokenBindingValidator {
@@ -59,6 +67,9 @@ public class TokenBindingValidator {
      * Keycloak Access Token은 Audience 매퍼 설정에 따라 {@code aud}에 client-id를 포함하지 않는 경우가
      * 흔하므로 {@code aud} 포함 여부는 강제하지 않습니다.
      *
+     * <p>이 메서드는 Client 결합(azp)만 검증합니다. 사용자 결합(sub)은 {@link #validateAccessTokenSubject}로
+     * 별도 검증해야 하며, 호출부는 이 메서드에 이어서 반드시 함께 호출해야 합니다(2.0.1 패치).</p>
+     *
      * @param accessToken 서명 검증이 완료된 Access Token {@link Jwt} (JWT 형식일 때만 호출)
      * @param clientId    이 애플리케이션의 OIDC client-id
      * @throws TokenBindingException azp가 있는데 client-id와 불일치할 시
@@ -68,6 +79,40 @@ public class TokenBindingValidator {
             return;
         }
         validateAzp(accessToken, clientId, "Access Token");
+    }
+
+    /**
+     * JWT 형식인 Access Token의 {@code sub}가 ID Token의 {@code sub}와 동일한지 직접 비교합니다.
+     *
+     * <p><b>보안 패치 2.0.1(외부 검토 High #1) 대응:</b> 기존에는 Access Token에 대해 {@code azp}만
+     * 검증하고 {@code sub}는 UserInfo 조회 결과를 통해서만 간접 확인했습니다({@link
+     * #validateSubjectBinding}). {@code require-user-info=false}(기본값)에서 UserInfo 조회가 실패하면
+     * 그 간접 검증 자체가 스킵되어, 사용자 A의 ID Token과 같은 Client에서 발급된 사용자 B의 Access Token
+     * 조합이 azp 일치만으로 인증을 통과할 수 있었습니다(Principal=A, 토큰=B 혼동). 이 메서드는 UserInfo
+     * 가용성과 무관하게 Access Token 자체의 서명 검증된 {@code sub} 클레임을 ID Token의 {@code sub}와
+     * 직접 비교하여 이 경로를 차단합니다.</p>
+     *
+     * <p><b>호출 순서:</b> {@link #validateAccessTokenAzp}로 Client 결합(azp)을 검증한 직후 이 메서드로
+     * 사용자 결합(sub)을 검증해야 합니다(둘 다 Access Token이 구조적으로 JWT일 때만 호출).</p>
+     *
+     * <p><b>Opaque Access Token의 한계:</b> Access Token이 Opaque(비-JWT) 형식이면 로컬에서 {@code sub}를
+     * 확인할 방법이 없습니다(Keycloak Introspect 응답이 {@code active} 여부만 노출하는 라이브러리 제약).
+     * 이 경우 호출부({@code JwtUtil.isStructurallyJwt}로 분기)가 이 메서드를 호출하지 않으며, 기존 정책
+     * (UserInfo 200 응답 + {@link #validateSubjectBinding})으로만 보호됩니다 — 회귀 없음. 이 한계를
+     * 제거하려면 Keycloak Access Token을 JWT 형식으로 발급하도록 구성해야 합니다.</p>
+     *
+     * @param accessToken    서명 검증이 완료된 Access Token {@link Jwt} (JWT 형식일 때만 호출)
+     * @param idTokenSubject 서명 검증이 완료된 ID Token에서 추출한 subject
+     * @throws TokenBindingException Access Token의 subject가 ID Token의 subject와 다를 경우(둘 중
+     *     하나라도 null이어서 비교 불가한 경우 포함)
+     */
+    public static void validateAccessTokenSubject(Jwt accessToken, String idTokenSubject) {
+        String accessTokenSubject = accessToken.getSubject();
+        if (accessTokenSubject == null || !accessTokenSubject.equals(idTokenSubject)) {
+            throw new TokenBindingException(
+                "Access Token의 subject(" + accessTokenSubject + ")가 ID Token의 subject("
+                    + idTokenSubject + ")와 일치하지 않습니다.");
+        }
     }
 
     private static void validateAzp(Jwt token, String clientId, String tokenLabel) {

--- a/keycloak-spring-security-core/src/test/java/com/ids/keycloak/security/util/TokenBindingValidatorTest.java
+++ b/keycloak-spring-security-core/src/test/java/com/ids/keycloak/security/util/TokenBindingValidatorTest.java
@@ -114,6 +114,50 @@ class TokenBindingValidatorTest {
     }
 
     @Nested
+    class validateAccessTokenSubject_테스트 {
+
+        // 2.0.1 패치(외부 검토 High #1): JWT Access Token의 sub를 ID Token의 sub와
+        // UserInfo 가용성과 무관하게 직접 비교한다. validateAccessTokenAzp와 대칭 구조.
+
+        @Test
+        void AT_sub와_ID_sub가_동일하면_성공한다() {
+            Jwt accessToken = buildJwt("user-1", List.of("account"), CLIENT_ID);
+
+            assertThatCode(() -> TokenBindingValidator.validateAccessTokenSubject(accessToken, "user-1"))
+                .doesNotThrowAnyException();
+        }
+
+        @Test
+        void AT_sub와_ID_sub가_다르면_TokenBindingException이_발생한다() {
+            // A의 ID Token(sub=user-A) + B의 Access Token(sub=user-B) 조합
+            Jwt accessToken = buildJwt("user-B", List.of("account"), CLIENT_ID);
+
+            assertThatThrownBy(() -> TokenBindingValidator.validateAccessTokenSubject(accessToken, "user-A"))
+                .isInstanceOf(TokenBindingException.class)
+                .hasMessageContaining("subject");
+        }
+
+        @Test
+        void AT_sub가_null이면_TokenBindingException이_발생한다() {
+            Jwt accessToken = buildJwt(null, List.of("account"), CLIENT_ID);
+
+            assertThatThrownBy(() -> TokenBindingValidator.validateAccessTokenSubject(accessToken, "user-1"))
+                .isInstanceOf(TokenBindingException.class)
+                .hasMessageContaining("subject");
+        }
+
+        @Test
+        void ID_sub가_null이면_TokenBindingException이_발생한다() {
+            // ID Token subject를 알 수 없는 상황(방어적 케이스) — 비교 불가로 간주해 차단
+            Jwt accessToken = buildJwt("user-1", List.of("account"), CLIENT_ID);
+
+            assertThatThrownBy(() -> TokenBindingValidator.validateAccessTokenSubject(accessToken, null))
+                .isInstanceOf(TokenBindingException.class)
+                .hasMessageContaining("subject");
+        }
+    }
+
+    @Nested
     class validateSubjectBinding_테스트 {
 
         @Test

--- a/keycloak-spring-security-web-starter/build.gradle
+++ b/keycloak-spring-security-web-starter/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     // N-3 round-trip 테스트: Redis 직렬화 검증용 (테스트 전용, production 산출물에 전이되지 않음)
     testImplementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.session:spring-session-data-redis'
+
+    // ApplicationContextRunner (Servlet OIDC JwtDecoder AutoConfiguration 통합 테스트용)
+    testImplementation 'org.springframework.boot:spring-boot-test'
 }
 
 signing {

--- a/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/KeycloakServletAutoConfiguration.java
+++ b/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/KeycloakServletAutoConfiguration.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -227,11 +228,21 @@ public class KeycloakServletAutoConfiguration {
          * 조회하므로, 애플리케이션 기동 시점에 Keycloak이 아직 기동되지 않았어도 컨텍스트 초기화가
          * 실패하지 않습니다.</p>
          *
-         * <p>사용자가 직접 {@link JwtDecoder} 빈을 등록하면 이 빈은 생략됩니다.</p>
+         * <p><b>High #2 대응 (webflux {@code keycloakOidcReactiveJwtDecoder}와 동일 패턴 정렬):</b>
+         * 조건을 {@code JwtDecoder.class} 타입이 아니라 이 빈의 <b>이름</b>({@code keycloakOidcJwtDecoder})
+         * 기반으로 좁힙니다. 과거에는 타입 기반 {@code @ConditionalOnMissingBean(JwtDecoder.class)}였는데,
+         * 애플리케이션이 다른 issuer/resource-server용 {@link JwtDecoder} 빈을 이미 가지고 있으면 이 전용
+         * decoder가 아예 생성되지 않거나(다른 decoder로 조용히 대체), 두 빈이 동시에 존재할 경우
+         * {@code NoUniqueBeanDefinitionException}으로 기동 자체가 실패할 수 있었습니다. 이 decoder를
+         * 소비하는 {@link #authenticationManager}도 타입이 아닌 {@code @Qualifier("keycloakOidcJwtDecoder")}로
+         * 명시 주입받습니다.</p>
+         *
+         * <p>사용자가 같은 이름({@code keycloakOidcJwtDecoder})의 {@link JwtDecoder} 빈을 직접 등록하면
+         * 이 빈은 생략됩니다.</p>
          */
-        @Bean
-        @ConditionalOnMissingBean(JwtDecoder.class)
-        public JwtDecoder keycloakJwtDecoder(
+        @Bean("keycloakOidcJwtDecoder")
+        @ConditionalOnMissingBean(name = "keycloakOidcJwtDecoder")
+        public JwtDecoder keycloakOidcJwtDecoder(
             KeycloakInfrastructureConfiguration.KeycloakConfig keycloakConfig,
             KeycloakSecurityProperties securityProperties,
             @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri:"
@@ -257,7 +268,7 @@ public class KeycloakServletAutoConfiguration {
             KeycloakClient keycloakClient,
             KeycloakInfrastructureConfiguration.KeycloakConfig keycloakConfig,
             KeycloakSecurityProperties securityProperties,
-            JwtDecoder jwtDecoder
+            @Qualifier("keycloakOidcJwtDecoder") JwtDecoder jwtDecoder
         ) {
             List<AuthenticationProvider> providers = new ArrayList<>();
 

--- a/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/KeycloakOidcJwtDecoderAutoConfigurationIntegrationTest.java
+++ b/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/KeycloakOidcJwtDecoderAutoConfigurationIntegrationTest.java
@@ -1,0 +1,229 @@
+package com.ids.keycloak.security.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+
+import com.ids.keycloak.security.authentication.KeycloakAuthenticationProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * {@link KeycloakServletAutoConfiguration.KeycloakAuthenticationConfiguration}의
+ * 보안 High #2 대응(name 기반 조건 + {@code @Qualifier} 배선)을 {@link ApplicationContextRunner}로
+ * 검증하는 통합 테스트입니다.
+ *
+ * <p>{@code KeycloakBackChannelAutoConfigurationIntegrationTest}(webflux)와 동일한 패턴으로,
+ * 전체 {@code KeycloakServletAutoConfiguration}(OAuth2 client/web security 등 무관한 필수 프로퍼티가
+ * 많은 설정)이 아닌 인증(Authentication) 전용 nested {@code @Configuration}
+ * ({@code KeycloakInfrastructureConfiguration} + {@code KeycloakAuthenticationConfiguration})만
+ * 좁혀 등록합니다.</p>
+ */
+class KeycloakOidcJwtDecoderAutoConfigurationIntegrationTest {
+
+  private static final String REALM_NAME = "test-realm";
+  private static final String BASE_URL = "http://keycloak.local";
+  private static final String RELATIVE_PATH = "";
+  private static final String CLIENT_ID = "test-client";
+  private static final String REDIRECT_URI = "{baseUrl}/login/oauth2/code/keycloak";
+  private static final String LOGOUT_REDIRECT_URI = "http://localhost:8080";
+  private static final String RESPONSE_TYPE = "code";
+  private static final String CLIENT_SECRET = "test-secret";
+
+  /**
+   * {@code KeycloakSecurityProperties}({@code @ConfigurationProperties})를 활성화하기 위한 지원 설정.
+   * {@code SessionConfigurationTest}의 {@code PropertyConfig}와 동일한 패턴.
+   */
+  @Configuration
+  @EnableConfigurationProperties(KeycloakSecurityProperties.class)
+  static class PropertiesConfig {
+  }
+
+  private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+      .withUserConfiguration(PropertiesConfig.class)
+      .withConfiguration(AutoConfigurations.of(
+          KeycloakServletAutoConfiguration.KeycloakInfrastructureConfiguration.class,
+          KeycloakServletAutoConfiguration.KeycloakAuthenticationConfiguration.class))
+      .withPropertyValues(
+          "keycloak.realm-name=" + REALM_NAME,
+          "keycloak.base-url=" + BASE_URL,
+          "keycloak.relative-path=" + RELATIVE_PATH,
+          "keycloak.logout.redirect.uri=" + LOGOUT_REDIRECT_URI,
+          "keycloak.response.type=" + RESPONSE_TYPE,
+          "spring.security.oauth2.client.registration.keycloak.client-id=" + CLIENT_ID,
+          "spring.security.oauth2.client.registration.keycloak.redirect-uri=" + REDIRECT_URI,
+          "spring.security.oauth2.client.registration.keycloak.client-secret=" + CLIENT_SECRET);
+
+  /**
+   * {@code authenticationManager}({@link ProviderManager})가 실제로 배선한 {@link JwtDecoder}를
+   * {@link KeycloakAuthenticationProvider}의 {@code jwtDecoder} 필드에서 꺼내옵니다.
+   * {@code authenticationManager}가 바로 "이 decoder를 조립하는 지점"입니다.
+   */
+  private static JwtDecoder wiredOidcDecoder(AssertableApplicationContext context) {
+    ProviderManager authenticationManager = (ProviderManager) context.getBean("authenticationManager");
+    KeycloakAuthenticationProvider provider = authenticationManager.getProviders().stream()
+        .filter(KeycloakAuthenticationProvider.class::isInstance)
+        .map(KeycloakAuthenticationProvider.class::cast)
+        .findFirst()
+        .orElseThrow(() -> new AssertionError(
+            "authenticationManager에 KeycloakAuthenticationProvider가 등록되어 있지 않습니다."));
+    return (JwtDecoder) ReflectionTestUtils.getField(provider, "jwtDecoder");
+  }
+
+  // ==========================================================================
+  // 무관 JwtDecoder 빈 공존 (name 기반 조건, 회귀 방지 CWE-347/863)
+  // ==========================================================================
+
+  @Nested
+  @DisplayName("무관한 JwtDecoder 빈이 있어도 keycloakOidcJwtDecoder는 대체되지 않는다")
+  class 무관_Decoder_대체_방지 {
+
+    @Configuration
+    static class UnrelatedResourceServerDecoderConfig {
+      @Bean
+      public JwtDecoder resourceServerJwtDecoder() {
+        // 리소스서버용 등 무관한 decoder — 이름이 keycloakOidcJwtDecoder가 아니므로
+        // 타입 기반 @ConditionalOnMissingBean(JwtDecoder.class)이었다면 우리 decoder가 생성되지
+        // 않거나(조용히 대체), 두 빈이 동시에 존재해 NoUniqueBeanDefinitionException으로 기동
+        // 자체가 실패했을 시나리오
+        return mock(JwtDecoder.class);
+      }
+    }
+
+    @Test
+    @DisplayName("keycloakOidcJwtDecoder가 여전히 생성되고, authenticationManager는 그것만 주입받는다")
+    void 무관_decoder_공존시_oidc_decoder_유지_및_authenticationManager_배선() {
+      contextRunner
+          .withUserConfiguration(UnrelatedResourceServerDecoderConfig.class)
+          .run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasBean("keycloakOidcJwtDecoder");
+            assertThat(context).hasBean("resourceServerJwtDecoder");
+            assertThat(context.getBeansOfType(JwtDecoder.class)).hasSize(2);
+            // 타입 기반 조건이었다면 여기서 NoUniqueBeanDefinitionException으로 기동이 실패했을 것
+            assertThat(context).hasSingleBean(AuthenticationManager.class);
+
+            JwtDecoder wiredDecoder = wiredOidcDecoder(context);
+
+            assertThat(wiredDecoder)
+                .isSameAs(context.getBean("keycloakOidcJwtDecoder", JwtDecoder.class));
+            assertThat(wiredDecoder)
+                .isNotSameAs(context.getBean("resourceServerJwtDecoder", JwtDecoder.class));
+          });
+    }
+  }
+
+  @Nested
+  @DisplayName("여러 JwtDecoder(OIDC용 + 앱 decoder)가 공존해도 정확히 keycloakOidcJwtDecoder만 주입된다")
+  class 다중_Decoder_공존 {
+
+    @Configuration
+    static class MultipleUnrelatedDecodersConfig {
+      @Bean
+      public JwtDecoder appJwtDecoder() {
+        // 애플리케이션이 별도로 등록한 decoder (예: 리소스서버용)
+        return mock(JwtDecoder.class);
+      }
+
+      @Bean
+      public JwtDecoder anotherAppJwtDecoder() {
+        // 또 다른 무관한 decoder
+        return mock(JwtDecoder.class);
+      }
+    }
+
+    @Test
+    @DisplayName("총 3개의 JwtDecoder 빈이 공존하고, authenticationManager는 keycloakOidcJwtDecoder만 주입받는다")
+    void 다중_decoder_공존시_정확히_oidc_decoder_주입() {
+      contextRunner
+          .withUserConfiguration(MultipleUnrelatedDecodersConfig.class)
+          .run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context.getBeansOfType(JwtDecoder.class)).hasSize(3);
+
+            JwtDecoder wiredDecoder = wiredOidcDecoder(context);
+
+            assertThat(wiredDecoder)
+                .isSameAs(context.getBean("keycloakOidcJwtDecoder", JwtDecoder.class));
+            assertThat(wiredDecoder)
+                .isNotSameAs(context.getBean("appJwtDecoder", JwtDecoder.class));
+            assertThat(wiredDecoder)
+                .isNotSameAs(context.getBean("anotherAppJwtDecoder", JwtDecoder.class));
+          });
+    }
+  }
+
+  // ==========================================================================
+  // 이름 재정의 — 사용자가 keycloakOidcJwtDecoder 이름으로 직접 등록
+  // ==========================================================================
+
+  @Nested
+  @DisplayName("사용자가 keycloakOidcJwtDecoder 이름으로 빈을 등록하면 라이브러리 기본 빈은 생략된다")
+  class 이름_재정의 {
+
+    @Configuration
+    static class CustomOidcDecoderConfig {
+      @Bean("keycloakOidcJwtDecoder")
+      public JwtDecoder keycloakOidcJwtDecoder() {
+        return mock(JwtDecoder.class);
+      }
+    }
+
+    @Test
+    @DisplayName("keycloakOidcJwtDecoder 빈이 사용자 정의로 대체되고, authenticationManager는 사용자 빈을 주입받는다")
+    void 이름_재정의시_사용자_빈_사용_및_배선() {
+      contextRunner
+          .withUserConfiguration(CustomOidcDecoderConfig.class)
+          .run(context -> {
+            assertThat(context).hasNotFailed();
+            // 이름이 같으므로 딱 하나만 존재 — 라이브러리 기본 빈(NimbusJwtDecoder)이 아니라
+            // 사용자가 등록한 mock이어야 한다 (@ConditionalOnMissingBean(name=...)이 정상 작동)
+            assertThat(context.getBeansOfType(JwtDecoder.class)).hasSize(1);
+
+            JwtDecoder registeredDecoder = context.getBean("keycloakOidcJwtDecoder", JwtDecoder.class);
+            assertThat(mockingDetails(registeredDecoder).isMock()).isTrue();
+            assertThat(registeredDecoder).isNotInstanceOf(NimbusJwtDecoder.class);
+
+            JwtDecoder wiredDecoder = wiredOidcDecoder(context);
+            assertThat(wiredDecoder).isSameAs(registeredDecoder);
+          });
+    }
+  }
+
+  // ==========================================================================
+  // 기본(단독) 구성 — positive control
+  // ==========================================================================
+
+  @Nested
+  @DisplayName("기본(단독) 구성에서 keycloakOidcJwtDecoder가 정상 생성된다")
+  class 기본_단독_구성 {
+
+    @Test
+    @DisplayName("추가 설정 없이도 keycloakOidcJwtDecoder 빈이 정확히 하나 생성되고 authenticationManager에 주입된다")
+    void 기본_구성시_decoder_정상_생성_및_배선() {
+      contextRunner.run(context -> {
+        assertThat(context).hasNotFailed();
+        assertThat(context).hasSingleBean(JwtDecoder.class);
+        assertThat(context).hasBean("keycloakOidcJwtDecoder");
+
+        JwtDecoder decoder = context.getBean("keycloakOidcJwtDecoder", JwtDecoder.class);
+        assertThat(decoder).isInstanceOf(NimbusJwtDecoder.class);
+
+        JwtDecoder wiredDecoder = wiredOidcDecoder(context);
+        assertThat(wiredDecoder).isSameAs(decoder);
+      });
+    }
+  }
+}

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/authentication/KeycloakAuthenticationProvider.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/authentication/KeycloakAuthenticationProvider.java
@@ -38,7 +38,8 @@ import org.springframework.web.client.RestClientException;
  * <p><b>보안 Advisory 1 대응:</b> ID Token은 {@link JwtDecoder}로 서명 검증을 통과한 뒤에만 Principal
  * 식별자(subject)로 사용하며, ID Token과 Access Token(UserInfo)이 동일 사용자·동일 Client에서
  * 발급되었는지({@link TokenBindingValidator}) 검증합니다. 하나라도 불일치하면
- * {@link TokenBindingException}이 발생해 인증에 실패합니다.</p>
+ * {@link TokenBindingException}이 발생해 인증에 실패합니다. (2.0.1 패치) JWT Access Token은
+ * UserInfo 가용성과 무관하게 subject를 ID Token과 직접 비교합니다.</p>
  */
 @Slf4j
 public class KeycloakAuthenticationProvider implements AuthenticationProvider {
@@ -133,7 +134,8 @@ public class KeycloakAuthenticationProvider implements AuthenticationProvider {
     *   <li>Access Token으로 UserInfo 조회(기존 로직)</li>
     *   <li>ID Token의 aud/azp가 이 애플리케이션의 client-id와 일치하는지 검증</li>
     *   <li>ID Token의 subject와 UserInfo의 subject가 일치하는지 검증</li>
-    *   <li>Access Token이 JWT 형식이면 추가로 디코딩하여 azp를 검증(Opaque면 로컬 결합 검증은 스킵)</li>
+    *   <li>Access Token이 JWT 형식이면 추가로 디코딩하여 azp와 subject(2.0.1 패치, ID Token과 직접
+    *       비교)를 검증(Opaque면 로컬 결합 검증은 스킵)</li>
     * </ol>
     * 하나라도 실패하면 {@link TokenBindingException}이 발생해 인증이 실패합니다(SecurityContext 미생성).</p>
     *
@@ -153,7 +155,7 @@ public class KeycloakAuthenticationProvider implements AuthenticationProvider {
       TokenBindingValidator.validateIdTokenBinding(idToken, clientId);
       TokenBindingValidator.validateSubjectBinding(
           idToken.getSubject(), oidcUserInfo != null ? oidcUserInfo.getSubject() : null);
-      validateAccessTokenIfJwt(accessTokenValue);
+      validateAccessTokenIfJwt(accessTokenValue, idToken.getSubject());
 
       OidcIdToken oidcIdToken = createOidcIdToken(idTokenValue, idToken);
       KeycloakPrincipal principal = createPrincipal(oidcIdToken, oidcUserInfo, idToken.getSubject());
@@ -179,23 +181,34 @@ public class KeycloakAuthenticationProvider implements AuthenticationProvider {
    }
 
    /**
-    * Access Token이 구조적으로 JWT 형식일 때만 추가로 디코딩하여 azp 결합 검증을 수행합니다.
+    * Access Token이 구조적으로 JWT 형식일 때만 추가로 디코딩하여 azp/subject 결합 검증을 수행합니다.
+    *
+    * <p><b>2.0.1 패치(외부 검토 High #1):</b> azp 검증({@link TokenBindingValidator#validateAccessTokenAzp})에
+    * 이어 Access Token의 subject를 ID Token의 subject와 직접 비교합니다
+    * ({@link TokenBindingValidator#validateAccessTokenSubject}). UserInfo 조회 실패
+    * ({@code require-user-info=false})로 {@link TokenBindingValidator#validateSubjectBinding}이
+    * 스킵되더라도, 이 직접 비교로 사용자 A의 ID Token과 사용자 B의 Access Token 조합(Principal=A,
+    * 토큰=B)을 차단합니다.</p>
     *
     * <p><b>알려진 제약(Opaque Access Token):</b> Access Token이 Opaque(비-JWT) 형식이면
-    * Keycloak Introspect 응답이 {@code active} 여부만 노출하므로(라이브러리 제약) 로컬 aud/azp
+    * Keycloak Introspect 응답이 {@code active} 여부만 노출하므로(라이브러리 제약) 로컬 aud/azp/subject
     * 결합 검증을 수행할 수 없습니다. 이 경우 UserInfo 200 응답 + subject 일치 검증으로만 보호됩니다
     * (기존 정책과 동일, 회귀 없음).</p>
     *
-    * @throws TokenBindingException Access Token이 JWT 구조인데 서명/클레임 검증에 실패한 경우
+    * @param accessTokenValue Access Token
+    * @param idTokenSubject   서명 검증이 완료된 ID Token에서 추출한 subject
+    * @throws TokenBindingException Access Token이 JWT 구조인데 서명/클레임 검증에 실패했거나,
+    *     azp/subject 결합 검증에 실패한 경우
     */
-   private void validateAccessTokenIfJwt(String accessTokenValue) {
+   private void validateAccessTokenIfJwt(String accessTokenValue, String idTokenSubject) {
       if (!JwtUtil.isStructurallyJwt(accessTokenValue)) {
-         log.debug("[Provider] Access Token이 JWT 구조가 아님(Opaque 추정) — aud/azp 로컬 결합 검증 스킵.");
+         log.debug("[Provider] Access Token이 JWT 구조가 아님(Opaque 추정) — aud/azp/subject 로컬 결합 검증 스킵.");
          return;
       }
       try {
          Jwt accessToken = jwtDecoder.decode(accessTokenValue);
          TokenBindingValidator.validateAccessTokenAzp(accessToken, clientId);
+         TokenBindingValidator.validateAccessTokenSubject(accessToken, idTokenSubject);
       } catch (JwtException e) {
          log.warn("[Provider] Access Token 서명/클레임 검증 실패: {}", e.getMessage());
          throw new TokenBindingException(

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/config/KeycloakHttpConfigurer.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/config/KeycloakHttpConfigurer.java
@@ -120,7 +120,10 @@ public final class KeycloakHttpConfigurer extends AbstractHttpConfigurer<Keycloa
         // === 1. Authentication Provider 등록 ===
         String clientId = clientRegistrationRepository.findByRegistrationId("keycloak").getClientId();
         // 보안 Advisory 1: ID/Access Token 서명 검증 및 토큰 결합 검증용 JwtDecoder
-        JwtDecoder jwtDecoder = context.getBean(JwtDecoder.class);
+        // High #2: 타입(JwtDecoder.class)이 아닌 keycloakOidcJwtDecoder 빈 이름으로 조회한다.
+        // 애플리케이션이 다른 issuer/resource-server용 JwtDecoder를 등록해도 이 전용 decoder를
+        // 정확히 지목하며, NoUniqueBeanDefinitionException 위험도 없앤다.
+        JwtDecoder jwtDecoder = context.getBean("keycloakOidcJwtDecoder", JwtDecoder.class);
         KeycloakAuthenticationProvider provider =
             new KeycloakAuthenticationProvider(keycloakClient, clientId, jwtDecoder);
         // M-2: require-user-info 토글 적용 (기본 false = 기존 동작 유지, 회귀 0)

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/config/KeycloakHttpConfigurer.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/config/KeycloakHttpConfigurer.java
@@ -205,8 +205,8 @@ public final class KeycloakHttpConfigurer extends AbstractHttpConfigurer<Keycloa
 
           // Bearer Token 경로 면제:
           //   /token, /refresh — 비인증 자격증명 제출 엔드포인트이므로 항상 면제
-          //   /logout          — Bearer Token 활성 시에만 면제
-          //                      (쿠키 기반 OIDC 전용 환경에서는 /logout에 CSRF 보호 유지)
+          //   /logout(prefix)  — Bearer Token 전용 로그아웃 API. Bearer 토큰으로만 호출되므로
+          //                      (브라우저 폼 세션과 무관) Bearer Token 활성 시 면제
           if (bearerTokenProperties.isEnabled()) {
               String prefix = bearerTokenProperties.getTokenEndpoint().getPrefix();
               ignorePaths.add(prefix + "/token");
@@ -214,16 +214,13 @@ public final class KeycloakHttpConfigurer extends AbstractHttpConfigurer<Keycloa
               ignorePaths.add(prefix + "/logout");
           }
 
-          // Front-Channel 로그아웃(/logout):
-          //   Bearer Token 비활성(쿠키 기반 OIDC 전용)인 경우 CSRF 보호 유지.
-          //   Bearer Token 활성인 경우 위에서 이미 추가됨.
-          if (!bearerTokenProperties.isEnabled()) {
-              // OIDC 로그아웃은 브라우저 폼 POST → CSRF 보호 적용 (면제 목록에서 제외)
-              log.debug("Bearer Token 비활성 — /logout CSRF 보호 활성화 (면제 목록에서 제외)");
-          } else {
-              // Bearer Token 활성 시 /logout은 위에서 이미 추가했으므로 추가 처리 불필요
-              ignorePaths.add(LOGOUT_URL);
-          }
+          // 보안 Medium #4: 브라우저 Front-Channel 로그아웃(LOGOUT_URL, 기본 "/logout")은
+          // Bearer Token 전용 로그아웃(prefix + "/logout")과 별개의 엔드포인트이며, 항상
+          // CSRF 보호를 유지한다(Bearer Token 활성 여부와 무관). 이 경로는 브라우저 쿠키 기반
+          // OIDC 세션을 종료하는 폼 POST 엔드포인트이므로, 여기를 CSRF 면제 목록에 포함시키면
+          // 공격 사이트가 크로스사이트 POST로 로그인된 사용자를 강제 로그아웃시킬 수 있다
+          // (CSRF, CWE-352). 따라서 어떤 조건에서도 LOGOUT_URL을 ignorePaths에 추가하지 않는다.
+          log.debug("/logout(LOGOUT_URL) CSRF 보호 항상 활성화 (Bearer Token 활성 여부와 무관, 면제 목록에서 제외)");
 
           // 사용자 지정 면제 경로 추가
           ignorePaths.addAll(csrfProperties.getIgnorePaths());

--- a/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/filter/KeycloakAuthenticationFilter.java
+++ b/keycloak-spring-security-web/src/main/java/com/ids/keycloak/security/filter/KeycloakAuthenticationFilter.java
@@ -8,6 +8,7 @@ import com.ids.keycloak.security.exception.AuthenticationFailedException;
 import com.ids.keycloak.security.ratelimit.AuthenticationEventLogger;
 import com.ids.keycloak.security.exception.IntrospectionFailedException;
 import com.ids.keycloak.security.exception.RefreshTokenException;
+import com.ids.keycloak.security.exception.TokenBindingException;
 import com.ids.keycloak.security.exception.UserInfoFetchException;
 import com.ids.keycloak.security.model.KeycloakPrincipal;
 import com.ids.keycloak.security.session.KeycloakSessionManager;
@@ -217,6 +218,16 @@ public class KeycloakAuthenticationFilter extends OncePerRequestFilter {
             AuthenticationEventLogger.logSuccess(
                 AuthenticationEventLogger.METHOD_OIDC_COOKIE, getClientIp(request), successfulAuthentication.getName());
 
+        } catch (TokenBindingException e) {
+            // ID Token/Access Token 결합 검증 실패는 오설정·재발급으로 해소되지 않는 예상된 인증
+            // 실패 사유이므로(Advisory 1), generic catch(Exception)의 "예상치 못한 오류"
+            // 스택트레이스 로깅 대신 원인 메시지만 warn으로 남긴다(로그 노이즈 정리).
+            SecurityContextHolder.clearContext();
+            log.warn("[Filter] 결합 검증 실패로 인증 실패: {}", e.getMessage());
+            AuthenticationEventLogger.logFailure(
+                AuthenticationEventLogger.METHOD_OIDC_COOKIE, getClientIp(request), "unknown", e.getMessage());
+            CookieUtil.deleteAllTokenCookies(response);
+            sessionManager.invalidateSession(request.getSession());
         } catch (AuthenticationException e) {
             SecurityContextHolder.clearContext();
             log.warn("[Filter] Keycloak 인증에 실패했습니다: {}", e.getMessage());

--- a/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/authentication/KeycloakAuthenticationProviderTest.java
+++ b/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/authentication/KeycloakAuthenticationProviderTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.ids.keycloak.security.exception.ConfigurationException;
@@ -12,6 +14,12 @@ import com.ids.keycloak.security.exception.IntrospectionFailedException;
 import com.ids.keycloak.security.exception.TokenBindingException;
 import com.ids.keycloak.security.exception.UserInfoFetchException;
 import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.auth.KeycloakIntrospectResponse;
 import com.sd.KeycloakClient.dto.user.KeycloakUserInfo;
@@ -98,6 +106,26 @@ class KeycloakAuthenticationProviderTest {
             builder.claim("azp", azp);
         }
         return builder.build();
+    }
+
+    /**
+     * {@code JwtUtil.isStructurallyJwt()}가 {@code true}를 반환하도록 실제로 서명된(점 2개 포함,
+     * header.payload.signature 구조) JWT 문자열을 생성합니다.
+     *
+     * <p>이 문자열 자체의 서명/클레임은 이 테스트에서 신뢰되지 않습니다 — {@link #jwtDecoder}가 mock이므로
+     * 실제 검증은 {@code when(jwtDecoder.decode(...))} 스텁으로 대체됩니다. 오직 "구조적으로 JWT인가"만
+     * 확인하는 {@code JwtUtil.isStructurallyJwt()} 분기를 통과시키기 위한 픽스처입니다(2.0.1 패치:
+     * Opaque Access Token과 구분해야 subject 직접 비교 로직이 호출됨).</p>
+     */
+    private String buildStructuralJwtAccessToken() {
+        try {
+            JWTClaimsSet claims = new JWTClaimsSet.Builder().subject("fixture-subject").build();
+            SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claims);
+            signedJWT.sign(new MACSigner("0123456789abcdef0123456789abcdef"));
+            return signedJWT.serialize();
+        } catch (JOSEException e) {
+            throw new IllegalStateException("테스트 픽스처 JWT 서명 생성에 실패했습니다.", e);
+        }
     }
 
     private void stubIntrospectSuccess(String idToken) {
@@ -306,6 +334,84 @@ class KeycloakAuthenticationProviderTest {
             assertThatThrownBy(() ->
                 provider.authenticate(buildAuthRequest(ID_TOKEN_VAL, ACCESS_TOKEN_VAL, USER_SUB)))
                 .isInstanceOf(TokenBindingException.class);
+        }
+    }
+
+    /**
+     * 2.0.1 패치(외부 검토 High #1) 핵심 회귀 방지 테스트.
+     *
+     * <p>패치 이전에는 Access Token에 대해 azp만 검증하고 sub는 UserInfo를 통해서만 간접 확인했습니다.
+     * {@code require-user-info=false}(기본값)에서 UserInfo 조회가 실패하면 이 간접 sub 검증 자체가
+     * 스킵되어, 사용자 A의 ID Token과 같은 Client에서 발급된 사용자 B의 JWT Access Token 조합이
+     * azp 일치만으로 인증을 통과할 수 있었습니다. 이 클래스는 그 회귀가 재발하지 않는지 검증합니다.</p>
+     */
+    @Nested
+    class Access_Token_Subject_직접_검증_2_0_1_패치 {
+
+        private String jwtAccessTokenVal;
+
+        @BeforeEach
+        void setUp() {
+            stubIntrospectSuccess(ID_TOKEN_VAL);
+            jwtAccessTokenVal = buildStructuralJwtAccessToken();
+            when(jwtDecoder.decode(ID_TOKEN_VAL))
+                .thenReturn(buildJwt(ID_TOKEN_VAL, USER_SUB, List.of(CLIENT_ID), CLIENT_ID));
+        }
+
+        @Test
+        void requireUserInfo_false_UserInfo_실패_JWT_AT_sub_불일치시_TokenBindingException으로_인증에_실패한다() {
+            // require-user-info=false(기본값)에서 UserInfo 조회가 401로 실패하면 UserInfo 기반
+            // validateSubjectBinding은 스킵된다. 그러나 Access Token이 JWT 구조이고 sub가 ID Token과
+            // 다르면(OTHER_USER_SUB != USER_SUB) validateAccessTokenSubject가 이를 직접 차단해야 한다.
+            @SuppressWarnings("unchecked")
+            KeycloakResponse<KeycloakUserInfo> userInfoResponse = mock(KeycloakResponse.class);
+            lenient().when(userInfoResponse.getStatus()).thenReturn(401);
+            when(keycloakClient.user().getUserInfo(jwtAccessTokenVal)).thenReturn(userInfoResponse);
+
+            when(jwtDecoder.decode(jwtAccessTokenVal))
+                .thenReturn(buildJwt(jwtAccessTokenVal, OTHER_USER_SUB, List.of(CLIENT_ID), CLIENT_ID));
+
+            // 예외가 발생하므로 authenticate()가 Authentication을 반환하지 않고,
+            // 호출부(Filter)도 SecurityContext를 세팅하지 않는다(SecurityContext 미생성 보장).
+            assertThatThrownBy(() ->
+                provider.authenticate(buildAuthRequest(ID_TOKEN_VAL, jwtAccessTokenVal, USER_SUB)))
+                .isInstanceOf(TokenBindingException.class)
+                .hasMessageContaining("subject");
+        }
+
+        @Test
+        void Opaque_Access_Token은_UserInfo_실패해도_sub_직접_검증을_스킵하고_기존_정책대로_인증에_성공한다_회귀없음() {
+            // Opaque(비-JWT) Access Token은 JwtUtil.isStructurallyJwt()가 false이므로
+            // jwtDecoder.decode(accessToken)가 호출되지 않아야 하고, 기존 정책
+            // (require-user-info=false → UserInfo 실패 시 빈 권한으로 인증 성공)이 그대로 유지되어야 한다.
+            String opaqueAccessTokenVal = "opaque-access-token-no-dots";
+
+            @SuppressWarnings("unchecked")
+            KeycloakResponse<KeycloakUserInfo> userInfoResponse = mock(KeycloakResponse.class);
+            lenient().when(userInfoResponse.getStatus()).thenReturn(401);
+            when(keycloakClient.user().getUserInfo(opaqueAccessTokenVal)).thenReturn(userInfoResponse);
+
+            Authentication result =
+                provider.authenticate(buildAuthRequest(ID_TOKEN_VAL, opaqueAccessTokenVal, USER_SUB));
+
+            assertThat(result.isAuthenticated()).isTrue();
+            assertThat(result.getAuthorities()).isEmpty();
+            verify(jwtDecoder, never()).decode(opaqueAccessTokenVal);
+        }
+
+        @Test
+        void Refresh_경로_createAuthenticatedToken_직접_호출에서도_JWT_AT_sub_불일치시_TokenBindingException이_발생한다() {
+            // Refresh Token 재발급 후 Filter가 직접 호출하는 진입점(createAuthenticatedToken)도
+            // 동일한 검증을 우회할 수 없어야 한다. UserInfo의 subject는 ID Token과 일치시켜
+            // (기존 validateSubjectBinding 통과) 실패 원인이 오직 새 direct sub 비교임을 격리한다.
+            stubUserInfoSuccess(jwtAccessTokenVal, USER_SUB);
+            when(jwtDecoder.decode(jwtAccessTokenVal))
+                .thenReturn(buildJwt(jwtAccessTokenVal, OTHER_USER_SUB, List.of(CLIENT_ID), CLIENT_ID));
+
+            assertThatThrownBy(() ->
+                provider.createAuthenticatedToken(ID_TOKEN_VAL, jwtAccessTokenVal))
+                .isInstanceOf(TokenBindingException.class)
+                .hasMessageContaining("subject");
         }
     }
 

--- a/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/config/KeycloakHttpConfigurerCsrfTest.java
+++ b/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/config/KeycloakHttpConfigurerCsrfTest.java
@@ -145,7 +145,7 @@ class KeycloakHttpConfigurerCsrfTest {
     when(context.getBean(KeycloakLogoutHandler.class)).thenReturn(keycloakLogoutHandler);
     when(context.getBean(OidcClientInitiatedLogoutSuccessHandler.class)).thenReturn(oidcLogoutSuccessHandler);
     when(context.getBean(KeycloakSessionManager.class)).thenReturn(sessionManager);
-    when(context.getBean(JwtDecoder.class)).thenReturn(jwtDecoder);
+    when(context.getBean("keycloakOidcJwtDecoder", JwtDecoder.class)).thenReturn(jwtDecoder);
     when(context.getBean(KeycloakSecurityProperties.class)).thenReturn(props);
     when(context.getBean(KeycloakAuthenticationEntryPoint.class)).thenReturn(entryPoint);
     when(context.getBean(KeycloakAccessDeniedHandler.class)).thenReturn(accessDeniedHandler);

--- a/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/config/KeycloakHttpConfigurerCsrfTest.java
+++ b/keycloak-spring-security-web/src/test/java/com/ids/keycloak/security/config/KeycloakHttpConfigurerCsrfTest.java
@@ -42,6 +42,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.session.FindByIndexNameSessionRepository;
@@ -58,8 +59,15 @@ import org.springframework.session.Session;
  * 요청을 직접 흘려보내며 검증한다 — matcher/ignore 경로 로직을 테스트에 복제하지 않는다.</p>
  *
  * <p>webflux 모듈의 {@code CsrfExemptMatcherTest}와 동일한 시나리오를 검증해 servlet/webflux
- * 동등성을 확인한다 (보안 Advisory 3: {@code Authorization: Basic} 헤더는 더 이상 CSRF 면제
- * 사유가 아니다).</p>
+ * 동등성을 확인한다:
+ * <ul>
+ *   <li><b>보안 Advisory 3:</b> {@code Authorization: Basic} 헤더는 더 이상 CSRF 면제
+ *   사유가 아니다.</li>
+ *   <li><b>보안 Medium 4:</b> 브라우저 Front-Channel 로그아웃({@code /logout})은 Bearer Token
+ *   전용 로그아웃(prefix + {@code /logout})과 별개 엔드포인트이며, Bearer Token 활성 여부와
+ *   무관하게 항상 CSRF 보호를 유지해야 한다(CWE-352 — 강제 로그아웃 CSRF 방지).</li>
+ * </ul>
+ * </p>
  */
 class KeycloakHttpConfigurerCsrfTest {
 
@@ -151,6 +159,9 @@ class KeycloakHttpConfigurerCsrfTest {
     when(context.getBean(KeycloakAccessDeniedHandler.class)).thenReturn(accessDeniedHandler);
     when(context.getBean(LoggingContextAccessor.class)).thenReturn(new WebMdcContextAccessor());
     when(context.getBean(LoggingValueSanitizer.class)).thenReturn(new DefaultPiiMaskingSanitizer());
+    // Bearer Token 활성화 시 KeycloakHttpConfigurer#init이 OpaqueTokenIntrospector 빈을 조회한다
+    // (bearer-token.enabled=false인 시나리오에서는 조회되지 않으므로 stub만 등록해 두어도 무해하다).
+    when(context.getBean(OpaqueTokenIntrospector.class)).thenReturn(mock(OpaqueTokenIntrospector.class));
     // AuthorizeHttpRequestsConfigurer가 MVC 존재 여부/선택적 빈 존재 여부를 확인하기 위해 호출한다
     // (MVC·선택적 빈 미사용 환경으로 취급).
     when(context.getBeanNamesForType(any(Class.class))).thenReturn(new String[0]);
@@ -301,6 +312,75 @@ class KeycloakHttpConfigurerCsrfTest {
 
       assertThat(reached).isFalse();
       assertThat(response.getStatus()).isEqualTo(403);
+    }
+  }
+
+  // ==========================================================================
+  // 보안 Medium #4: 브라우저 Front-Channel 로그아웃(/logout)은 Bearer Token 활성 여부와
+  // 무관하게 항상 CSRF 보호를 유지한다. Bearer Token 전용 로그아웃(prefix + "/logout")과는
+  // 별개의 엔드포인트이며, 과거처럼 Bearer 활성 시 /logout까지 면제하면 공격 사이트가
+  // 크로스사이트 POST로 로그인 사용자를 강제 로그아웃시킬 수 있다(CWE-352).
+  // webflux CsrfExemptMatcherTest.Medium4_브라우저_logout_CSRF_보호_항상_유지 와 동일 시나리오.
+  // ==========================================================================
+
+  @Nested
+  class Medium4_브라우저_logout_CSRF_보호_항상_유지 {
+
+    @Test
+    void bearerToken_비활성시_logout_경로는_CSRF_보호_적용됨() throws Exception {
+      CsrfFilter csrfFilter = buildRealCsrfFilter(baseProperties());
+
+      MockHttpServletRequest request = newRequest("POST", "/logout");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      boolean reached = runThroughRealFilter(csrfFilter, request, response);
+
+      assertThat(reached).isFalse();
+      assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void bearerToken_활성시에도_logout_경로는_CSRF_보호_유지() throws Exception {
+      // 보안 Medium #4 회귀 방지: Bearer Token을 켜도 브라우저 /logout은 면제되면 안 된다.
+      KeycloakSecurityProperties props = baseProperties();
+      props.getBearerToken().setEnabled(true);
+      CsrfFilter csrfFilter = buildRealCsrfFilter(props);
+
+      MockHttpServletRequest request = newRequest("POST", "/logout");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      boolean reached = runThroughRealFilter(csrfFilter, request, response);
+
+      assertThat(reached).isFalse();
+      assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void bearerToken_활성시_전용_logout_엔드포인트는_CSRF_면제() throws Exception {
+      // Bearer 전용 로그아웃(prefix + "/logout")은 브라우저 폼 세션과 무관하므로 계속 면제된다.
+      KeycloakSecurityProperties props = baseProperties();
+      props.getBearerToken().setEnabled(true);
+      CsrfFilter csrfFilter = buildRealCsrfFilter(props);
+
+      String prefix = props.getBearerToken().getTokenEndpoint().getPrefix();
+      MockHttpServletRequest request = newRequest("POST", prefix + "/logout");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      boolean reached = runThroughRealFilter(csrfFilter, request, response);
+
+      assertThat(reached).isTrue();
+    }
+
+    @Test
+    void bearerToken_비활성시_back_channel_경로는_여전히_CSRF_면제() throws Exception {
+      CsrfFilter csrfFilter = buildRealCsrfFilter(baseProperties());
+
+      MockHttpServletRequest request = newRequest("POST", "/logout/connect/back-channel/keycloak");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      boolean reached = runThroughRealFilter(csrfFilter, request, response);
+
+      assertThat(reached).isTrue();
     }
   }
 }

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakReactiveAuthenticationManager.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakReactiveAuthenticationManager.java
@@ -39,7 +39,8 @@ import reactor.core.publisher.Mono;
  * <p><b>보안 Advisory 1 대응:</b> ID Token은 {@link ReactiveJwtDecoder}로 서명 검증을 통과한 뒤에만
  * Principal 식별자(subject)로 사용하며, ID Token과 Access Token(UserInfo)이 동일 사용자·동일 Client에서
  * 발급되었는지({@link TokenBindingValidator}) 검증합니다. 하나라도 불일치하면
- * {@link TokenBindingException}이 발생해 인증에 실패합니다.</p>
+ * {@link TokenBindingException}이 발생해 인증에 실패합니다. (2.0.1 패치) JWT Access Token은
+ * UserInfo 가용성과 무관하게 subject를 ID Token과 직접 비교합니다.</p>
  */
 @Slf4j
 public class KeycloakReactiveAuthenticationManager implements ReactiveAuthenticationManager {
@@ -143,7 +144,8 @@ public class KeycloakReactiveAuthenticationManager implements ReactiveAuthentica
    *   <li>ID Token을 {@link ReactiveJwtDecoder}로 디코딩(서명·iss·exp·nbf 검증) — 실패 시 {@link TokenBindingException}</li>
    *   <li>ID Token의 aud/azp가 이 애플리케이션의 client-id와 일치하는지 검증</li>
    *   <li>ID Token의 subject와 UserInfo의 subject가 일치하는지 검증</li>
-   *   <li>Access Token이 JWT 형식이면 추가로 디코딩하여 azp를 검증(Opaque면 로컬 결합 검증은 스킵)</li>
+   *   <li>Access Token이 JWT 형식이면 추가로 디코딩하여 azp와 subject(2.0.1 패치, ID Token과 직접
+   *       비교)를 검증(Opaque면 로컬 결합 검증은 스킵)</li>
    * </ol>
    * 하나라도 실패하면 반환된 {@link Mono}가 {@link TokenBindingException}으로 에러 신호를 보냅니다.</p>
    *
@@ -155,7 +157,7 @@ public class KeycloakReactiveAuthenticationManager implements ReactiveAuthentica
   public Mono<Authentication> createAuthenticatedToken(
       String idTokenValue, String accessTokenValue, OidcUserInfo oidcUserInfo) {
     return decodeIdToken(idTokenValue)
-        .flatMap(idToken -> validateAccessTokenIfJwt(accessTokenValue)
+        .flatMap(idToken -> validateAccessTokenIfJwt(accessTokenValue, idToken.getSubject())
             .then(Mono.fromCallable(
                 () -> buildAuthenticatedToken(idToken, idTokenValue, accessTokenValue, oidcUserInfo))));
   }
@@ -175,22 +177,36 @@ public class KeycloakReactiveAuthenticationManager implements ReactiveAuthentica
   }
 
   /**
-   * Access Token이 구조적으로 JWT 형식일 때만 추가로 디코딩하여 azp 결합 검증을 수행합니다.
+   * Access Token이 구조적으로 JWT 형식일 때만 추가로 디코딩하여 azp/subject 결합 검증을 수행합니다.
+   *
+   * <p><b>2.0.1 패치(외부 검토 High #1):</b> azp 검증({@link TokenBindingValidator#validateAccessTokenAzp})에
+   * 이어 Access Token의 subject를 ID Token의 subject와 직접 비교합니다
+   * ({@link TokenBindingValidator#validateAccessTokenSubject}). UserInfo 조회 실패
+   * ({@code require-user-info=false})로 {@link TokenBindingValidator#validateSubjectBinding}이
+   * 스킵되더라도, 이 직접 비교로 사용자 A의 ID Token과 사용자 B의 Access Token 조합(Principal=A,
+   * 토큰=B)을 차단합니다.</p>
    *
    * <p><b>알려진 제약(Opaque Access Token):</b> servlet {@code KeycloakAuthenticationProvider}와
-   * 동일하게, Access Token이 Opaque(비-JWT) 형식이면 로컬 aud/azp 결합 검증을 수행할 수 없습니다
+   * 동일하게, Access Token이 Opaque(비-JWT) 형식이면 로컬 aud/azp/subject 결합 검증을 수행할 수 없습니다
    * (Keycloak Introspect 응답이 {@code active} 여부만 노출하는 라이브러리 제약). 이 경우 UserInfo 200
    * 응답 + subject 일치 검증으로만 보호됩니다(기존 정책과 동일, 회귀 없음).</p>
    *
-   * @throws TokenBindingException Access Token이 JWT 구조인데 서명/클레임 검증에 실패한 경우
+   * @param accessTokenValue Access Token
+   * @param idTokenSubject   서명 검증이 완료된 ID Token에서 추출한 subject
+   * @throws TokenBindingException Access Token이 JWT 구조인데 서명/클레임 검증에 실패했거나,
+   *     azp/subject 결합 검증에 실패한 경우
    */
-  private Mono<Void> validateAccessTokenIfJwt(String accessTokenValue) {
+  private Mono<Void> validateAccessTokenIfJwt(String accessTokenValue, String idTokenSubject) {
     if (!JwtUtil.isStructurallyJwt(accessTokenValue)) {
-      log.debug("[ReactiveAuthManager] Access Token이 JWT 구조가 아님(Opaque 추정) — aud/azp 로컬 결합 검증 스킵.");
+      log.debug(
+          "[ReactiveAuthManager] Access Token이 JWT 구조가 아님(Opaque 추정) — aud/azp/subject 로컬 결합 검증 스킵.");
       return Mono.empty();
     }
     return jwtDecoder.decode(accessTokenValue)
-        .doOnNext(accessToken -> TokenBindingValidator.validateAccessTokenAzp(accessToken, clientId))
+        .doOnNext(accessToken -> {
+          TokenBindingValidator.validateAccessTokenAzp(accessToken, clientId);
+          TokenBindingValidator.validateAccessTokenSubject(accessToken, idTokenSubject);
+        })
         .onErrorMap(JwtException.class, e -> {
           log.warn("[ReactiveAuthManager] Access Token 서명/클레임 검증 실패: {}", e.getMessage());
           return new TokenBindingException(

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakReactiveAuthenticationManager.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/authentication/KeycloakReactiveAuthenticationManager.java
@@ -157,9 +157,16 @@ public class KeycloakReactiveAuthenticationManager implements ReactiveAuthentica
   public Mono<Authentication> createAuthenticatedToken(
       String idTokenValue, String accessTokenValue, OidcUserInfo oidcUserInfo) {
     return decodeIdToken(idTokenValue)
-        .flatMap(idToken -> validateAccessTokenIfJwt(accessTokenValue, idToken.getSubject())
-            .then(Mono.fromCallable(
-                () -> buildAuthenticatedToken(idToken, idTokenValue, accessTokenValue, oidcUserInfo))));
+        .flatMap(idToken -> {
+          // servlet KeycloakAuthenticationProvider와 동일한 순서로 정렬(일관성 목적, 보안 정책·결과는
+          // 동일): ID Token 결합 검증 -> Subject 결합 검증 -> Access Token(JWT인 경우) azp/subject 검증.
+          TokenBindingValidator.validateIdTokenBinding(idToken, clientId);
+          TokenBindingValidator.validateSubjectBinding(
+              idToken.getSubject(), oidcUserInfo != null ? oidcUserInfo.getSubject() : null);
+          return validateAccessTokenIfJwt(accessTokenValue, idToken.getSubject())
+              .then(Mono.fromCallable(
+                  () -> buildAuthenticatedToken(idToken, idTokenValue, accessTokenValue, oidcUserInfo)));
+        });
   }
 
   /**
@@ -216,17 +223,11 @@ public class KeycloakReactiveAuthenticationManager implements ReactiveAuthentica
   }
 
   /**
-   * 서명 검증이 완료된 ID Token, UserInfo로부터 최종 인증 객체를 생성합니다.
-   * 토큰 결합 검증(sub/aud/azp)을 수행한 뒤 Principal을 생성합니다.
-   *
-   * @throws TokenBindingException 토큰 결합 검증 실패 시
+   * 서명 검증 및 토큰 결합 검증(sub/aud/azp, {@link #createAuthenticatedToken}에서 선행 수행)이 모두
+   * 끝난 ID Token, UserInfo로부터 최종 인증 객체를 생성합니다.
    */
   private Authentication buildAuthenticatedToken(
       Jwt idToken, String idTokenValue, String accessTokenValue, OidcUserInfo oidcUserInfo) {
-    TokenBindingValidator.validateIdTokenBinding(idToken, clientId);
-    TokenBindingValidator.validateSubjectBinding(
-        idToken.getSubject(), oidcUserInfo != null ? oidcUserInfo.getSubject() : null);
-
     OidcIdToken oidcIdToken = createOidcIdToken(idTokenValue, idToken);
     KeycloakPrincipal principal = createPrincipal(oidcIdToken, oidcUserInfo, idToken.getSubject());
 

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxSecurityConfigurer.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxSecurityConfigurer.java
@@ -239,11 +239,14 @@ public final class KeycloakWebFluxSecurityConfigurer {
    *
    * <p><b>면제 대상:</b>
    * <ul>
-   *   <li>Front-Channel 로그아웃 경로 ({@code /logout})</li>
    *   <li>Back-Channel 로그아웃 경로 — POST+exact 경로 한정 (M-2 보강)</li>
-   *   <li>Bearer Token 엔드포인트 경로</li>
+   *   <li>Bearer Token 엔드포인트 경로 (토큰 발급/갱신, Bearer 전용 로그아웃)</li>
    *   <li>사용자 지정 ignorePaths</li>
    * </ul>
+   * <b>면제 대상 아님(항상 CSRF 보호):</b> 브라우저 Front-Channel 로그아웃 경로
+   * ({@link KeycloakWebFluxConstants#LOGOUT_URL}, 기본 {@code /logout}). Bearer 전용
+   * 로그아웃(prefix + {@code /logout})과는 별개의 엔드포인트이며, Bearer Token 활성 여부와
+   * 무관하게 CSRF 면제 목록에서 제외한다(보안 Medium #4, CWE-352 — 브라우저 강제 로그아웃 방지).
    * </p>
    *
    * <p><b>보안 Advisory 3:</b> {@code Authorization: Basic} 헤더 보유 여부만으로 CSRF를 전면
@@ -273,14 +276,19 @@ public final class KeycloakWebFluxSecurityConfigurer {
       // /token, /refresh — 비인증 자격증명 제출 엔드포인트이므로 항상 면제
       ignorePaths.add(prefix + "/token");
       ignorePaths.add(prefix + "/refresh");
-      // /logout — Bearer Token 활성 시에만 면제
+      // /logout(prefix) — Bearer Token 전용 로그아웃 API. Bearer 토큰으로만 호출되므로
+      // (브라우저 폼 세션과 무관) Bearer Token 활성 시 면제
       ignorePaths.add(prefix + "/logout");
-      // Front-Channel 로그아웃도 Bearer Token 활성 시에만 면제
-      // (쿠키 기반 OIDC 전용 환경에서는 /logout CSRF 보호 유지)
-      ignorePaths.add(KeycloakWebFluxConstants.LOGOUT_URL);
-    } else {
-      log.debug("[Configurer] Bearer Token 비활성 — /logout CSRF 보호 활성화 (면제 목록에서 제외)");
     }
+
+    // 보안 Medium #4: 브라우저 Front-Channel 로그아웃(KeycloakWebFluxConstants.LOGOUT_URL,
+    // 기본 "/logout")은 Bearer Token 전용 로그아웃(prefix + "/logout")과 별개의 엔드포인트이며,
+    // 항상 CSRF 보호를 유지한다(Bearer Token 활성 여부와 무관). 이 경로는 브라우저 쿠키 기반
+    // OIDC 세션을 종료하는 폼 POST 엔드포인트이므로, 여기를 CSRF 면제 목록에 포함시키면 공격
+    // 사이트가 크로스사이트 POST로 로그인된 사용자를 강제 로그아웃시킬 수 있다(CSRF, CWE-352).
+    // 따라서 어떤 조건에서도 LOGOUT_URL을 ignorePaths에 추가하지 않는다.
+    log.debug("[Configurer] /logout(LOGOUT_URL) CSRF 보호 항상 활성화 "
+        + "(Bearer Token 활성 여부와 무관, 면제 목록에서 제외)");
 
     ignorePaths.addAll(csrfProperties.getIgnorePaths());
     log.info("[Configurer] CSRF 활성화 (면제 경로: {})", ignorePaths);

--- a/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxSecurityConfigurer.java
+++ b/keycloak-spring-security-webflux/src/main/java/com/ids/keycloak/security/config/KeycloakWebFluxSecurityConfigurer.java
@@ -33,6 +33,7 @@ import org.springframework.security.oauth2.client.web.server.ServerOAuth2Authori
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.AuthenticationWebFilter;
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+import org.springframework.security.web.server.csrf.CsrfWebFilter;
 import org.springframework.security.web.server.util.matcher.AndServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.NegatedServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.OrServerWebExchangeMatcher;
@@ -229,8 +230,12 @@ public final class KeycloakWebFluxSecurityConfigurer {
   /**
    * CSRF 설정을 적용합니다.
    *
-   * <p>API 서버 기본값은 disabled. CSRF 활성화 시 면제 경로를 {@code requireCsrfProtectionMatcher}에
-   * <b>부정 매처(NegatedServerWebExchangeMatcher)</b>로 지정합니다.</p>
+   * <p>API 서버 기본값은 disabled. CSRF 활성화 시 {@code requireCsrfProtectionMatcher}는
+   * <b>{@link CsrfWebFilter#DEFAULT_CSRF_MATCHER}(GET/HEAD/TRACE/OPTIONS 등 안전 메서드 제외)</b>와
+   * <b>면제 경로 부정 매처(NegatedServerWebExchangeMatcher)</b>를 AND로 결합해 지정합니다.
+   * 안전 메서드까지 CSRF 보호 대상으로 잘못 지정되면 일반 GET 요청, OIDC 로그인 콜백,
+   * 정적 리소스, 리다이렉트 등이 403으로 차단될 수 있으므로 반드시 두 조건을 함께 적용해야
+   * 합니다.</p>
    *
    * <p><b>면제 대상:</b>
    * <ul>
@@ -293,7 +298,15 @@ public final class KeycloakWebFluxSecurityConfigurer {
     // 머신 전용 API를 면제하려면 csrfProperties.ignorePaths에 해당 경로를 명시적으로 등록한다.
 
     ServerWebExchangeMatcher exemptMatcher = new OrServerWebExchangeMatcher(exemptMatchers);
-    ServerWebExchangeMatcher csrfMatcher = new NegatedServerWebExchangeMatcher(exemptMatcher);
+
+    // 보안 Medium 3: 안전 메서드(GET/HEAD/TRACE/OPTIONS)는 CSRF 기본 동작과 동일하게 항상 제외한다.
+    // CsrfWebFilter.DEFAULT_CSRF_MATCHER를 재사용해 Spring Security 표준 안전-메서드 판정을 그대로 따르고,
+    // 여기에 "면제 경로가 아님" 조건을 AND로 추가해 최종 보호 대상을 좁힌다.
+    // (기존에는 면제 경로 부정만 사용해 안전 메서드까지 CSRF 토큰을 요구 -> GET 등이 403이 되는 버그가 있었다.)
+    ServerWebExchangeMatcher csrfMatcher = new AndServerWebExchangeMatcher(
+        CsrfWebFilter.DEFAULT_CSRF_MATCHER,
+        new NegatedServerWebExchangeMatcher(exemptMatcher)
+    );
 
     http.csrf(csrf -> csrf.requireCsrfProtectionMatcher(csrfMatcher));
   }

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/KeycloakReactiveAuthenticationManagerTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/authentication/KeycloakReactiveAuthenticationManagerTest.java
@@ -3,6 +3,8 @@ package com.ids.keycloak.security.authentication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.ids.keycloak.security.exception.AuthenticationFailedException;
@@ -10,6 +12,12 @@ import com.ids.keycloak.security.exception.ConfigurationException;
 import com.ids.keycloak.security.exception.IntrospectionFailedException;
 import com.ids.keycloak.security.exception.TokenBindingException;
 import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.sd.KeycloakClient.client.auth.async.KeycloakAuthAsyncClient;
 import com.sd.KeycloakClient.client.user.async.KeycloakUserAsyncClient;
 import com.sd.KeycloakClient.dto.KeycloakResponse;
@@ -102,6 +110,23 @@ class KeycloakReactiveAuthenticationManagerTest {
       builder.claim("azp", azp);
     }
     return builder.build();
+  }
+
+  /**
+   * {@code JwtUtil.isStructurallyJwt()}가 {@code true}를 반환하도록 실제로 서명된(점 2개 포함,
+   * header.payload.signature 구조) JWT 문자열을 생성합니다. servlet
+   * {@code KeycloakAuthenticationProviderTest}와 동일한 픽스처 — 서명/클레임 내용은 이 테스트에서
+   * 신뢰되지 않으며(jwtDecoder가 mock), 오직 Opaque Access Token과 구분하기 위한 구조만 필요하다.
+   */
+  private String buildStructuralJwtAccessToken() {
+    try {
+      JWTClaimsSet claims = new JWTClaimsSet.Builder().subject("fixture-subject").build();
+      SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claims);
+      signedJWT.sign(new MACSigner("0123456789abcdef0123456789abcdef"));
+      return signedJWT.serialize();
+    } catch (JOSEException e) {
+      throw new IllegalStateException("테스트 픽스처 JWT 서명 생성에 실패했습니다.", e);
+    }
   }
 
   private KeycloakResponse<KeycloakIntrospectResponse> introspectOk(boolean active) {
@@ -237,6 +262,85 @@ class KeycloakReactiveAuthenticationManagerTest {
       StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, ACCESS_TOKEN_VAL)))
           .expectErrorMatches(e -> e instanceof TokenBindingException
               && e.getMessage().contains("azp"))
+          .verify();
+    }
+  }
+
+  // ==========================================================================
+  // 2.0.1 패치(외부 검토 High #1) 핵심 회귀 방지 — servlet Provider와 동일 시나리오, WebFlux 스택
+  // ==========================================================================
+
+  /**
+   * 패치 이전에는 Access Token에 대해 azp만 검증하고 sub는 UserInfo를 통해서만 간접 확인했다.
+   * {@code require-user-info=false}(기본값)에서 UserInfo 조회가 실패하면 이 간접 sub 검증 자체가
+   * 스킵되어, 사용자 A의 ID Token과 같은 Client에서 발급된 사용자 B의 JWT Access Token 조합이
+   * azp 일치만으로 인증을 통과할 수 있었다. 이 클래스는 그 회귀가 재발하지 않는지 검증한다.
+   */
+  @Nested
+  class Access_Token_Subject_직접_검증_2_0_1_패치 {
+
+    private String jwtAccessTokenVal;
+
+    @BeforeEach
+    void setUp() {
+      jwtAccessTokenVal = buildStructuralJwtAccessToken();
+      lenient().when(authAsyncClient.authenticationByIntrospect(ID_TOKEN_VAL))
+          .thenReturn(Mono.just(introspectOk(true)));
+      lenient().when(jwtDecoder.decode(ID_TOKEN_VAL))
+          .thenReturn(Mono.just(buildJwt(ID_TOKEN_VAL, USER_SUB, List.of(CLIENT_ID), CLIENT_ID)));
+    }
+
+    @Test
+    void requireUserInfo_false_UserInfo_실패_JWT_AT_sub_불일치시_TokenBindingException으로_인증에_실패한다() {
+      // require-user-info=false(기본값)에서 UserInfo 조회가 401로 실패하면 UserInfo 기반
+      // validateSubjectBinding은 스킵된다. 그러나 Access Token이 JWT 구조이고 sub가 ID Token과
+      // 다르면(OTHER_USER_SUB != USER_SUB) validateAccessTokenSubject가 이를 직접 차단해야 한다.
+      when(userAsyncClient.getUserInfo(jwtAccessTokenVal))
+          .thenReturn(Mono.just(userInfoFail(401)));
+      when(jwtDecoder.decode(jwtAccessTokenVal))
+          .thenReturn(Mono.just(buildJwt(jwtAccessTokenVal, OTHER_USER_SUB, List.of(CLIENT_ID), CLIENT_ID)));
+
+      StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, jwtAccessTokenVal)))
+          .expectErrorMatches(e -> e instanceof TokenBindingException
+              && e.getMessage().contains("subject"))
+          .verify();
+    }
+
+    @Test
+    void Opaque_Access_Token은_UserInfo_실패해도_sub_직접_검증을_스킵하고_기존_정책대로_인증에_성공한다_회귀없음() {
+      // Opaque(비-JWT) Access Token은 JwtUtil.isStructurallyJwt()가 false이므로
+      // jwtDecoder.decode(accessToken)가 호출되지 않아야 하고, 기존 정책
+      // (require-user-info=false → UserInfo 실패 시 빈 권한으로 인증 성공)이 그대로 유지되어야 한다.
+      String opaqueAccessTokenVal = "opaque-access-token-no-dots";
+      when(userAsyncClient.getUserInfo(opaqueAccessTokenVal))
+          .thenReturn(Mono.just(userInfoFail(401)));
+
+      StepVerifier.create(manager.authenticate(buildAuthRequest(ID_TOKEN_VAL, opaqueAccessTokenVal)))
+          .expectNextMatches(auth -> {
+            assertThat(auth.isAuthenticated()).isTrue();
+            assertThat(auth.getAuthorities()).isEmpty();
+            return true;
+          })
+          .verifyComplete();
+
+      verify(jwtDecoder, never()).decode(opaqueAccessTokenVal);
+    }
+
+    @Test
+    void Refresh_경로_createAuthenticatedToken_직접_호출에서도_JWT_AT_sub_불일치시_TokenBindingException이_발생한다() {
+      // Refresh Token 재발급 후 Filter가 직접 호출하는 진입점(createAuthenticatedToken)도
+      // 동일한 검증을 우회할 수 없어야 한다. UserInfo의 subject는 ID Token과 일치시켜
+      // (기존 validateSubjectBinding 통과) 실패 원인이 오직 새 direct sub 비교임을 격리한다.
+      when(jwtDecoder.decode(jwtAccessTokenVal))
+          .thenReturn(Mono.just(buildJwt(jwtAccessTokenVal, OTHER_USER_SUB, List.of(CLIENT_ID), CLIENT_ID)));
+
+      org.springframework.security.oauth2.core.oidc.OidcUserInfo sameUserInfo =
+          new org.springframework.security.oauth2.core.oidc.OidcUserInfo(Map.of("sub", USER_SUB));
+
+      StepVerifier.create(
+              manager.createAuthenticatedToken(ID_TOKEN_VAL, jwtAccessTokenVal, sameUserInfo))
+          .expectErrorMatches(e -> e instanceof TokenBindingException
+              && e.getMessage().contains("subject"))
           .verify();
     }
   }

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/config/CsrfExemptMatcherTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/config/CsrfExemptMatcherTest.java
@@ -33,11 +33,14 @@ import reactor.test.StepVerifier;
  * 꺼내 요청을 직접 흘려보내며 검증한다. production {@code configureCsrf}가 조립한 matcher를
  * 그대로 실행하므로, matcher 로직이 바뀌면 이 테스트가 즉시 반응한다.</p>
  *
- * <p>CSRF 보호 = NOT(면제 대상) 공식 검증:
+ * <p>CSRF 보호 = AND(안전하지 않은 메서드, NOT(면제 대상)) 공식 검증:
  * <ul>
  *   <li>면제 경로(로그아웃/Back-Channel 로그아웃/Bearer Token 엔드포인트/사용자 지정 ignore-paths)
  *   → CSRF 토큰 없이도 통과</li>
- *   <li>일반 경로 → CSRF 토큰이 없으면 403</li>
+ *   <li>일반 경로 + 안전하지 않은 메서드(POST/PUT/PATCH/DELETE) → CSRF 토큰이 없으면 403</li>
+ *   <li><b>보안 Medium 3:</b> 안전 메서드(GET/HEAD/OPTIONS)는 {@link CsrfWebFilter#DEFAULT_CSRF_MATCHER}에
+ *   의해 비면제 경로에서도 CSRF 토큰 없이 항상 통과해야 한다 — 그렇지 않으면 일반 GET, OIDC 로그인
+ *   콜백, 정적 리소스, 리다이렉트 등이 403으로 차단된다.</li>
  *   <li><b>보안 Advisory 3:</b> {@code Authorization: Basic} 헤더 보유 여부는 더 이상 CSRF 면제
  *   사유가 아니다. Basic 헤더가 있어도 non-ignore 경로에서는 CSRF 토큰이 없으면 403이 반환되어야
  *   한다 — 브라우저가 캐시한 Basic 자격증명(ambient credential)을 이용한 cross-site 폼 제출이
@@ -123,6 +126,54 @@ class CsrfExemptMatcherTest {
   }
 
   // ==========================================================================
+  // 보안 Medium 3: 안전 메서드(GET/HEAD/OPTIONS)는 비면제 경로에서도 CSRF 보호 대상이 아니다.
+  // CsrfWebFilter.DEFAULT_CSRF_MATCHER가 안전 메서드를 판정하므로, production configureCsrf가
+  // 만든 실제 매처를 태워 검증한다.
+  // ==========================================================================
+
+  @Nested
+  class 안전_메서드는_비면제_경로에서도_CSRF_보호_대상_아님 {
+
+    @Test
+    void GET_요청은_비면제_경로에서도_토큰_없이_통과() throws Exception {
+      CsrfWebFilter csrfFilter = buildRealCsrfFilter(baseProperties());
+
+      MockServerWebExchange ex = exchange("GET", "/api/resource");
+
+      assertThat(runThroughRealFilter(csrfFilter, ex)).isTrue();
+    }
+
+    @Test
+    void HEAD_요청은_비면제_경로에서도_토큰_없이_통과() throws Exception {
+      CsrfWebFilter csrfFilter = buildRealCsrfFilter(baseProperties());
+
+      MockServerWebExchange ex = exchange("HEAD", "/api/resource");
+
+      assertThat(runThroughRealFilter(csrfFilter, ex)).isTrue();
+    }
+
+    @Test
+    void OPTIONS_요청은_비면제_경로에서도_토큰_없이_통과() throws Exception {
+      CsrfWebFilter csrfFilter = buildRealCsrfFilter(baseProperties());
+
+      MockServerWebExchange ex = exchange("OPTIONS", "/api/resource");
+
+      assertThat(runThroughRealFilter(csrfFilter, ex)).isTrue();
+    }
+
+    @Test
+    void OIDC_로그인_콜백_GET_요청은_토큰_없이_통과() throws Exception {
+      // OIDC Authorization Code Grant 리다이렉트 콜백. 브라우저가 인가서버에서 리다이렉트되며
+      // GET으로 도달하므로 CSRF 토큰을 들고 올 수 없다 — 안전 메서드 예외가 없으면 항상 403이 된다.
+      CsrfWebFilter csrfFilter = buildRealCsrfFilter(baseProperties());
+
+      MockServerWebExchange ex = exchange("GET", "/login/oauth2/code/keycloak");
+
+      assertThat(runThroughRealFilter(csrfFilter, ex)).isTrue();
+    }
+  }
+
+  // ==========================================================================
   // 면제 경로 → CSRF 토큰 없이 통과
   // ==========================================================================
 
@@ -182,6 +233,39 @@ class CsrfExemptMatcherTest {
       CsrfWebFilter csrfFilter = buildRealCsrfFilter(baseProperties());
 
       MockServerWebExchange ex = exchange("POST", "/");
+      boolean reached = runThroughRealFilter(csrfFilter, ex);
+
+      assertThat(reached).isFalse();
+      assertThat(ex.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void PUT_요청은_비면제_경로에서_토큰_없으면_403() throws Exception {
+      CsrfWebFilter csrfFilter = buildRealCsrfFilter(baseProperties());
+
+      MockServerWebExchange ex = exchange("PUT", "/api/resource");
+      boolean reached = runThroughRealFilter(csrfFilter, ex);
+
+      assertThat(reached).isFalse();
+      assertThat(ex.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void PATCH_요청은_비면제_경로에서_토큰_없으면_403() throws Exception {
+      CsrfWebFilter csrfFilter = buildRealCsrfFilter(baseProperties());
+
+      MockServerWebExchange ex = exchange("PATCH", "/api/resource");
+      boolean reached = runThroughRealFilter(csrfFilter, ex);
+
+      assertThat(reached).isFalse();
+      assertThat(ex.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void DELETE_요청은_비면제_경로에서_토큰_없으면_403() throws Exception {
+      CsrfWebFilter csrfFilter = buildRealCsrfFilter(baseProperties());
+
+      MockServerWebExchange ex = exchange("DELETE", "/api/resource");
       boolean reached = runThroughRealFilter(csrfFilter, ex);
 
       assertThat(reached).isFalse();

--- a/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/config/CsrfExemptMatcherTest.java
+++ b/keycloak-spring-security-webflux/src/test/java/com/ids/keycloak/security/config/CsrfExemptMatcherTest.java
@@ -35,12 +35,15 @@ import reactor.test.StepVerifier;
  *
  * <p>CSRF 보호 = AND(안전하지 않은 메서드, NOT(면제 대상)) 공식 검증:
  * <ul>
- *   <li>면제 경로(로그아웃/Back-Channel 로그아웃/Bearer Token 엔드포인트/사용자 지정 ignore-paths)
- *   → CSRF 토큰 없이도 통과</li>
+ *   <li>면제 경로(Back-Channel 로그아웃/Bearer Token 엔드포인트(전용 로그아웃 포함)/사용자 지정
+ *   ignore-paths) → CSRF 토큰 없이도 통과</li>
  *   <li>일반 경로 + 안전하지 않은 메서드(POST/PUT/PATCH/DELETE) → CSRF 토큰이 없으면 403</li>
  *   <li><b>보안 Medium 3:</b> 안전 메서드(GET/HEAD/OPTIONS)는 {@link CsrfWebFilter#DEFAULT_CSRF_MATCHER}에
  *   의해 비면제 경로에서도 CSRF 토큰 없이 항상 통과해야 한다 — 그렇지 않으면 일반 GET, OIDC 로그인
  *   콜백, 정적 리소스, 리다이렉트 등이 403으로 차단된다.</li>
+ *   <li><b>보안 Medium 4:</b> 브라우저 Front-Channel 로그아웃({@code /logout})은 Bearer Token
+ *   전용 로그아웃(prefix + {@code /logout})과 별개 엔드포인트이며, Bearer Token 활성 여부와
+ *   무관하게 항상 CSRF 보호를 유지해야 한다(CWE-352 — 강제 로그아웃 CSRF 방지).</li>
  *   <li><b>보안 Advisory 3:</b> {@code Authorization: Basic} 헤더 보유 여부는 더 이상 CSRF 면제
  *   사유가 아니다. Basic 헤더가 있어도 non-ignore 경로에서는 CSRF 토큰이 없으면 403이 반환되어야
  *   한다 — 브라우저가 캐시한 Basic 자격증명(ambient credential)을 이용한 cross-site 폼 제출이
@@ -274,11 +277,14 @@ class CsrfExemptMatcherTest {
   }
 
   // ==========================================================================
-  // H-4: /logout CSRF 면제는 Bearer Token 활성 시에만
+  // 보안 Medium #4: 브라우저 Front-Channel 로그아웃(/logout)은 Bearer Token 활성 여부와
+  // 무관하게 항상 CSRF 보호를 유지한다. Bearer Token 전용 로그아웃(prefix + "/logout")과는
+  // 별개의 엔드포인트이며, 과거처럼 Bearer 활성 시 /logout까지 면제하면 공격 사이트가
+  // 크로스사이트 POST로 로그인 사용자를 강제 로그아웃시킬 수 있다(CWE-352).
   // ==========================================================================
 
   @Nested
-  class H4_logout_CSRF_면제_조건 {
+  class Medium4_브라우저_logout_CSRF_보호_항상_유지 {
 
     @Test
     void bearerToken_비활성시_logout_경로는_CSRF_보호_적용됨() throws Exception {
@@ -292,12 +298,28 @@ class CsrfExemptMatcherTest {
     }
 
     @Test
-    void bearerToken_활성시_logout_경로는_CSRF_면제됨() throws Exception {
+    void bearerToken_활성시에도_logout_경로는_CSRF_보호_유지() throws Exception {
+      // 보안 Medium #4 회귀 방지: Bearer Token을 켜도 브라우저 /logout은 면제되면 안 된다.
       KeycloakSecurityProperties props = baseProperties();
       props.getBearerToken().setEnabled(true);
       CsrfWebFilter csrfFilter = buildRealCsrfFilter(props);
 
-      assertThat(runThroughRealFilter(csrfFilter, exchange("POST", "/logout"))).isTrue();
+      MockServerWebExchange ex = exchange("POST", "/logout");
+      boolean reached = runThroughRealFilter(csrfFilter, ex);
+
+      assertThat(reached).isFalse();
+      assertThat(ex.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void bearerToken_활성시_전용_logout_엔드포인트는_CSRF_면제() throws Exception {
+      // Bearer 전용 로그아웃(prefix + "/logout")은 브라우저 폼 세션과 무관하므로 계속 면제된다.
+      KeycloakSecurityProperties props = baseProperties();
+      props.getBearerToken().setEnabled(true);
+      CsrfWebFilter csrfFilter = buildRealCsrfFilter(props);
+
+      String prefix = props.getBearerToken().getTokenEndpoint().getPrefix();
+      assertThat(runThroughRealFilter(csrfFilter, exchange("POST", prefix + "/logout"))).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## 2.0.1 — 외부 보안 검토 4건 대응 (patch)

2.0.0에 대한 외부 보안 검토에서 발견된 4건을 수정합니다. 익스플로잇 상세는 Draft Security Advisory 참조.

### Security
1. **OIDC 토큰 결합 강화** — JWT Access Token의 `sub`를 ID Token `sub`와 직접 비교. UserInfo 장애(`require-user-info=false`) 시 서로 다른 사용자의 ID/Access 토큰 결합을 차단. (잔여 한계: Opaque Access Token은 로컬 sub 비교 불가 → `require-user-info: true` 권장)
2. **WebFlux CSRF 안전 메서드 제외** — CSRF 매처를 `AND(안전하지 않은 메서드, NOT 면제경로)`로 결합. CSRF 활성 시 GET·OIDC 로그인 콜백 등 안전 요청이 403되던 문제 수정.
3. **브라우저 `/logout` CSRF 보호** — Bearer Token 활성 여부와 무관하게 Front-Channel `/logout`을 CSRF 보호(강제 로그아웃 CSRF 차단). Bearer 전용 `{prefix}/logout`만 면제 유지.
4. (Low) Bearer `prefix` 검증(fail-fast), 인증 검증 순서 Servlet/WebFlux 정렬, `TokenBindingException` 로그 정리, 예외 메시지 subject 마스킹.

### Changed (Breaking)
- **Servlet OIDC `JwtDecoder` 빈 대체 조건이 타입 → 빈 이름(`keycloakOidcJwtDecoder`) 기반으로 변경** (WebFlux와 정렬). 커스텀 decoder 재정의 시 동일 이름 사용 필요. 앱에 별도 resource-server용 `JwtDecoder`가 있으면 오주입/`NoUniqueBeanDefinitionException` 없이 안전하게 공존. (기존 타입 기반 재정의 사용자는 빈 이름 지정 필요)

### 문서
- README 영/한 이중언어 분리 (`README.md` 영어 메인 + `README.ko.md` 한국어 + 언어 스위처)
- CHANGELOG 2.0.1, GUIDE 마이그레이션(servlet decoder 재정의 규칙 · Opaque AT + `require-user-info` 주의), SECURITY 지원 버전 갱신

### 검증
- 4건 각각 code-review + 단위/통합 테스트 완료
- 전체 모듈 테스트 통과 (core / web / web-starter / webflux / webflux-starter + integration-tests)
