### PR TITLE
Hotfix 2.0.2: fix Redis+Jackson session deserialization regression (500 on auth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-07-15
+### Fixed
+- **Redis 세션 사용 시 인증 요청이 500으로 실패하던 회귀 수정**: `session.store-type=redis` + `GenericJackson2JsonRedisSerializer`(Jackson 세션 직렬화) 조합에서 세션에 저장된 `SecurityContext`(OIDC 인증 정보)를 역직렬화할 때마다 예외가 발생해 이후 모든 요청이 인증 실패로 처리되던 문제. 원인 2가지를 함께 수정.
+  - 세션 전용 Jackson mixin(`KeycloakPrincipalMixin`/`KeycloakAuthenticationMixin`)이 getter 기반 introspection이라, `OidcUser`가 상속하는 setter 없는 파생 getter(`getAudience()` 등, `aud`는 OIDC 필수 클레임)까지 프로퍼티로 잡혀 `InvalidDefinitionException`(`no way to handle typed deser with setterless yet`)이 발생 → 필드 기반 introspection(`@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE)`)으로 전환(Spring 공식 `DefaultOidcUserMixin`과 동일 패턴).
+  - claims 역직렬화 시 `java.time.Instant`(`iat`/`exp`/`nbf`) 타입이 알려진 타입 목록에 없어 예외 없이 2-원소 `List`로 조용히 손상되던 것을 복원하도록 수정.
+  - 영향 범위: 2.0.0/2.0.1에서 `session.store-type=redis`를 사용하는 환경 전체(모든 인증 요청에서 재현). 세션 저장소가 `memory`(기본값)이거나 Redis를 JDK 직렬화로 쓰는 경우는 영향 없음.
+  - 대응: 세션 직렬화 포맷·설정 변경 없이 라이브러리 업그레이드만으로 해결(앱 코드 변경 불필요). breaking change 없음.
+
 ## [2.0.1] - 2026-07-15
 ### Security
 - **OIDC Access Token·ID Token subject 직접 비교 (외부 검토 High #1)**: 쿠키 기반 OIDC 인증에서 Access Token이 구조적으로 JWT이면 `TokenBindingValidator#validateAccessTokenSubject`로 Access Token의 `sub`를 ID Token `sub`와 직접 비교하도록 강화(servlet `KeycloakAuthenticationProvider`, webflux `KeycloakReactiveAuthenticationManager` 동일 적용). 기존에는 Access Token과 ID Token의 결합 여부를 UserInfo 엔드포인트 조회가 성공한 경우에만 확인했는데, UserInfo 조회가 실패하거나(장애) `require-user-info`가 기본값(`false`)이면 서로 다른 사용자의 Access Token과 ID Token이 조합되어도 인증이 성립할 수 있었음. **잔여 한계**: Opaque(불투명) Access Token은 로컬에서 `sub`를 파싱할 수 없어 이 직접 비교가 적용되지 않으며 여전히 UserInfo 일치 검증에만 의존함 — Opaque Access Token을 쓰는 환경은 `keycloak.security.authentication.require-user-info=true`로 UserInfo 검증을 필수화할 것을 권장.
@@ -118,7 +126,8 @@
 ### Added
 - `@EnableMethodSecurity` 적용, 초기 OIDC 로그인/세션/로그아웃/Redis 세션 등 기반 기능
 
-[Unreleased]: https://github.com/L-DXD/keycloak-spring-security/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/L-DXD/keycloak-spring-security/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/L-DXD/keycloak-spring-security/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/L-DXD/keycloak-spring-security/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/L-DXD/keycloak-spring-security/compare/v1.10.2...v2.0.0
 [1.10.2]: https://github.com/L-DXD/keycloak-spring-security/compare/v1.10.1...v1.10.2

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3,7 +3,7 @@
 Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 하나와 최소 설정으로 OIDC 로그인·세션·로그아웃·인가가 자동 구성됩니다.
 
 - **지원**: JDK 17+, Spring Boot 3.5.x, Spring Security 6.5.x
-- **현재 버전**: `2.0.1`
+- **현재 버전**: `2.0.2`
 - **스택**: Servlet(Spring MVC) / **Reactive(WebFlux) — v1.8.0부터 servlet과 기능 동등** ([8. Reactive](#8-reactivewebflux))
 - 이 문서는 **도입 개발자용 사용 가이드**입니다. 아키텍처/기여 규칙은 [README](../README.md) 참고.
 
@@ -27,10 +27,10 @@ Keycloak을 Spring Security에 통합하는 라이브러리입니다. 의존성 
 
 ```gradle
 // Servlet (Spring MVC)
-implementation("io.github.l-dxd:keycloak-spring-security-web-starter:2.0.1")
+implementation("io.github.l-dxd:keycloak-spring-security-web-starter:2.0.2")
 
 // 또는 Reactive (WebFlux)
-implementation("io.github.l-dxd:keycloak-spring-security-webflux-starter:2.0.1")
+implementation("io.github.l-dxd:keycloak-spring-security-webflux-starter:2.0.2")
 ```
 > Redis 세션을 쓸 경우에만 추가:
 > ```gradle
@@ -366,6 +366,7 @@ LoggingValueSanitizer loggingValueSanitizer() {
 
 | 버전 | 변경 | 주의 |
 |------|------|------|
+| **2.0.2** | (버그픽스) `session.store-type: redis` 사용 시 세션의 `SecurityContext` 역직렬화가 실패해 인증 요청이 500이 되던 회귀 수정(mixin 필드 기반 introspection 전환, claims의 `Instant` 복원 누락 수정) | breaking 없음. 세션 직렬화 포맷 변경 없음, 앱 코드 변경 불필요 |
 | **2.0.1** ⚠️ | **외부 보안 검토 4건 대응** — OIDC Access Token subject를 ID Token subject와 직접 비교(High #1), WebFlux CSRF 안전 메서드 예외 누락 수정(Medium #3), 브라우저 Front-Channel `/logout` CSRF 우회 차단(Medium #4), Bearer prefix 검증·검증 순서 정렬·로그 정리·subject 마스킹(Low #1~#4) | **Breaking 1건** — 아래 [마이그레이션](#마이그레이션-201--외부-보안-검토-4건-breaking) |
 | **2.0.0** ⚠️ | **보안 강화 8건** — OIDC ID/Access Token 결합 검증(Advisory 1), 로그인 세션 고정 방지(Advisory 2), Rate Limit IP 판정 일원화(Advisory 2), Basic Auth CSRF 전면 면제 제거(Advisory 3), 백채널 로그아웃 로그 마스킹(Advisory 5), 인메모리 세션 저장소 용량 상한(Advisory 6), Realm/Client Role 네임스페이스 분리(Advisory 7), WebFlux 백채널 decoder 검증 강화(Advisory 8) | **Breaking 3건** — 아래 [마이그레이션](#마이그레이션-200--보안-강화-8건-breaking) |
 | **1.10.2** | (버그픽스 #54) webflux 토큰 무효화(백채널 로그아웃 등) 후 보호 경로 접근 시 refresh 재발급 실패가 500 나던 문제 → 미인증 처리로 EntryPoint(로그인 리다이렉트/401) 경유 | breaking 없음 |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version Management
-projectVersion=2.0.1
+projectVersion=2.0.2
 
 # Maven Publishing Info
 mavenGroupId=io.github.l-dxd

--- a/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/RedisSessionConfiguration.java
+++ b/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/RedisSessionConfiguration.java
@@ -1,5 +1,7 @@
 package com.ids.keycloak.security.config;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
@@ -173,14 +175,45 @@ public class RedisSessionConfiguration {
   // allowlist mixin — 커스텀 Keycloak 도메인 클래스
   // ---------------------------------------------------------------------------
 
-  /** allowlist mixin — {@link KeycloakPrincipal} */
+  /**
+   * allowlist mixin — {@link KeycloakPrincipal}.
+   *
+   * <p><b>2.0.2 패치(치명적 회귀):</b> {@code fieldVisibility=ANY, getterVisibility=NONE}로
+   * 필드 기반 introspection을 강제합니다. {@code KeycloakPrincipal}은 {@link
+   * org.springframework.security.oauth2.core.oidc.IdTokenClaimAccessor}를 구현하므로
+   * {@code getAudience()}(aud 클레임, {@code List<String>})·{@code getAuthenticationMethods()}(amr
+   * 클레임)처럼 setter 없는 파생 컬렉션 getter를 다수 상속합니다. 기본(getter 기반) introspection에서는
+   * default typing이 활성화된 상태에서 이 getter들도 직렬화 대상 프로퍼티로 잡히고, 역직렬화 시
+   * Jackson이 {@code SetterlessProperty}로 처리하려다
+   * {@code InvalidDefinitionException: Problem deserializing 'setterless' property ("audience"):
+   * no way to handle typed deser with setterless yet}를 던집니다. {@code aud} 클레임은 OIDC 필수
+   * 클레임이므로 실제 운영 ID Token에는 항상 존재해 <b>모든 인증 요청에서 세션 역직렬화가 실패</b>합니다
+   * (Spring 공식 {@code DefaultOidcUserMixin}/{@code OidcIdTokenMixin}과 동일한 필드 기반 패턴 적용).
+   * 필드 기반으로 전환하면 실제 생성자 파라미터(name/authorities/idToken/userInfo)만 프로퍼티로 잡혀
+   * 파생 getter는 전부 배제됩니다.</p>
+   */
   @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY,
+      getterVisibility = JsonAutoDetect.Visibility.NONE,
+      isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+  @JsonIgnoreProperties(value = {"attributes", "claims"}, ignoreUnknown = true)
   abstract static class KeycloakPrincipalMixin {
 
   }
 
-  /** allowlist mixin — {@link KeycloakAuthentication} */
+  /**
+   * allowlist mixin — {@link KeycloakAuthentication}.
+   *
+   * <p><b>2.0.2 패치:</b> {@link KeycloakPrincipalMixin}과 동일한 이유로 필드 기반 introspection을
+   * 적용합니다. {@code KeycloakAuthentication}은 {@code AbstractAuthenticationToken}을 상속하며,
+   * 이 슈퍼클래스가 노출하는 setter 없는 파생 getter({@code getName()} 등)를 getter 기반
+   * introspection에서 프로퍼티로 잡을 경우 유사한 역직렬화 실패 위험이 있어 동일하게 방지합니다.</p>
+   */
   @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY,
+      getterVisibility = JsonAutoDetect.Visibility.NONE,
+      isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+  @JsonIgnoreProperties(ignoreUnknown = true)
   abstract static class KeycloakAuthenticationMixin {
 
   }
@@ -266,8 +299,17 @@ public class RedisSessionConfiguration {
    * 이 클래스는 {@link JsonNode}를 직접 파싱하여 plain Java 타입으로 변환하므로,
    * AllowlistTypeIdResolver를 거치지 않습니다.</p>
    *
+   * <p><b>2.0.2 패치:</b> ID Token의 {@code iat}/{@code exp}/{@code nbf} 클레임은
+   * {@code Jwt.getClaims()}(Spring의 {@code MappedJwtClaimSetConverter}) 단계에서 이미
+   * {@code java.time.Instant}로 변환되어 있습니다({@code Long} 아님). 기존 코드가
+   * {@code isKnownTypeName()}에 {@code "java.time.Instant"}를 포함하지 않아, 이 값이
+   * {@code ["java.time.Instant", 1737039434.096212]} 형태로 직렬화된 뒤 역직렬화 시 타입 이름을
+   * 인식하지 못하고 <b>2개짜리 List로 잘못 변환되는 데이터 손상</b>이 있었습니다(예외는 발생하지 않아
+   * 발견이 어려움). {@code java.time.Instant}/{@code java.util.Date}를 별도 분기로 처리하여
+   * 실제 {@link Instant} 값으로 정확히 복원합니다.</p>
+   *
    * <p>지원 타입: {@code String}, {@code Long}, {@code Integer}, {@code Double},
-   * {@code Boolean}, {@code null}, 중첩 {@code Map}, {@code List}</p>
+   * {@code Boolean}, {@code Instant}, {@code Date}, {@code null}, 중첩 {@code Map}, {@code List}</p>
    */
   static class PlainClaimsMapDeserializer extends StdDeserializer<Map<String, Object>> {
 
@@ -340,17 +382,63 @@ public class RedisSessionConfiguration {
         return new ArrayList<>();
       }
       JsonNode first = arrayNode.get(0);
-      if (first.isTextual() && isKnownTypeName(first.asText())) {
-        // default typing 배열: ["TypeName", value] — 타입 이름을 무시하고 실제 값만 반환
-        if (arrayNode.size() >= 2) {
-          return parseNodeValue(arrayNode.get(1));
+      if (first.isTextual()) {
+        String typeName = first.asText();
+        // java.time.Instant/java.util.Date: 값을 그대로 반환하면 안 되고 실제 Instant로 복원해야 함
+        // (2.0.2 패치 — iat/exp/nbf 클레임 손상 수정)
+        if (isTemporalTypeName(typeName) && arrayNode.size() >= 2) {
+          return parseTemporalValue(arrayNode.get(1));
         }
-        return null;
+        if (isKnownTypeName(typeName)) {
+          // default typing 배열: ["TypeName", value] — 타입 이름을 무시하고 실제 값만 반환
+          if (arrayNode.size() >= 2) {
+            return parseNodeValue(arrayNode.get(1));
+          }
+          return null;
+        }
       }
       // 일반 배열
       List<Object> list = new ArrayList<>();
       arrayNode.forEach(item -> list.add(parseNodeValue(item)));
       return list;
+    }
+
+    /**
+     * {@code java.time.Instant}/{@code java.util.Date}로 default typing 래핑된 값을 실제
+     * {@link Instant}로 복원합니다.
+     *
+     * <p>jackson-datatype-jsr310의 기본 직렬화 형태(초 단위 소수 타임스탬프 숫자, 예:
+     * {@code 1737039434.096212}), ISO-8601 문자열, {@code {"epochSecond":..,"nano":..}} 객체
+     * 형태를 모두 지원합니다.</p>
+     */
+    private static Instant parseTemporalValue(JsonNode node) {
+      if (node == null || node.isNull()) {
+        return null;
+      }
+      if (node.isNumber()) {
+        java.math.BigDecimal seconds = node.decimalValue();
+        long epochSecond = seconds.longValue();
+        long nanos = seconds.subtract(java.math.BigDecimal.valueOf(epochSecond))
+            .multiply(java.math.BigDecimal.valueOf(1_000_000_000L))
+            .longValue();
+        return Instant.ofEpochSecond(epochSecond, nanos);
+      }
+      if (node.isTextual()) {
+        return Instant.parse(node.asText());
+      }
+      if (node.isObject()) {
+        long epochSecond = node.has("epochSecond") ? node.get("epochSecond").asLong() : 0;
+        int nano = node.has("nano") ? node.get("nano").asInt() : 0;
+        return Instant.ofEpochSecond(epochSecond, nano);
+      }
+      return null;
+    }
+
+    /**
+     * 클레임 맵 값 중 시간 관련 타입(변환이 필요한 타입)인지 확인합니다.
+     */
+    private static boolean isTemporalTypeName(String name) {
+      return name.equals("java.time.Instant") || name.equals("java.util.Date");
     }
 
     /**

--- a/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/RedisSessionConfiguration.java
+++ b/keycloak-spring-security-web-starter/src/main/java/com/ids/keycloak/security/config/RedisSessionConfiguration.java
@@ -11,15 +11,22 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.ids.keycloak.security.authentication.KeycloakAuthentication;
 import com.ids.keycloak.security.model.KeycloakPrincipal;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -113,6 +120,12 @@ public class RedisSessionConfiguration {
    *
    * <p>커스텀 직렬화기를 사용하려면 {@code springSessionDefaultRedisSerializer} 이름으로
    * 직접 {@link RedisSerializer} 빈을 등록하세요(이 빈이 생략됩니다).</p>
+   *
+   * <p><b>code-review High #2 (2.0.2):</b> {@link JavaTimeModule}을 명시적으로 등록합니다.
+   * {@code SecurityJackson2Modules}는 {@code jackson-datatype-jsr310}이 클래스패스에 있을 때만
+   * 조건부로 등록하므로, 이 라이브러리 자체의 보장으로는 부족합니다. 명시 등록으로 {@code Instant}
+   * 등 {@code java.time.*} 값의 직렬화 형태(초 단위 소수 타임스탬프)를 안정적으로 고정합니다.
+   * {@link PlainClaimsMapDeserializer}는 이 형태를 전제로 {@code Instant}를 복원합니다.</p>
    */
   @Bean("springSessionDefaultRedisSerializer")
   @ConditionalOnMissingBean(name = "springSessionDefaultRedisSerializer")
@@ -122,6 +135,10 @@ public class RedisSessionConfiguration {
     // 1. Spring Security 도메인 객체 직렬화 지원 + default typing 활성화
     //    (OAuth2ClientJackson2Module이 OidcIdToken mixin을 등록)
     mapper.registerModules(SecurityJackson2Modules.getModules(this.getClass().getClassLoader()));
+
+    // 1-1. code-review High #2: java.time.* 직렬화 형태를 명시적으로 고정
+    //      (SecurityJackson2Modules의 조건부 등록에 의존하지 않음)
+    mapper.registerModule(new JavaTimeModule());
 
     // 2. N-3: KeycloakSecurityJackson2Module을 마지막에 등록.
     //    - OidcIdToken/OidcUserInfo: 커스텀 Deserializer로 claims Long 문제 해결
@@ -293,25 +310,80 @@ public class RedisSessionConfiguration {
   /**
    * JWT claims {@code Map<String, Object>}를 타입 정보 없이 plain 값으로 역직렬화하는 유틸리티.
    *
-   * <p>{@code SecurityJackson2Modules}의 default typing이 활성화되면, claims 맵 내 값들이
-   * {@code ["java.lang.Long", 1234567890]} 형태의 배열로 직렬화됩니다.
-   * {@code AllowlistTypeIdResolver}는 {@code java.lang.Long}을 거부하므로 역직렬화가 실패합니다.
-   * 이 클래스는 {@link JsonNode}를 직접 파싱하여 plain Java 타입으로 변환하므로,
-   * AllowlistTypeIdResolver를 거치지 않습니다.</p>
+   * <p>{@code SecurityJackson2Modules}의 default typing이 활성화되면, claims 맵처럼 값의 정적
+   * 타입이 {@code Object}(즉, 실행 시점에야 구체 타입을 알 수 있는 위치)인 경우 Jackson이 타입
+   * 정보를 함께 기록합니다. 이 라이브러리가 사용하는
+   * {@link GenericJackson2JsonRedisSerializer}(PROPERTY 방식 default typing)는 실제로 두 가지
+   * 형태를 모두 사용합니다.</p>
+   * <ul>
+   *   <li>스칼라/배열 값 — {@code ["TypeName", value]} 2원소 배열 (예:
+   *   {@code ["java.lang.Long", 1234567890]}, {@code ["java.net.URL", "https://..."]})</li>
+   *   <li>객체(Map) 값 — 값 자체에 {@code "@class"} 속성이 추가됨 (예:
+   *   {@code {"@class":"java.util.LinkedHashMap", "sub":"user-1"}})</li>
+   * </ul>
+   * <p>{@code AllowlistTypeIdResolver}는 이런 타입들 대부분(예: {@code java.lang.Long})을
+   * 거부하므로 표준 역직렬화 경로로는 복원할 수 없습니다. 이 클래스는 {@link JsonNode}를 직접
+   * 순회하여 위 두 형태의 타입 메타데이터를 제거하고 plain Java 타입으로 복원하므로
+   * {@code AllowlistTypeIdResolver}를 거치지 않습니다.</p>
    *
-   * <p><b>2.0.2 패치:</b> ID Token의 {@code iat}/{@code exp}/{@code nbf} 클레임은
-   * {@code Jwt.getClaims()}(Spring의 {@code MappedJwtClaimSetConverter}) 단계에서 이미
-   * {@code java.time.Instant}로 변환되어 있습니다({@code Long} 아님). 기존 코드가
-   * {@code isKnownTypeName()}에 {@code "java.time.Instant"}를 포함하지 않아, 이 값이
-   * {@code ["java.time.Instant", 1737039434.096212]} 형태로 직렬화된 뒤 역직렬화 시 타입 이름을
-   * 인식하지 못하고 <b>2개짜리 List로 잘못 변환되는 데이터 손상</b>이 있었습니다(예외는 발생하지 않아
-   * 발견이 어려움). {@code java.time.Instant}/{@code java.util.Date}를 별도 분기로 처리하여
-   * 실제 {@link Instant} 값으로 정확히 복원합니다.</p>
+   * <p><b>code-review High #1 (2.0.2, silent claim 손상):</b> 이전 구현은 {@code isKnownTypeName()}
+   * allowlist에 없는 타입 이름을 만나면 배열을 <b>그냥 일반 2원소 List로 오인식</b>했습니다. 운영
+   * ID Token의 {@code iss}는 {@code OidcIdTokenDecoderFactory}(내부적으로 실제
+   * {@code NimbusJwtDecoder}를 사용)의 기본 claim 변환기가 항상 {@code java.net.URL}로 변환하는데,
+   * 구버전 allowlist에는 없어 {@code ["java.net.URL", "https://..."]}가
+   * {@code [URL 문자열, 실제 URL 문자열]} 형태의 2원소 List로 조용히 손상되었습니다({@code iss}는
+   * OIDC 필수 클레임이라 항상 발생 — 예외는 없어 발견이 어려움). {@code resource_access}/
+   * {@code realm_access}처럼 중첩된 객체 값도 {@code @class} 속성이 그대로 claim 키로 섞여
+   * 들어가는 별도의 오염이 있었습니다.</p>
    *
-   * <p>지원 타입: {@code String}, {@code Long}, {@code Integer}, {@code Double},
-   * {@code Boolean}, {@code Instant}, {@code Date}, {@code null}, 중첩 {@code Map}, {@code List}</p>
+   * <p>이번 패치는 화이트리스트를 계속 나열하는 대신(whack-a-mole) <b>범용 언랩 휴리스틱</b>을
+   * 적용합니다.</p>
+   * <ol>
+   *   <li>배열 값이 정확히 2개이고 첫 번째 요소가 FQCN 형태의 문자열
+   *   ({@code 패키지.클래스}, 정규식 {@link #FQCN_PATTERN})이면 타입 래퍼로 간주하고 두 번째
+   *   요소(실제 값)를 언랩 대상으로 삼습니다.</li>
+   *   <li>알려진 스칼라(Long/Integer/Short/Byte/Double/Float/Boolean/String/BigDecimal/
+   *   BigInteger)·시간 타입(Instant/Date)·{@code java.net.URL}/{@code URI}는 실제 타입의 값으로
+   *   정확히 복원합니다.</li>
+   *   <li>그 외 타입은, 언랩 대상 값 자체가 JSON 객체/배열이면(= Map/List로 표현 가능한 구조라는
+   *   뜻) 구체 클래스 이름(예: {@code java.util.HashMap}, {@code net.minidev.json.JSONObject},
+   *   {@code com.nimbusds.jose.shaded.gson.internal.LinkedTreeMap} 등 무엇이든)을 몰라도
+   *   Map/List로 안전하게 복원합니다.</li>
+   *   <li>그마저도 아닌, 진짜 미인식 스칼라 타입 래퍼는 <b>warn 로그를 남기고 원본 구조
+   *   ({@code [typeName, value]})를 그대로 보존</b>합니다. silent 손상을 내는 대신 실패를
+   *   드러내어 필요 시 이 클래스에 처리를 추가할 수 있게 합니다.</li>
+   * </ol>
+   *
+   * <p>객체(Map) 값에 섞여 들어오는 {@code "@class"} 속성은 {@link #parseNodeAsMap(JsonNode)}에서
+   * (중첩 여부와 무관하게) 항상 제거합니다.</p>
+   *
+   * <p><b>code-review High #2 (2.0.2):</b> {@code java.time.Instant}는
+   * jackson-datatype-jsr310의 기본 직렬화 형태(초 단위 소수 타임스탬프 숫자, 예:
+   * {@code 1737039434.096212}) 기준으로 복원합니다. 이 형태가 실제로 보장되도록
+   * {@code springSessionDefaultRedisSerializer()}에 {@link JavaTimeModule}을 명시 등록했습니다.
+   * {@code java.util.Date}는 Instant와 달리 <b>초 단위 소수가 아닌 epoch 밀리초(정수)</b>로
+   * 직렬화되므로 별도 분기로 처리합니다(둘을 같은 방식으로 처리하면 약 1000배 오차가 발생).</p>
    */
   static class PlainClaimsMapDeserializer extends StdDeserializer<Map<String, Object>> {
+
+    /** GenericJackson2JsonRedisSerializer(PROPERTY 방식 default typing)가 객체 값에 삽입하는 타입 속성. */
+    private static final String JACKSON_TYPE_PROPERTY = "@class";
+
+    /** {@code패키지.클래스} 형태(점으로 구분된 2개 이상의 세그먼트)를 판별하는 정규식. */
+    private static final Pattern FQCN_PATTERN =
+        Pattern.compile("^[A-Za-z_$][A-Za-z0-9_$]*(\\.[A-Za-z_$][A-Za-z0-9_$]*)+$");
+
+    private static final Set<String> KNOWN_SCALAR_TYPE_NAMES = Set.of(
+        "java.lang.Long",
+        "java.lang.Integer",
+        "java.lang.Short",
+        "java.lang.Byte",
+        "java.lang.Double",
+        "java.lang.Float",
+        "java.lang.Boolean",
+        "java.lang.String",
+        "java.math.BigDecimal",
+        "java.math.BigInteger");
 
     PlainClaimsMapDeserializer() {
       super(Map.class);
@@ -327,15 +399,20 @@ public class RedisSessionConfiguration {
     /**
      * {@link JsonNode}에서 {@code Map<String, Object>}를 파싱합니다 (static 유틸리티).
      *
-     * <p>default typing으로 생성된 {@code ["java.lang.Long", 123]} 배열 값도 올바르게 처리합니다.</p>
+     * <p>{@code "@class"} 속성(default typing이 객체 값에 삽입하는 타입 메타데이터)은 실제
+     * claim이 아니므로 제외합니다.</p>
      */
     static Map<String, Object> parseNodeAsMap(JsonNode node) {
       if (node == null || node.isNull()) {
         return new LinkedHashMap<>();
       }
       Map<String, Object> result = new LinkedHashMap<>();
-      node.fields().forEachRemaining(entry ->
-          result.put(entry.getKey(), parseNodeValue(entry.getValue())));
+      node.fields().forEachRemaining(entry -> {
+        if (JACKSON_TYPE_PROPERTY.equals(entry.getKey())) {
+          return;
+        }
+        result.put(entry.getKey(), parseNodeValue(entry.getValue()));
+      });
       return result;
     }
 
@@ -374,27 +451,18 @@ public class RedisSessionConfiguration {
     /**
      * 배열 노드를 파싱합니다.
      *
-     * <p>배열의 첫 번째 요소가 알려진 타입 이름 문자열이면 default typing 배열로 간주하고
-     * 두 번째 요소(실제 값)를 반환합니다. 그렇지 않으면 일반 List로 파싱합니다.</p>
+     * <p>정확히 2개 요소이고 첫 번째가 FQCN 형태 문자열이면 default typing 타입 래퍼로 간주하고
+     * {@link #unwrapTypedValue(String, JsonNode)}로 위임합니다. 그렇지 않으면 일반 List로
+     * 파싱합니다.</p>
      */
     private static Object parseNodeArray(JsonNode arrayNode) {
       if (arrayNode.isEmpty()) {
         return new ArrayList<>();
       }
-      JsonNode first = arrayNode.get(0);
-      if (first.isTextual()) {
-        String typeName = first.asText();
-        // java.time.Instant/java.util.Date: 값을 그대로 반환하면 안 되고 실제 Instant로 복원해야 함
-        // (2.0.2 패치 — iat/exp/nbf 클레임 손상 수정)
-        if (isTemporalTypeName(typeName) && arrayNode.size() >= 2) {
-          return parseTemporalValue(arrayNode.get(1));
-        }
-        if (isKnownTypeName(typeName)) {
-          // default typing 배열: ["TypeName", value] — 타입 이름을 무시하고 실제 값만 반환
-          if (arrayNode.size() >= 2) {
-            return parseNodeValue(arrayNode.get(1));
-          }
-          return null;
+      if (arrayNode.size() == 2 && arrayNode.get(0).isTextual()) {
+        String typeName = arrayNode.get(0).asText();
+        if (FQCN_PATTERN.matcher(typeName).matches()) {
+          return unwrapTypedValue(typeName, arrayNode.get(1));
         }
       }
       // 일반 배열
@@ -404,8 +472,45 @@ public class RedisSessionConfiguration {
     }
 
     /**
-     * {@code java.time.Instant}/{@code java.util.Date}로 default typing 래핑된 값을 실제
-     * {@link Instant}로 복원합니다.
+     * {@code ["TypeName", value]} 타입 래퍼를 언랩합니다.
+     *
+     * <p>알려진 타입은 실제 값으로 정확히 복원하고, Map/List로 표현 가능한 구조는 타입 이름에
+     * 상관없이 안전하게 복원합니다. 그 외(미인식 스칼라 타입)는 silent 손상을 피하기 위해 warn
+     * 로그를 남기고 원본 구조({@code [typeName, value]})를 그대로 보존합니다.</p>
+     */
+    private static Object unwrapTypedValue(String typeName, JsonNode valueNode) {
+      if (isTemporalTypeName(typeName)) {
+        return "java.time.Instant".equals(typeName)
+            ? parseTemporalValue(valueNode)
+            : parseDateValue(valueNode);
+      }
+      if (isNetTypeName(typeName)) {
+        return parseNetValue(typeName, valueNode);
+      }
+      if (KNOWN_SCALAR_TYPE_NAMES.contains(typeName)) {
+        return parseScalarValue(typeName, valueNode);
+      }
+      if (valueNode != null && (valueNode.isObject() || valueNode.isArray())) {
+        // Map/List 등 구조적 타입 — 구체 클래스 이름(HashMap/LinkedTreeMap/JSONObject/
+        // ImmutableCollections$... 등 무엇이든)에 관계없이 JSON 형태(object/array) 자체가 구조를
+        // 결정하므로 타입 이름을 몰라도 안전하게 복원 가능
+        return parseNodeValue(valueNode);
+      }
+      // 미인식 타입 래퍼(스칼라인데 알려지지 않은 타입) — 추측 대신 원본 보존 + 경고 로그
+      // (silent 손상 방지: allowlist를 계속 나열하는 대신, 모르는 타입은 있는 그대로 보존한다)
+      log.warn(
+          "Redis 세션 claims 역직렬화: 인식되지 않은 타입 래퍼 '{}' 를 만났습니다. 값을 "
+              + "[typeName, value] 형태로 보존합니다 — PlainClaimsMapDeserializer에 해당 타입 "
+              + "처리 추가를 검토하세요.",
+          typeName);
+      List<Object> preserved = new ArrayList<>(2);
+      preserved.add(typeName);
+      preserved.add(parseNodeValue(valueNode));
+      return preserved;
+    }
+
+    /**
+     * {@code java.time.Instant}로 default typing 래핑된 값을 실제 {@link Instant}로 복원합니다.
      *
      * <p>jackson-datatype-jsr310의 기본 직렬화 형태(초 단위 소수 타임스탬프 숫자, 예:
      * {@code 1737039434.096212}), ISO-8601 문자열, {@code {"epochSecond":..,"nano":..}} 객체
@@ -435,33 +540,95 @@ public class RedisSessionConfiguration {
     }
 
     /**
-     * 클레임 맵 값 중 시간 관련 타입(변환이 필요한 타입)인지 확인합니다.
+     * {@code java.util.Date}로 default typing 래핑된 값을 실제 {@link Date}로 복원합니다.
+     *
+     * <p>Jackson 기본 직렬화 형태는 <b>epoch 밀리초(정수)</b>입니다. {@link Instant}(초 단위
+     * 소수)와 단위가 다르므로 같은 방식으로 처리하면 약 1000배 오차가 발생합니다.</p>
      */
-    private static boolean isTemporalTypeName(String name) {
-      return name.equals("java.time.Instant") || name.equals("java.util.Date");
+    private static Date parseDateValue(JsonNode node) {
+      if (node == null || node.isNull()) {
+        return null;
+      }
+      if (node.isNumber()) {
+        return new Date(node.asLong());
+      }
+      if (node.isTextual()) {
+        return Date.from(Instant.parse(node.asText()));
+      }
+      if (node.isObject() && node.has("epochSecond")) {
+        long epochSecond = node.get("epochSecond").asLong();
+        return new Date(epochSecond * 1000L);
+      }
+      return null;
     }
 
     /**
-     * default typing에서 사용되는 알려진 Java 타입 이름인지 확인합니다.
+     * {@code java.net.URL}/{@code java.net.URI}로 default typing 래핑된 값을 실제 객체로
+     * 복원합니다. 복원에 실패하면(형식 오류 등) warn 로그를 남기고 원본 문자열을 반환합니다
+     * (예외를 던져 세션 전체 역직렬화를 실패시키지 않음).
      */
-    private static boolean isKnownTypeName(String name) {
-      return name.equals("java.lang.Long")
-          || name.equals("java.lang.Integer")
-          || name.equals("java.lang.Double")
-          || name.equals("java.lang.Float")
-          || name.equals("java.lang.Boolean")
-          || name.equals("java.lang.String")
-          || name.equals("java.lang.Short")
-          || name.equals("java.lang.Byte")
-          || name.equals("java.math.BigDecimal")
-          || name.equals("java.math.BigInteger")
-          || name.startsWith("java.util.ImmutableCollections")
-          || name.startsWith("java.util.Collections$")
-          || name.equals("java.util.ArrayList")
-          || name.equals("java.util.LinkedList")
-          || name.equals("java.util.HashMap")
-          || name.equals("java.util.LinkedHashMap")
-          || name.equals("java.util.TreeMap");
+    private static Object parseNetValue(String typeName, JsonNode node) {
+      if (node == null || !node.isTextual()) {
+        return null;
+      }
+      String text = node.asText();
+      try {
+        if ("java.net.URL".equals(typeName)) {
+          // java.net.URL(String) 생성자는 Java 20부터 deprecated — URI 경유로 생성
+          return new URI(text).toURL();
+        }
+        return new URI(text);
+      } catch (MalformedURLException | URISyntaxException | IllegalArgumentException ex) {
+        log.warn(
+            "Redis 세션 claims 역직렬화: {} 값 '{}' 복원 실패 - 원본 문자열로 대체합니다.",
+            typeName, text, ex);
+        return text;
+      }
+    }
+
+    /**
+     * 알려진 boxed 스칼라 타입 이름에 맞춰 값을 정확한 타입으로 복원합니다.
+     *
+     * <p>{@link #parseNodeValue(JsonNode)}의 크기 기반 int/long 자동 추론에 맡기지 않고 타입
+     * 이름을 그대로 존중합니다 — 그렇지 않으면 예컨대 {@code java.lang.Long} 값이 {@code int}
+     * 범위 안에 들 때 {@code Integer}로 복원되어 (라운드트립 후) 타입이 바뀌는 손상이 됩니다.</p>
+     */
+    private static Object parseScalarValue(String typeName, JsonNode node) {
+      if (node == null || node.isNull()) {
+        return null;
+      }
+      switch (typeName) {
+        case "java.lang.Long":
+          return node.asLong();
+        case "java.lang.Integer":
+          return node.asInt();
+        case "java.lang.Short":
+          return (short) node.asInt();
+        case "java.lang.Byte":
+          return (byte) node.asInt();
+        case "java.lang.Double":
+          return node.asDouble();
+        case "java.lang.Float":
+          return (float) node.asDouble();
+        case "java.lang.Boolean":
+          return node.asBoolean();
+        case "java.lang.String":
+          return node.asText();
+        case "java.math.BigDecimal":
+          return node.decimalValue();
+        case "java.math.BigInteger":
+          return node.bigIntegerValue();
+        default:
+          return parseNodeValue(node);
+      }
+    }
+
+    private static boolean isTemporalTypeName(String name) {
+      return "java.time.Instant".equals(name) || "java.util.Date".equals(name);
+    }
+
+    private static boolean isNetTypeName(String name) {
+      return "java.net.URL".equals(name) || "java.net.URI".equals(name);
     }
   }
 

--- a/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/RedisSessionSerializationRoundTripTest.java
+++ b/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/RedisSessionSerializationRoundTripTest.java
@@ -7,18 +7,34 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ids.keycloak.security.authentication.KeycloakAuthentication;
 import com.ids.keycloak.security.config.RedisSessionConfiguration.KeycloakSecurityJackson2Module;
 import com.ids.keycloak.security.model.KeycloakPrincipal;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.net.URL;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.jackson2.SecurityJackson2Modules;
+import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 
 /**
  * N-3: Redis 세션 직렬화 round-trip 검증 테스트.
@@ -256,54 +272,120 @@ class RedisSessionSerializationRoundTripTest {
   }
 
   // ------------------------------------------------------------------
-  // 2.0.2 회귀 테스트 — 실제 운영 ID Token 클레임 형태
+  // 2.0.2 회귀 테스트 — 실제 NimbusJwtDecoder 산출 Jwt.getClaims() 기반
   // ------------------------------------------------------------------
 
   /**
-   * 2.0.1까지의 회귀(regression) 재현 테스트.
+   * 2.0.1까지의 회귀(regression) 재현 + code-review High #1/#2(2.0.2) 검증 테스트.
    *
-   * <p>위의 기존 테스트들은 {@code aud} 클레임을 포함하지 않아 다음 결함을 놓쳤다.</p>
+   * <p>과거 테스트들은 손으로 만든 {@code Map.of(...)} claims를 사용해 다음 결함들을 놓쳤다.</p>
    * <ul>
-   *   <li>{@code KeycloakPrincipal}은 {@code OidcUser}/{@code IdTokenClaimAccessor}의
-   *   {@code getAudience()}(setter 없는 파생 {@code List<String>} getter)를 상속한다. {@code aud}는
-   *   OIDC 필수 클레임이라 실제 ID Token에는 항상 존재하며, 2.0.1의 mixin(getter 기반 introspection)은
-   *   이 파생 getter까지 프로퍼티로 잡아 역직렬화 시
-   *   {@code InvalidDefinitionException: Problem deserializing 'setterless' property ("audience"):
-   *   no way to handle typed deser with setterless yet}로 실패했다 — 모든 인증 요청에서 세션 복원이
-   *   깨지는 원인.</li>
-   *   <li>{@code Jwt.getClaims()}(Spring {@code MappedJwtClaimSetConverter})는 {@code iat}/{@code exp}를
-   *   {@code Long}이 아닌 {@code java.time.Instant}로 변환한다. 2.0.1의
-   *   {@code PlainClaimsMapDeserializer.isKnownTypeName()}에는 {@code java.time.Instant}가 없어
-   *   예외는 없지만 값이 2-원소 {@code List}로 조용히 손상되었다.</li>
+   *   <li>{@code KeycloakPrincipal}이 상속하는 setter 없는 파생 getter(예: {@code getAudience()})가
+   *   getter 기반 introspection에서 프로퍼티로 잡혀 역직렬화가 실패하던 결함(2.0.1) — 필드 기반
+   *   introspection(mixin)으로 수정됨.</li>
+   *   <li><b>High #1</b>: 운영 ID Token의 {@code iss}는 {@link OidcIdTokenDecoderFactory}(실제
+   *   {@link NimbusJwtDecoder}를 내부에서 사용)의 기본 claim 변환기가 {@code java.net.URL}로
+   *   변환하는데, 구버전 allowlist에 없어 2원소 {@code List}로 조용히 손상되었다. 중첩된
+   *   {@code resource_access}/{@code realm_access} 객체 값에는 {@code @class} 타입 메타데이터가
+   *   claim 키로 섞여 들어가는 오염도 있었다.</li>
+   *   <li><b>High #2</b>: {@code iat}/{@code exp}/{@code auth_time}은 {@code Instant}로 변환되는데
+   *   {@code JavaTimeModule} 미등록 시 직렬화 형태가 불안정했다.</li>
    * </ul>
+   *
+   * <p>아래 테스트는 손으로 만든 claims 대신, 로컬 RSA 키로 자체 서명한 JWT를 실제
+   * {@link NimbusJwtDecoder}로 디코딩하고 운영 코드와 동일한
+   * {@link OidcIdTokenDecoderFactory#createDefaultClaimTypeConverter()}를 적용해 얻은
+   * {@link Jwt#getClaims()}를 사용한다(네트워크 불필요 — JWKS 조회 없이 공개키로 즉시 검증).</p>
    */
   @Nested
-  class 실제_운영_클레임_형태_회귀테스트 {
+  class 실제_NimbusJwtDecoder_클레임_기반_회귀테스트 {
+
+    /**
+     * 로컬 RSA 키로 자체 서명한 JWT를 실제 {@link NimbusJwtDecoder} + 운영과 동일한
+     * {@link OidcIdTokenDecoderFactory} 기본 claim 변환기로 디코딩해 실제 운영 ID Token과
+     * 동일한 형태({@code iss}=URL, {@code aud}=List, {@code iat}/{@code exp}=Instant, 중첩
+     * {@code resource_access}/{@code realm_access}, 커스텀 Long 클레임)의 {@link Jwt}를 만든다.
+     */
+    private Jwt decodeRealIdTokenClaims() throws Exception {
+      KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+      keyPairGenerator.initialize(2048);
+      KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+      Instant now = Instant.now();
+      JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+          .issuer("https://keycloak.example.com/realms/test")
+          .subject("user-123")
+          .audience("my-client")
+          .issueTime(Date.from(now))
+          .expirationTime(Date.from(now.plusSeconds(3600)))
+          // Keycloak가 추가하는, 기본 claim 변환기가 건드리지 않는 커스텀 숫자 클레임(Long 유지 검증용)
+          .claim("org_id", 9_999_999_999L)
+          .claim("resource_access", Map.of(
+              "my-client", Map.of("roles", List.of("ROLE_USER", "ROLE_ADMIN"))))
+          .claim("realm_access", Map.of("roles", List.of("offline_access", "uma_authorization")))
+          .build();
+
+      SignedJWT signedJwt =
+          new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).build(), claimsSet);
+      signedJwt.sign(new RSASSASigner((RSAPrivateKey) keyPair.getPrivate()));
+      String token = signedJwt.serialize();
+
+      NimbusJwtDecoder decoder =
+          NimbusJwtDecoder.withPublicKey((RSAPublicKey) keyPair.getPublic()).build();
+      // 운영 코드(OidcIdTokenDecoderFactory.createDecoder)와 동일한 claim 변환기를 재사용:
+      // iss -> java.net.URL, aud/amr -> List<String>, iat/exp/auth_time -> Instant 등
+      decoder.setClaimSetConverter(OidcIdTokenDecoderFactory.createDefaultClaimTypeConverter());
+
+      return decoder.decode(token);
+    }
+
+    /**
+     * claims 키집합 + 값 타입 + 값이 원본과 동일한지(잉여 {@code @class} 키 없음, 손상 없음)를
+     * 단언한다.
+     *
+     * <p>{@code iss}(URL)는 {@link URL#equals}가 호스트명 DNS 조회를 수행할 수 있어 테스트
+     * 환경에 따라 느려지거나 결과가 달라질 위험이 있으므로 {@code toString()} 비교로 대체하고,
+     * 나머지는 {@link Map#equals}로 한 번에 비교한다(값 타입이 바뀌면 예:
+     * {@code Long(1).equals(Integer(1))}이 {@code false}이므로 타입 손상도 함께 잡힌다).</p>
+     */
+    private void assertClaimsRoundTripIntact(Map<String, Object> expected, Map<String, Object> actual) {
+      assertThat(actual.keySet()).containsExactlyInAnyOrderElementsOf(expected.keySet());
+
+      assertThat(actual.get("iss")).isInstanceOf(URL.class);
+      assertThat(actual.get("iss").toString()).isEqualTo(expected.get("iss").toString());
+
+      Map<String, Object> expectedWithoutIss = new LinkedHashMap<>(expected);
+      Map<String, Object> actualWithoutIss = new LinkedHashMap<>(actual);
+      expectedWithoutIss.remove("iss");
+      actualWithoutIss.remove("iss");
+      assertThat(actualWithoutIss).isEqualTo(expectedWithoutIss);
+    }
 
     @Test
-    void aud_클레임_포함_KeycloakAuthentication_round_trip_성공() {
-      Instant now = Instant.now();
-      // Jwt.getClaims()가 실제로 만드는 형태: aud=List<String>, iat/exp=Instant,
-      // auth_time=Long(Keycloak가 추가하는, Spring이 자동 변환하지 않는 커스텀 숫자 클레임)
-      Map<String, Object> idTokenClaims = Map.of(
-          "sub", "user-123",
-          "aud", List.of("my-client"),
-          "iat", now,
-          "exp", now.plusSeconds(3600),
-          "auth_time", now.getEpochSecond()
-      );
+    void 실제_클레임_사전조건_확인() throws Exception {
+      // 아래 라운드트립 테스트가 실제로 취약했던 형태를 검증하고 있는지 사전 확인
+      Map<String, Object> claims = decodeRealIdTokenClaims().getClaims();
+
+      assertThat(claims.get("iss")).isInstanceOf(URL.class);
+      assertThat(claims.get("aud")).isInstanceOf(List.class);
+      assertThat(claims.get("iat")).isInstanceOf(Instant.class);
+      assertThat(claims.get("exp")).isInstanceOf(Instant.class);
+      assertThat(claims.get("org_id")).isInstanceOf(Long.class);
+      assertThat(claims.get("resource_access")).isInstanceOf(Map.class);
+      assertThat(claims.get("realm_access")).isInstanceOf(Map.class);
+    }
+
+    @Test
+    void 실제_클레임_GenericJackson2JsonRedisSerializer_왕복_손상없음() throws Exception {
+      Jwt jwt = decodeRealIdTokenClaims();
+      Map<String, Object> claims = jwt.getClaims();
+
       OidcIdToken idToken = new OidcIdToken(
-          "valid.id.token", now, now.plusSeconds(3600), idTokenClaims);
-
+          "signed.jwt.token", jwt.getIssuedAt(), jwt.getExpiresAt(), claims);
       KeycloakPrincipal principal = new KeycloakPrincipal(
-          "user-123",
-          List.of(new SimpleGrantedAuthority("ROLE_USER")),
-          idToken,
-          null
-      );
-
+          "user-123", List.of(new SimpleGrantedAuthority("ROLE_USER")), idToken, null);
       KeycloakAuthentication original =
-          new KeycloakAuthentication(principal, "valid.id.token", "valid.access.token", true);
+          new KeycloakAuthentication(principal, "signed.jwt.token", "access.token.value", true);
 
       byte[] serialized = serializer.serialize(original);
       Object deserialized = serializer.deserialize(serialized);
@@ -313,10 +395,33 @@ class RedisSessionSerializationRoundTripTest {
       assertThat(result.getPrincipal().getAudience()).containsExactly("my-client");
 
       Map<String, Object> resultClaims = result.getPrincipal().getIdToken().getClaims();
-      assertThat(resultClaims.get("iat")).isInstanceOf(Instant.class);
-      assertThat((Instant) resultClaims.get("iat"))
-          .isCloseTo(now, org.assertj.core.api.Assertions.within(1, java.time.temporal.ChronoUnit.SECONDS));
-      assertThat(resultClaims.get("auth_time")).isEqualTo(now.getEpochSecond());
+      assertClaimsRoundTripIntact(claims, resultClaims);
+      assertThat(result.getPrincipal().getIdToken().getIssuedAt()).isEqualTo(idToken.getIssuedAt());
+      assertThat(result.getPrincipal().getIdToken().getExpiresAt()).isEqualTo(idToken.getExpiresAt());
+    }
+
+    @Test
+    void 실제_클레임_JdkSerializationRedisSerializer_왕복_손상없음() throws Exception {
+      Jwt jwt = decodeRealIdTokenClaims();
+      Map<String, Object> claims = jwt.getClaims();
+
+      OidcIdToken idToken = new OidcIdToken(
+          "signed.jwt.token", jwt.getIssuedAt(), jwt.getExpiresAt(), claims);
+      KeycloakPrincipal principal = new KeycloakPrincipal(
+          "user-123", List.of(new SimpleGrantedAuthority("ROLE_USER")), idToken, null);
+      KeycloakAuthentication original =
+          new KeycloakAuthentication(principal, "signed.jwt.token", "access.token.value", true);
+
+      JdkSerializationRedisSerializer jdkSerializer = new JdkSerializationRedisSerializer();
+      byte[] serialized = jdkSerializer.serialize(original);
+      Object deserialized = jdkSerializer.deserialize(serialized);
+      assertThat(deserialized).isInstanceOf(KeycloakAuthentication.class);
+
+      KeycloakAuthentication result = (KeycloakAuthentication) deserialized;
+      Map<String, Object> resultClaims = result.getPrincipal().getIdToken().getClaims();
+      // JDK 직렬화는 Jackson default typing/@class 메타데이터 경로를 타지 않으므로
+      // (원본 객체 그래프를 그대로 직렬화) claims가 완전히 동일해야 한다.
+      assertThat(resultClaims).isEqualTo(claims);
     }
   }
 }

--- a/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/RedisSessionSerializationRoundTripTest.java
+++ b/keycloak-spring-security-web-starter/src/test/java/com/ids/keycloak/security/config/RedisSessionSerializationRoundTripTest.java
@@ -254,4 +254,69 @@ class RedisSessionSerializationRoundTripTest {
       assertThat(result.getAuthorities()).hasSize(1);
     }
   }
+
+  // ------------------------------------------------------------------
+  // 2.0.2 회귀 테스트 — 실제 운영 ID Token 클레임 형태
+  // ------------------------------------------------------------------
+
+  /**
+   * 2.0.1까지의 회귀(regression) 재현 테스트.
+   *
+   * <p>위의 기존 테스트들은 {@code aud} 클레임을 포함하지 않아 다음 결함을 놓쳤다.</p>
+   * <ul>
+   *   <li>{@code KeycloakPrincipal}은 {@code OidcUser}/{@code IdTokenClaimAccessor}의
+   *   {@code getAudience()}(setter 없는 파생 {@code List<String>} getter)를 상속한다. {@code aud}는
+   *   OIDC 필수 클레임이라 실제 ID Token에는 항상 존재하며, 2.0.1의 mixin(getter 기반 introspection)은
+   *   이 파생 getter까지 프로퍼티로 잡아 역직렬화 시
+   *   {@code InvalidDefinitionException: Problem deserializing 'setterless' property ("audience"):
+   *   no way to handle typed deser with setterless yet}로 실패했다 — 모든 인증 요청에서 세션 복원이
+   *   깨지는 원인.</li>
+   *   <li>{@code Jwt.getClaims()}(Spring {@code MappedJwtClaimSetConverter})는 {@code iat}/{@code exp}를
+   *   {@code Long}이 아닌 {@code java.time.Instant}로 변환한다. 2.0.1의
+   *   {@code PlainClaimsMapDeserializer.isKnownTypeName()}에는 {@code java.time.Instant}가 없어
+   *   예외는 없지만 값이 2-원소 {@code List}로 조용히 손상되었다.</li>
+   * </ul>
+   */
+  @Nested
+  class 실제_운영_클레임_형태_회귀테스트 {
+
+    @Test
+    void aud_클레임_포함_KeycloakAuthentication_round_trip_성공() {
+      Instant now = Instant.now();
+      // Jwt.getClaims()가 실제로 만드는 형태: aud=List<String>, iat/exp=Instant,
+      // auth_time=Long(Keycloak가 추가하는, Spring이 자동 변환하지 않는 커스텀 숫자 클레임)
+      Map<String, Object> idTokenClaims = Map.of(
+          "sub", "user-123",
+          "aud", List.of("my-client"),
+          "iat", now,
+          "exp", now.plusSeconds(3600),
+          "auth_time", now.getEpochSecond()
+      );
+      OidcIdToken idToken = new OidcIdToken(
+          "valid.id.token", now, now.plusSeconds(3600), idTokenClaims);
+
+      KeycloakPrincipal principal = new KeycloakPrincipal(
+          "user-123",
+          List.of(new SimpleGrantedAuthority("ROLE_USER")),
+          idToken,
+          null
+      );
+
+      KeycloakAuthentication original =
+          new KeycloakAuthentication(principal, "valid.id.token", "valid.access.token", true);
+
+      byte[] serialized = serializer.serialize(original);
+      Object deserialized = serializer.deserialize(serialized);
+      assertThat(deserialized).isInstanceOf(KeycloakAuthentication.class);
+
+      KeycloakAuthentication result = (KeycloakAuthentication) deserialized;
+      assertThat(result.getPrincipal().getAudience()).containsExactly("my-client");
+
+      Map<String, Object> resultClaims = result.getPrincipal().getIdToken().getClaims();
+      assertThat(resultClaims.get("iat")).isInstanceOf(Instant.class);
+      assertThat((Instant) resultClaims.get("iat"))
+          .isCloseTo(now, org.assertj.core.api.Assertions.within(1, java.time.temporal.ChronoUnit.SECONDS));
+      assertThat(resultClaims.get("auth_time")).isEqualTo(now.getEpochSecond());
+    }
+  }
 }


### PR DESCRIPTION
## 2.0.2 — Redis + Jackson 세션 역직렬화 회귀 수정 (hotfix)

2.0.0/2.0.1에서 `GenericJackson2JsonRedisSerializer` + Redis 세션 사용 시 `SecurityContext` 역직렬화가 실패해 **인증 요청마다 500**이 나던 회귀를 수정합니다.

### 원인
세션에 저장되는 `KeycloakPrincipal`의 OIDC 토큰 claims 역직렬화 결함 2종:
1. **setterless getter 오검출** — mixin이 getter 기반이라 `OidcUser`의 setter 없는 파생 getter(`getAudience()` 등)까지 프로퍼티로 잡혀 `InvalidDefinitionException` (aud는 항상 존재 → 매 요청 500).
2. **claims 값 타입 손상** — `iss`(`java.net.URL`)·`iat`/`exp`(`java.time.Instant`)·중첩 객체(`resource_access` 등)가 allowlist 미등록/`@class` 오염으로 조용히 손상.

### 수정
- 세션 mixin을 **필드 기반**(`@JsonAutoDetect` field-only, Spring `DefaultOidcUserMixin` 패턴)으로 전환 → setterless getter 문제 근본 제거.
- claims deserializer를 **범용 언랩**으로 재작성: 타입 래퍼 배열을 실제 타입으로 복원(URL/URI/Instant/Date/숫자/불리언 등), 중첩 Map/List는 구체 클래스 무관하게 안전 복원, 중첩 객체의 `@class` 오염 제거, 미인식 스칼라만 `warn` + 원본 보존(silent 손상 금지).
- 세션 ObjectMapper에 `JavaTimeModule` 등록.

### 영향
- **affects 2.0.0–2.0.1** (Redis + Jackson JSON 세션 직렬화 조합). Memory/JDK 직렬화는 무영향.
- **세션 직렬화 포맷 변경 없음, 앱 코드 변경 불필요**(자동설정). breaking 없음.
- 업그레이드 시 2.0.x가 써둔 깨진 세션은 flush 권장(재로그인).

### 검증
- **실제 `NimbusJwtDecoder` 산출 claims 기반 회귀 테스트** 신규 — iss(URL)·aud(List)·iat/exp(Instant)·커스텀 Long·중첩 Map을 `GenericJackson2JsonRedisSerializer` 및 JDK 양쪽에서 왕복, keySet·값·타입 완전 일치 단언.
- web-starter 53개 + 전 모듈 빌드 통과.

### 알려진 후속 (2.0.3)
`KeycloakAuthentication` 상속 필드 중복 직렬화 정리, `OidcIdTokenDeserializer.parseInstant` 중복 통합.
